### PR TITLE
Fix ipAccessList index out of range

### DIFF
--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -875,7 +875,7 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *ServiceRe
 		// the API does not differentiate between undefined and empty string
 		if ipAccess.Description == "" {
 			// we will set this field as "" when user defines the description field
-			isDescriptionNull := index > len(state.IpAccessList) || state.IpAccessList[index].Description.IsNull()
+			isDescriptionNull := index >= len(state.IpAccessList) || state.IpAccessList[index].Description.IsNull()
 			if !isDescriptionNull {
 				stateIpAccess.Description = types.StringValue("")
 			}


### PR DESCRIPTION
Step to reproduce (before the fix)
- in .tf file, configure ipAccessList with 1 item
- apply the TF change.
- in the UI you should see this IP. 
- Now add a new ip in the UI, and **set the description to empty.**
- reapply TF

Expected behavior
- Terraform provider should not crash

Actual behavior
- Terraform provider crashes

closes https://github.com/ClickHouse/support-escalation/issues/2259
closes https://github.com/ClickHouse/control-plane/issues/9213