### PR TITLE
Read token secret from CLICKHOUSE_TOKEN_SECRET environment variable

### DIFF
--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -128,7 +128,7 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 	apiUrl := os.Getenv("CLICKHOUSE_API_URL")
 	organizationId := os.Getenv("CLICKHOUSE_ORG_ID")
 	tokenKey := os.Getenv("CLICKHOUSE_TOKEN_KEY")
-	tokenSecret := os.Getenv("CLICKHOUSE_TOKEN_KEY")
+	tokenSecret := os.Getenv("CLICKHOUSE_TOKEN_SECRET")
 
 	if !config.ApiUrl.IsNull() {
 		apiUrl = config.ApiUrl.ValueString()


### PR DESCRIPTION
The code as written reads a default value for tokenSecret by reading the 'CLICKHOUSE_TOKEN_KEY' environment variable, same as the token key; I think this is a typo and this commit reads the secret from a separate environment variable.