### PR TITLE
fix obsolete instructions on how to use different environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,6 @@ Do you want to perform these actions?
   Enter a value:
 ```
 
-Note that this basic example points to a locally running OpenAPI server. If you do not have that server running, you can still test by changing the `environment` key on the provider to `qa`, `staging`, or `production`. Make sure to change the organization id, token key, and token secret to valid values for those environments.
+Note that this basic example points to a locally running OpenAPI server.
+If you do not have that server running, you can still test by changing the `api_url` key on the provider to a URL of running API server.
+Make sure to change the organization id, token key, and token secret to valid values for those environments.

--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -62,13 +62,6 @@ func (p *clickhouseProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 	}
 }
 
-var environmentMap = map[string]bool{
-	"production": true,
-	"staging":    true,
-	"qa":         true,
-	"local":      true,
-}
-
 // Configure prepares a ClickHouse OpenAPI client for data sources and resources.
 func (p *clickhouseProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	// Retrieve provider data from configuration


### PR DESCRIPTION
Looks like 'environment' key is not supported anymore. Cleaned up the code and updated doc.