### PR TITLE
Allow adjusting the number of replicas for existing services

### DIFF
--- a/clickhouse/client.go
+++ b/clickhouse/client.go
@@ -80,6 +80,7 @@ type Service struct {
 	IpAccessList          						[]IpAccess                    `json:"ipAccessList"`
 	MinTotalMemoryGb      						*int                          `json:"minTotalMemoryGb,omitempty"`
 	MaxTotalMemoryGb      						*int                          `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas           						*int                          `json:"numReplicas,omitempty"`
 	IdleTimeoutMinutes    						*int                          `json:"idleTimeoutMinutes,omitempty"`
 	State                 						string                        `json:"state,omitempty"`
 	Endpoints             						[]Endpoint                    `json:"endpoints,omitempty"`
@@ -100,6 +101,7 @@ type ServiceScalingUpdate struct {
 	IdleScaling        *bool `json:"idleScaling,omitempty"` // bool pointer so that `false`` is not omitted
 	MinTotalMemoryGb   *int   `json:"minTotalMemoryGb,omitempty"`
 	MaxTotalMemoryGb   *int   `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas        *int   `json:"numReplicas,omitempty"`
 	IdleTimeoutMinutes *int   `json:"idleTimeoutMinutes,omitempty"`
 }
 

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -183,7 +183,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 			},
 			"num_replicas": schema.Int64Attribute{
-				Description: "Number of replicas for the service. Available only for 'production' services. Must be greater than 3 and less than 25. Contact support to enable this feature.",
+				Description: "Number of replicas for the service. Available only for 'production' services. Must be greater than or equal to 3 and less than or equal to 20. Contact support to enable this feature.",
 				Optional:    true,
 			},
 			"idle_timeout_minutes": schema.Int64Attribute{

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -183,7 +183,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 			},
 			"num_replicas": schema.Int64Attribute{
-				Description: "Number of replicas for the service. Available only for 'production' services. Must be greater than or equal to 3 and less than or equal to 20. Contact support to enable this feature.",
+				Description: "Number of replicas for the service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.",
 				Optional:    true,
 			},
 			"idle_timeout_minutes": schema.Int64Attribute{

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -262,10 +262,10 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if service.Tier == "development" {
-		if !plan.IdleScaling.IsNull() || !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.IdleTimeoutMinutes.IsNull() {
+		if !plan.IdleScaling.IsNull() || !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.IdleTimeoutMinutes.IsNull() || !plan.NumReplicas.IsNull() {
 			resp.Diagnostics.AddError(
 				"Invalid Configuration",
-				"idle_scaling, min_total_memory_gb, max_total_memory_gb, and idle_timeout_minutes cannot be defined if the service tier is development",
+				"idle_scaling, min_total_memory_gb, max_total_memory_gb, idle_timeout_minutes and num_replicas cannot be defined if the service tier is development",
 			)
 			return
 		}

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -32,7 +32,7 @@ description: |-
 - `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Available only for 'production' services. Must be greater than or equal to 5 minutes.
 - `max_total_memory_gb` (Number) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
 - `min_total_memory_gb` (Number) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
-- `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be greater than 3 and less than 25. Contact support to enable this feature.
+- `num_replicas` (Number) Number of replicas for the service. Can only be specified for an existing service. Available only for 'production' services. Must be greater than or equal to 3 and less than or equal to 20. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.
 - `password_hash` (String, Sensitive) SHA256 hash of password for the default user. One of either `password` or `password_hash` must be specified.
 - `private_endpoint_ids` (List of String) List of private endpoint IDs

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -32,6 +32,7 @@ description: |-
 - `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Available only for 'production' services. Must be greater than or equal to 5 minutes.
 - `max_total_memory_gb` (Number) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
 - `min_total_memory_gb` (Number) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
+- `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be greater than 3 and less than 25. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.
 - `password_hash` (String, Sensitive) SHA256 hash of password for the default user. One of either `password` or `password_hash` must be specified.
 - `private_endpoint_ids` (List of String) List of private endpoint IDs

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -32,7 +32,7 @@ description: |-
 - `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Available only for 'production' services. Must be greater than or equal to 5 minutes.
 - `max_total_memory_gb` (Number) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
 - `min_total_memory_gb` (Number) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
-- `num_replicas` (Number) Number of replicas for the service. Can only be specified for an existing service. Available only for 'production' services. Must be greater than or equal to 3 and less than or equal to 20. Contact support to enable this feature.
+- `num_replicas` (Number) Number of replicas for the service. Can only be specified for an existing service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.
 - `password_hash` (String, Sensitive) SHA256 hash of password for the default user. One of either `password` or `password_hash` must be specified.
 - `private_endpoint_ids` (List of String) List of private endpoint IDs


### PR DESCRIPTION
Add `num_replicas` field to control the number of replicas (field `numReplicas` in `/scaling`: https://clickhouse.com/docs/en/cloud/manage/api/swagger#/paths/~1v1~1organizations~1:organizationId~1services~1:serviceId~1scaling/patch).