### PR TITLE
Issues supporting aws privatelink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 secrets.tfvars
 dev/
 .idea/
+*.backup

--- a/clickhouse/clickhouse_service_private_endpoint_attachment.go
+++ b/clickhouse/clickhouse_service_private_endpoint_attachment.go
@@ -1,0 +1,211 @@
+package clickhouse
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource                = &ClickhouseServicePrivateEndpointAttachmentResource{}
+	_ resource.ResourceWithConfigure   = &ClickhouseServicePrivateEndpointAttachmentResource{}
+	_ resource.ResourceWithImportState = &ClickhouseServicePrivateEndpointAttachmentResource{}
+)
+
+func NewClickhouseServicePrivateEndpointAttachmentResource() resource.Resource {
+	return &ClickhouseServicePrivateEndpointAttachmentResource{}
+}
+
+type ClickhouseServicePrivateEndpointAttachmentResource struct {
+	client *Client
+}
+
+type ClickhouseServicePrivateEndpointAttachmentModel struct {
+	PrivateEndpointIds types.List   `tfsdk:"private_endpoint_ids"`
+	ServiceId          types.String `tfsdk:"service_id"`
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_private_endpoint_attachment"
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"private_endpoint_ids": schema.ListAttribute{
+				Description: "List of private endpoint IDs",
+				ElementType: types.StringType,
+				Optional:    true,
+				Computed:    true,
+				Default:     listdefault.StaticValue(createEmptyList(types.StringType)),
+			},
+			"service_id": schema.StringAttribute{
+				Description: "ClickHouse Servie ID",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	r.client = req.ProviderData.(*Client)
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan ClickhouseServicePrivateEndpointAttachmentModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	service := ServiceUpdate{
+		Name:         "",
+		IpAccessList: nil,
+		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+			Add: []string{},
+		},
+	}
+	servicePrivateEndpointIds := make([]types.String, 0, len(plan.PrivateEndpointIds.Elements()))
+	plan.PrivateEndpointIds.ElementsAs(ctx, &servicePrivateEndpointIds, false)
+	for _, item := range servicePrivateEndpointIds {
+		service.PrivateEndpointIds.Add = append(service.PrivateEndpointIds.Add, item.ValueString())
+	}
+
+	_, err := r.client.UpdateService(plan.ServiceId.ValueString(), service)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Registering ClickHouse Organization Private Endpoint IDs",
+			"Could not update organization private endpoint IDs, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state ClickhouseServicePrivateEndpointAttachmentModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get latest service value from ClickHouse OpenAPI
+	service, err := r.client.GetService(state.ServiceId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Reading ClickHouse Service",
+			"Could not read ClickHouse service edpoints service id"+state.ServiceId.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	// Overwrite items with refreshed state
+	if len(service.PrivateEndpointIds) == 0 {
+		state.PrivateEndpointIds = createEmptyList(types.StringType)
+	} else {
+		state.PrivateEndpointIds, _ = types.ListValueFrom(ctx, types.StringType, service.PrivateEndpointIds)
+	}
+
+	// Set refreshed state
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var config, plan, state ClickhouseServicePrivateEndpointAttachmentModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+
+	service := ServiceUpdate{
+		Name:         "",
+		IpAccessList: nil,
+		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+			Add:    []string{},
+			Remove: []string{},
+		},
+	}
+	servicePrivateEndpointIds := make([]types.String, 0, len(plan.PrivateEndpointIds.Elements()))
+	plan.PrivateEndpointIds.ElementsAs(ctx, &servicePrivateEndpointIds, false)
+	for _, item := range servicePrivateEndpointIds {
+		service.PrivateEndpointIds.Add = append(service.PrivateEndpointIds.Add, item.ValueString())
+	}
+
+	servicePrivateEndpointIds = make([]types.String, 0, len(state.PrivateEndpointIds.Elements()))
+	state.PrivateEndpointIds.ElementsAs(ctx, &servicePrivateEndpointIds, false)
+	for _, item := range servicePrivateEndpointIds {
+		service.PrivateEndpointIds.Remove = append(service.PrivateEndpointIds.Add, item.ValueString())
+	}
+
+	_, err := r.client.UpdateService(plan.ServiceId.ValueString(), service)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Registering ClickHouse Organization Private Endpoint IDs",
+			"Could not update organization private endpoint IDs, service id"+state.ServiceId.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state ClickhouseServicePrivateEndpointAttachmentModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	service := ServiceUpdate{
+		Name:         "",
+		IpAccessList: nil,
+		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+			Remove: []string{},
+		},
+	}
+
+	servicePrivateEndpointIds := make([]types.String, 0, len(state.PrivateEndpointIds.Elements()))
+	state.PrivateEndpointIds.ElementsAs(ctx, &servicePrivateEndpointIds, false)
+	for _, item := range servicePrivateEndpointIds {
+		service.PrivateEndpointIds.Remove = append(service.PrivateEndpointIds.Add, item.ValueString())
+	}
+
+	_, err := r.client.UpdateService(state.ServiceId.ValueString(), service)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Registering ClickHouse Organization Private Endpoint IDs",
+			"Could not update organization private endpoint IDs, service id"+state.ServiceId.ValueString()+": "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *ClickhouseServicePrivateEndpointAttachmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("service_id"), req, resp)
+}

--- a/clickhouse/client.go
+++ b/clickhouse/client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 )
 
-
 type Client struct {
 	BaseUrl        string
 	HttpClient     *http.Client
@@ -71,24 +70,24 @@ type ServiceManagedEncryption struct {
 }
 
 type Service struct {
-	Id                    						string                        `json:"id,omitempty"`
-	Name                  						string                        `json:"name"`
-	Provider              						string                        `json:"provider"`
-	Region                						string                        `json:"region"`
-	Tier                  						string                        `json:"tier"`
-	IdleScaling           						bool                          `json:"idleScaling"`
-	IpAccessList          						[]IpAccess                    `json:"ipAccessList"`
-	MinTotalMemoryGb      						*int                          `json:"minTotalMemoryGb,omitempty"`
-	MaxTotalMemoryGb      						*int                          `json:"maxTotalMemoryGb,omitempty"`
-	NumReplicas           						*int                          `json:"numReplicas,omitempty"`
-	IdleTimeoutMinutes    						*int                          `json:"idleTimeoutMinutes,omitempty"`
-	State                 						string                        `json:"state,omitempty"`
-	Endpoints             						[]Endpoint                    `json:"endpoints,omitempty"`
-	IAMRole						    						string                        `json:"iamRole,omitempty"`
-	PrivateEndpointConfig 						*ServicePrivateEndpointConfig `json:"privateEndpointConfig,omitempty"`
-	PrivateEndpointIds    						[]string                      `json:"privateEndpointIds,omitempty"`
-	EncryptionKey    									string   											`json:"encryptionKey,omitempty"`
-	EncryptionAssumedRoleIdentifier		string												`json:"encryptionAssumedRoleIdentifier,omitempty"`
+	Id                              string                        `json:"id,omitempty"`
+	Name                            string                        `json:"name"`
+	Provider                        string                        `json:"provider"`
+	Region                          string                        `json:"region"`
+	Tier                            string                        `json:"tier"`
+	IdleScaling                     bool                          `json:"idleScaling"`
+	IpAccessList                    []IpAccess                    `json:"ipAccessList"`
+	MinTotalMemoryGb                *int                          `json:"minTotalMemoryGb,omitempty"`
+	MaxTotalMemoryGb                *int                          `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas                     *int                          `json:"numReplicas,omitempty"`
+	IdleTimeoutMinutes              *int                          `json:"idleTimeoutMinutes,omitempty"`
+	State                           string                        `json:"state,omitempty"`
+	Endpoints                       []Endpoint                    `json:"endpoints,omitempty"`
+	IAMRole                         string                        `json:"iamRole,omitempty"`
+	PrivateEndpointConfig           *ServicePrivateEndpointConfig `json:"privateEndpointConfig,omitempty"`
+	PrivateEndpointIds              []string                      `json:"privateEndpointIds,omitempty"`
+	EncryptionKey                   string                        `json:"encryptionKey,omitempty"`
+	EncryptionAssumedRoleIdentifier string                        `json:"encryptionAssumedRoleIdentifier,omitempty"`
 }
 
 type ServiceUpdate struct {
@@ -99,10 +98,10 @@ type ServiceUpdate struct {
 
 type ServiceScalingUpdate struct {
 	IdleScaling        *bool `json:"idleScaling,omitempty"` // bool pointer so that `false`` is not omitted
-	MinTotalMemoryGb   *int   `json:"minTotalMemoryGb,omitempty"`
-	MaxTotalMemoryGb   *int   `json:"maxTotalMemoryGb,omitempty"`
-	NumReplicas        *int   `json:"numReplicas,omitempty"`
-	IdleTimeoutMinutes *int   `json:"idleTimeoutMinutes,omitempty"`
+	MinTotalMemoryGb   *int  `json:"minTotalMemoryGb,omitempty"`
+	MaxTotalMemoryGb   *int  `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas        *int  `json:"numReplicas,omitempty"`
+	IdleTimeoutMinutes *int  `json:"idleTimeoutMinutes,omitempty"`
 }
 
 type ServicePasswordUpdate struct {
@@ -221,14 +220,12 @@ func (c *Client) checkStatusCode(req *http.Request) (*int, error) {
 	return &res.StatusCode, err
 }
 
-
 // GetService - Returns a specifc order
 func (c *Client) GetService(serviceId string) (*Service, error) {
 	req, err := http.NewRequest("GET", c.getServicePath(serviceId, ""), nil)
 	if err != nil {
 		return nil, err
 	}
-
 	body, err := c.doRequest(req)
 	if err != nil {
 		return nil, err
@@ -434,7 +431,7 @@ func (c *Client) DeleteService(serviceId string) (*Service, error) {
 		service, err := c.GetService(serviceId)
 		if err != nil {
 			numErrors++
-			if (numErrors > MAX_RETRY) {
+			if numErrors > MAX_RETRY {
 				return nil, err
 			} else {
 				time.Sleep(5 * time.Second)
@@ -475,7 +472,6 @@ func (c *Client) DeleteService(serviceId string) (*Service, error) {
 		time.Sleep(5 * time.Second)
 	}
 
-
 	return &serviceResponse.Result.Service, nil
 }
 
@@ -500,7 +496,7 @@ type OrganizationUpdate struct {
 }
 
 type OrgResult struct {
-	CreatedAt				 string            `json:"createdAt,omitempty"`
+	CreatedAt        string            `json:"createdAt,omitempty"`
 	ID               string            `json:"id,omitempty"`
 	Name             string            `json:"name,omitempty"`
 	PrivateEndpoints []PrivateEndpoint `json:"privateEndpoints,omitempty"`

--- a/clickhouse/datasource.go
+++ b/clickhouse/datasource.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	CloudProviderAWS = "aws"
-	CloudProviderGCP = "gcp"
+	CloudProviderAWS   = "aws"
+	CloudProviderGCP   = "gcp"
 	CloudProviderAzure = "azure"
 )
 
@@ -80,7 +80,7 @@ func (d *privateEndpointConfigDataSource) Read(ctx context.Context, req datasour
 	// Make the API request to get the private endpoint config
 	privateEndpointConfig, err := d.client.GetOrgPrivateEndpointConfig(cloudProvider, region)
 	if err != nil {
-		resp.Diagnostics.AddError("failed get", fmt.Sprintf("error getting privateEndpointConfig: %w", err))
+		resp.Diagnostics.AddError("failed get", fmt.Sprintf("error getting privateEndpointConfig: %v", err))
 		return
 	}
 	data.EndpointServiceID = types.StringValue(privateEndpointConfig.EndpointServiceId)

--- a/clickhouse/private_endpoint_registration.go
+++ b/clickhouse/private_endpoint_registration.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -223,5 +223,6 @@ func (p *clickhouseProvider) Resources(_ context.Context) []func() resource.Reso
 	return []func() resource.Resource{
 		NewServiceResource,
 		NewPrivateEndpointRegistrationResource,
+		NewClickhouseServicePrivateEndpointAttachmentResource,
 	}
 }

--- a/examples/PrivateLink/aws.tf
+++ b/examples/PrivateLink/aws.tf
@@ -1,19 +1,9 @@
-variable "aws_key" {
-  type = string
-}
-
-variable "aws_secret" {
-  type = string
-}
-
 variable "aws_region" {
   type = string
 }
 
 provider "aws" {
   region     = var.aws_region
-  access_key = var.aws_key
-  secret_key = var.aws_secret
 }
 
 variable "vpc_foo_id" {

--- a/examples/PrivateLink/main.tf
+++ b/examples/PrivateLink/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "0.0.5"
+      version = "0.0.10"
       source  = "ClickHouse/clickhouse"
     }
   }
@@ -39,9 +39,6 @@ resource "clickhouse_service" "aws_red" {
   min_total_memory_gb  = 24
   max_total_memory_gb  = 360
   idle_timeout_minutes = 5
-
-  // allow connections via PrivateLink from VPC foo only
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.id, ]
 }
 
 resource "clickhouse_service" "aws_blue" {
@@ -62,15 +59,13 @@ resource "clickhouse_service" "aws_blue" {
   min_total_memory_gb  = 24
   max_total_memory_gb  = 360
   idle_timeout_minutes = 5
-
-  // allow connecting via PrivateLink from VPC foo and bar
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.id, clickhouse_private_endpoint_registration.private_endpoint_aws_bar.id]
 }
 
 // Private Link Service name for aws/${var.aws_region}
 data "clickhouse_private_endpoint_config" "endpoint_config" {
   cloud_provider = "aws"
   region         = var.aws_region
+  depends_on = [clickhouse_service.aws_blue, clickhouse_service.aws_red]
 }
 
 // add AWS PrivateLink from VPC foo to organization
@@ -87,6 +82,15 @@ resource "clickhouse_private_endpoint_registration" "private_endpoint_aws_bar" {
   id             = aws_vpc_endpoint.pl_vpc_bar.id
   region         = var.aws_region
   description    = "Private Link from VPC bar"
+}
+
+resource "clickhouse_service_private_endpoint_attachment" "red_attachment" {
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.id]
+	service_id = clickhouse_service.aws_red.id
+}
+resource "clickhouse_service_private_endpoint_attachment" "blue_attachment" {
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.id, clickhouse_private_endpoint_registration.private_endpoint_aws_bar.id]
+	service_id = clickhouse_service.aws_blue.id
 }
 
 // hostname for connecting to instance via PrivateLink from VPC foo


### PR DESCRIPTION
This PR solves this [issue](https://github.com/ClickHouse/terraform-provider-clickhouse/issues/30). To solve the issue we need to have a ClickHouse service provisioned first before attaching the endpoints because the endpoints creation depends on the ClickHouse service itself. I moved endpoint attachment to a new resource so it happens after the endpoints are created. 