### PR TITLE
chore(docs): update provider docs for environment variable options

### DIFF
--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -42,19 +42,19 @@ func (p *clickhouseProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_url": schema.StringAttribute{
-				Description: "API URL of the ClickHouse OpenAPI the provider will interact with. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against.",
+				Description: "API URL of the ClickHouse OpenAPI the provider will interact with. Alternatively, can be configured using the `CLICKHOUSE_API_URL` environment variable. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against. ",
 				Optional:    true,
 			},
 			"organization_id": schema.StringAttribute{
-				Description: "ID of the organization the provider will create services under.",
+				Description: "ID of the organization the provider will create services under. Alternatively, can be configured using the `CLICKHOUSE_ORG_ID` environment variable.",
 				Required:    true,
 			},
 			"token_key": schema.StringAttribute{
-				Description: "Token key of the key/secret pair. Used to authenticate with OpenAPI.",
+				Description: "Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_KEY` environment variable.",
 				Required:    true,
 			},
 			"token_secret": schema.StringAttribute{
-				Description: "Token secret of the key/secret pair. Used to authenticate with OpenAPI.",
+				Description: "Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_SECRET` environment variable.",
 				Required:    true,
 				Sensitive:   true,
 			},

--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -42,7 +42,7 @@ func (p *clickhouseProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"api_url": schema.StringAttribute{
-				Description: "API URL of the ClickHouse OpenAPI the provider will interact with. Alternatively, can be configured using the `CLICKHOUSE_API_URL` environment variable. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against. ",
+				Description: "API URL of the ClickHouse OpenAPI the provider will interact with. Alternatively, can be configured using the `CLICKHOUSE_API_URL` environment variable. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against.",
 				Optional:    true,
 			},
 			"organization_id": schema.StringAttribute{


### PR DESCRIPTION
This documents the `CLICKHOUSE_` environment variables that can be used for the provider config. Had to dig into the code to find these as is.