### PR TITLE
Update handling for idle parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ terraform.tfstate
 terraform.tfstate.backup
 .terraform.lock.hcl
 
+terraform-provider-clickhouse
+
 node_modules/
 secrets.tfvars
 dev/

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -262,10 +262,10 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	if service.Tier == "development" {
-		if !plan.IdleScaling.IsNull() || !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.IdleTimeoutMinutes.IsNull() || !plan.NumReplicas.IsNull() {
+		if !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.NumReplicas.IsNull() {
 			resp.Diagnostics.AddError(
 				"Invalid Configuration",
-				"idle_scaling, min_total_memory_gb, max_total_memory_gb, idle_timeout_minutes and num_replicas cannot be defined if the service tier is development",
+				"min_total_memory_gb, max_total_memory_gb and num_replicas cannot be defined if the service tier is development",
 			)
 			return
 		}
@@ -278,10 +278,10 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			return
 		}
 	} else if service.Tier == "production" {
-		if plan.IdleScaling.ValueBool() && (plan.IdleScaling.IsNull() || plan.MinTotalMemoryGb.IsNull() || plan.MaxTotalMemoryGb.IsNull() || plan.IdleTimeoutMinutes.IsNull()) {
+		if plan.MinTotalMemoryGb.IsNull() || plan.MaxTotalMemoryGb.IsNull() {
 			resp.Diagnostics.AddError(
 				"Invalid Configuration",
-				"idle_scaling, min_total_memory_gb, max_total_memory_gb, and idle_timeout_minutes must be defined if the service tier is production and idle_scaling is enabled",
+				"min_total_memory_gb and max_total_memory_gb must be defined if the service tier is production",
 			)
 			return
 		}
@@ -302,8 +302,6 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			return
 		}
 
-		service.IdleScaling = bool(plan.IdleScaling.ValueBool())
-
 		if !plan.MinTotalMemoryGb.IsNull() {
 			minTotalMemoryGb := int(plan.MinTotalMemoryGb.ValueInt64())
 			service.MinTotalMemoryGb = &minTotalMemoryGb
@@ -319,16 +317,24 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			)
 			return
 		}
-		if !plan.IdleTimeoutMinutes.IsNull() {
-			idleTimeoutMinutes := int(plan.IdleTimeoutMinutes.ValueInt64())
-			service.IdleTimeoutMinutes = &idleTimeoutMinutes
-		}
 		if !plan.EncryptionKey.IsNull() {
 			service.EncryptionKey = string(plan.EncryptionKey.ValueString())
 		}
 		if !plan.EncryptionAssumedRoleIdentifier.IsNull() {
 			service.EncryptionAssumedRoleIdentifier = string(plan.EncryptionAssumedRoleIdentifier.ValueString())
 		}
+	}
+
+	service.IdleScaling = bool(plan.IdleScaling.ValueBool())
+	if !plan.IdleTimeoutMinutes.IsNull() {
+		idleTimeoutMinutes := int(plan.IdleTimeoutMinutes.ValueInt64())
+		service.IdleTimeoutMinutes = &idleTimeoutMinutes
+	} else if service.IdleScaling {
+		resp.Diagnostics.AddError(
+			"Invalid Configuration",
+			"idle_timeout_minutes should be defined if idle_scaling is enabled",
+		)
+		return
 	}
 
 	if !plan.Password.IsNull() && !plan.PasswordHash.IsNull() {
@@ -595,21 +601,26 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	if config.Tier.ValueString() == "development" {
-		if !plan.IdleScaling.IsNull() || !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.IdleTimeoutMinutes.IsNull() {
+		if !plan.MinTotalMemoryGb.IsNull() || !plan.MaxTotalMemoryGb.IsNull() || !plan.NumReplicas.IsNull() {
 			resp.Diagnostics.AddError(
 				"Invalid Configuration",
-				"idle_scaling, min_total_memory_gb, max_total_memory_gb, and idle_timeout_minutes cannot be defined if the service tier is development",
+				"min_total_memory_gb, max_total_memory_gb, and num_replicase cannot be defined if the service tier is development",
 			)
-			return
 		}
 	} else if config.Tier.ValueString() == "production" {
-		if plan.IdleScaling.ValueBool() && (plan.IdleScaling.IsNull() || plan.MinTotalMemoryGb.IsNull() || plan.MaxTotalMemoryGb.IsNull() || plan.IdleTimeoutMinutes.IsNull()) {
+		if plan.MinTotalMemoryGb.IsNull() || plan.MaxTotalMemoryGb.IsNull() {
 			resp.Diagnostics.AddError(
 				"Invalid Configuration",
-				"idle_scaling, min_total_memory_gb, max_total_memory_gb, and idle_timeout_minutes must be defined if the service tier is production and idle_scaling is enabled",
+				"min_total_memory_gb and max_total_memory_gb must be defined if the service tier is production",
 			)
-			return
 		}
+	}
+
+	if plan.IdleScaling.ValueBool() && plan.IdleTimeoutMinutes.IsNull() {
+		resp.Diagnostics.AddError(
+			"Invalid Configuration",
+			"idle_timeout_minutes should be defined if idle_scaling is enabled",
+		)
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -132,7 +132,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:    true,
 			},
 			"idle_scaling": schema.BoolAttribute{
-				Description: "When set to true the service is allowed to scale down to zero when idle. Always true for development services. Configurable only for 'production' services.",
+				Description: "When set to true the service is allowed to scale down to zero when idle.",
 				Optional:    true,
 			},
 			"ip_access": schema.ListNestedAttribute{
@@ -187,7 +187,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 			},
 			"idle_timeout_minutes": schema.Int64Attribute{
-				Description: "Set minimum idling timeout (in minutes). Available only for 'production' services. Must be greater than or equal to 5 minutes.",
+				Description: "Set minimum idling timeout (in minutes). Must be greater than or equal to 5 minutes. Must be set if idle_scaling is enabled",
 				Optional:    true,
 			},
 			"iam_role": schema.StringAttribute{

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -28,8 +28,8 @@ description: |-
 - `double_sha1_password_hash` (String, Sensitive) Double SHA1 hash of password for connecting with the MySQL protocol. Cannot be specified if `password` is specified.
 - `encryption_assumed_role_identifier` (String) Custom role identifier arn
 - `encryption_key` (String) Custom encryption key arn
-- `idle_scaling` (Boolean) When set to true the service is allowed to scale down to zero when idle. Always true for development services. Configurable only for 'production' services.
-- `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Available only for 'production' services. Must be greater than or equal to 5 minutes.
+- `idle_scaling` (Boolean) When set to true the service is allowed to scale down to zero when idle.
+- `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Must be greater than or equal to 5 minutes. Must be set if idle_scaling is enabled
 - `max_total_memory_gb` (Number) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
 - `min_total_memory_gb` (Number) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
 - `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.


### PR DESCRIPTION
Fixes #47 

1) idle_scaling param should not affect min_total_memory_gb and max_total_memory_gb
2) idle_scaling and idle_timeout_minutes should be configurable for dev tier too


There is some duplication for checks in Create and Update. It can be addressed in separate PR with addition of more test-cases.