### PR TITLE
remove all old ip access items and add all new items to preserve order

### DIFF
--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -484,6 +483,7 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 		service.Name = plan.Name.ValueString()
 		serviceChange = true
 	}
+
 	if !equal(plan.IpAccessList, state.IpAccessList) {
 		serviceChange = true
 		ipAccessListRawOld := state.IpAccessList
@@ -510,13 +510,9 @@ func (r *serviceResource) Update(ctx context.Context, req resource.UpdateRequest
 			ipAccessListNew = append(ipAccessListNew, ipAccess)
 		}
 
-		add, remove := diffArrays(ipAccessListOld, ipAccessListNew, func(a IpAccess) string {
-			return fmt.Sprintf("%s:%s", a.Source, a.Description)
-		})
-
 		service.IpAccessList = &IpAccessUpdate{
-			Add:    add,
-			Remove: remove,
+			Add:    ipAccessListNew,
+			Remove: ipAccessListOld,
 		}
 	}
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,11 +1,17 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "0.0.2"
+      version = "0.0.3"
       source  = "ClickHouse/clickhouse"
       # source  = "clickhouse.cloud/terraform/clickhouse" # used for dev
     }
   }
+}
+
+# only use if you have a specific deployment of the ClickHouse OpenAPI you want to interact with.
+# otherwise, just omit this variable.
+variable "api_url" {
+  type = string
 }
 
 variable "organization_id" {


### PR DESCRIPTION
there's a bug in the current version where if the user edits the ip access list in certain ways it'll give an `unexpected new value` error because of how we interact with ClickHouse OpenAPI for updating the list with the `add` and `remove` keys.

this pr changes the behavior to simply remove all old items and add the new items in the order specified in terraform so that the order is correctly returned by the api