### PR TITLE
move api client code from clickhouse package to own internal one and …

### DIFF
--- a/clickhouse/clickhouse_service_private_endpoint_attachment.go
+++ b/clickhouse/clickhouse_service_private_endpoint_attachment.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-clickhouse/internal/api"
 )
 
 var (
@@ -21,7 +23,7 @@ func NewClickhouseServicePrivateEndpointAttachmentResource() resource.Resource {
 }
 
 type ClickhouseServicePrivateEndpointAttachmentResource struct {
-	client *Client
+	client api.Client
 }
 
 type ClickhouseServicePrivateEndpointAttachmentModel struct {
@@ -56,7 +58,7 @@ func (r *ClickhouseServicePrivateEndpointAttachmentResource) Configure(_ context
 		return
 	}
 
-	r.client = req.ProviderData.(*Client)
+	r.client = req.ProviderData.(api.Client)
 }
 
 func (r *ClickhouseServicePrivateEndpointAttachmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -67,10 +69,10 @@ func (r *ClickhouseServicePrivateEndpointAttachmentResource) Create(ctx context.
 		return
 	}
 
-	service := ServiceUpdate{
+	service := api.ServiceUpdate{
 		Name:         "",
 		IpAccessList: nil,
-		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+		PrivateEndpointIds: &api.PrivateEndpointIdsUpdate{
 			Add: []string{},
 		},
 	}
@@ -138,10 +140,10 @@ func (r *ClickhouseServicePrivateEndpointAttachmentResource) Update(ctx context.
 	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 
-	service := ServiceUpdate{
+	service := api.ServiceUpdate{
 		Name:         "",
 		IpAccessList: nil,
-		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+		PrivateEndpointIds: &api.PrivateEndpointIdsUpdate{
 			Add:    []string{},
 			Remove: []string{},
 		},
@@ -182,10 +184,10 @@ func (r *ClickhouseServicePrivateEndpointAttachmentResource) Delete(ctx context.
 		return
 	}
 
-	service := ServiceUpdate{
+	service := api.ServiceUpdate{
 		Name:         "",
 		IpAccessList: nil,
-		PrivateEndpointIds: &PrivateEndpointIdsUpdate{
+		PrivateEndpointIds: &api.PrivateEndpointIdsUpdate{
 			Remove: []string{},
 		},
 	}

--- a/clickhouse/clickhouse_service_private_endpoint_attachment.go
+++ b/clickhouse/clickhouse_service_private_endpoint_attachment.go
@@ -2,14 +2,13 @@ package clickhouse
 
 import (
 	"context"
+	"terraform-provider-clickhouse/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"terraform-provider-clickhouse/internal/api"
 )
 
 var (

--- a/clickhouse/datasource.go
+++ b/clickhouse/datasource.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-clickhouse/internal/api"
 )
 
 const (
@@ -26,7 +28,7 @@ func NewPrivateEndpointConfigDataSource() datasource.DataSource {
 }
 
 type privateEndpointConfigDataSource struct {
-	client *Client
+	client api.Client
 }
 
 func (d *privateEndpointConfigDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -34,7 +36,7 @@ func (d *privateEndpointConfigDataSource) Configure(ctx context.Context, req dat
 	if req.ProviderData == nil {
 		return
 	}
-	d.client = req.ProviderData.(*Client)
+	d.client = req.ProviderData.(api.Client)
 }
 
 func (d *privateEndpointConfigDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {

--- a/clickhouse/datasource.go
+++ b/clickhouse/datasource.go
@@ -3,14 +3,13 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"terraform-provider-clickhouse/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"terraform-provider-clickhouse/internal/api"
 )
 
 const (

--- a/clickhouse/private_endpoint_registration.go
+++ b/clickhouse/private_endpoint_registration.go
@@ -2,13 +2,12 @@ package clickhouse
 
 import (
 	"context"
+	"terraform-provider-clickhouse/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"terraform-provider-clickhouse/internal/api"
 )
 
 var (

--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"os"
+	"terraform-provider-clickhouse/internal/api"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -10,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"terraform-provider-clickhouse/internal/api"
 )
 
 // Ensure the implementation satisfies the expected interfaces

--- a/clickhouse/provider.go
+++ b/clickhouse/provider.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-clickhouse/internal/api"
 )
 
 // Ensure the implementation satisfies the expected interfaces
@@ -187,7 +189,7 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 	}
 
 	// Create a new ClickHouse client using the configuration values
-	client, err := NewClient(apiUrl, organizationId, tokenKey, tokenSecret)
+	client, err := api.NewClient(apiUrl, organizationId, tokenKey, tokenSecret)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create ClickHouse OpenAPI Client",

--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -2,12 +2,13 @@ package clickhouse
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"strings"
+	"terraform-provider-clickhouse/internal/api"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -21,8 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"terraform-provider-clickhouse/internal/api"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -425,7 +424,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	// Update service password if provided explicitly
 	planPassword := plan.Password.ValueString()
 	if len(planPassword) > 0 {
-		_, err := r.client.UpdateServicePassword(s.Id, ServicePasswordUpdateFromPlainPassword(planPassword))
+		_, err := r.client.UpdateServicePassword(s.Id, servicePasswordUpdateFromPlainPassword(planPassword))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error setting service password",
@@ -771,7 +770,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	password := plan.Password.ValueString()
 	if len(password) > 0 && plan.Password != state.Password {
 		password = plan.Password.ValueString()
-		_, err := r.client.UpdateServicePassword(serviceId, ServicePasswordUpdateFromPlainPassword(password))
+		_, err := r.client.UpdateServicePassword(serviceId, servicePasswordUpdateFromPlainPassword(password))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating ClickHouse Service Password",
@@ -938,7 +937,7 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *ServiceRe
 	return nil
 }
 
-func ServicePasswordUpdateFromPlainPassword(password string) api.ServicePasswordUpdate {
+func servicePasswordUpdateFromPlainPassword(password string) api.ServicePasswordUpdate {
 	hash := sha256.Sum256([]byte(password))
 
 	singleSha1Hash := sha1.Sum([]byte(password))  // nolint:gosec

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,10 +1,7 @@
-package clickhouse
+package api
 
 import (
-	"crypto/sha1" // nolint:gosec
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +10,7 @@ import (
 	"time"
 )
 
-type Client struct {
+type ClientImpl struct {
 	BaseUrl        string
 	HttpClient     *http.Client
 	OrganizationId string
@@ -21,8 +18,8 @@ type Client struct {
 	TokenSecret    string
 }
 
-func NewClient(apiUrl string, organizationId string, tokenKey string, tokenSecret string) (*Client, error) {
-	client := &Client{
+func NewClient(apiUrl string, organizationId string, tokenKey string, tokenSecret string) (*ClientImpl, error) {
+	client := &ClientImpl{
 		BaseUrl: apiUrl,
 		HttpClient: &http.Client{
 			Timeout: time.Second * 30,
@@ -33,92 +30,6 @@ func NewClient(apiUrl string, organizationId string, tokenKey string, tokenSecre
 	}
 
 	return client, nil
-}
-
-/****
-	Service
-****/
-
-type IpAccess struct {
-	Source      string `json:"source,omitempty"`
-	Description string `json:"description,omitempty"`
-}
-
-type Endpoint struct {
-	Protocol string `json:"protocol,omitempty"`
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-}
-
-type IpAccessUpdate struct {
-	Add    []IpAccess `json:"add,omitempty"`
-	Remove []IpAccess `json:"remove,omitempty"`
-}
-
-type PrivateEndpointIdsUpdate struct {
-	Add    []string `json:"add,omitempty"`
-	Remove []string `json:"remove,omitempty"`
-}
-
-type ServicePrivateEndpointConfig struct {
-	EndpointServiceId  string `json:"endpointServiceId,omitempty"`
-	PrivateDnsHostname string `json:"privateDnsHostname,omitempty"`
-}
-type ServiceManagedEncryption struct {
-	KeyArn        string `json:"keyArn,omitempty"`
-	AssumeRoleArn string `json:"assumeRoleArn,omitempty"`
-}
-
-type Service struct {
-	Id                              string                        `json:"id,omitempty"`
-	Name                            string                        `json:"name"`
-	Provider                        string                        `json:"provider"`
-	Region                          string                        `json:"region"`
-	Tier                            string                        `json:"tier"`
-	IdleScaling                     bool                          `json:"idleScaling"`
-	IpAccessList                    []IpAccess                    `json:"ipAccessList"`
-	MinTotalMemoryGb                *int                          `json:"minTotalMemoryGb,omitempty"`
-	MaxTotalMemoryGb                *int                          `json:"maxTotalMemoryGb,omitempty"`
-	NumReplicas                     *int                          `json:"numReplicas,omitempty"`
-	IdleTimeoutMinutes              *int                          `json:"idleTimeoutMinutes,omitempty"`
-	State                           string                        `json:"state,omitempty"`
-	Endpoints                       []Endpoint                    `json:"endpoints,omitempty"`
-	IAMRole                         string                        `json:"iamRole,omitempty"`
-	PrivateEndpointConfig           *ServicePrivateEndpointConfig `json:"privateEndpointConfig,omitempty"`
-	PrivateEndpointIds              []string                      `json:"privateEndpointIds,omitempty"`
-	EncryptionKey                   string                        `json:"encryptionKey,omitempty"`
-	EncryptionAssumedRoleIdentifier string                        `json:"encryptionAssumedRoleIdentifier,omitempty"`
-}
-
-type ServiceUpdate struct {
-	Name               string                    `json:"name,omitempty"`
-	IpAccessList       *IpAccessUpdate           `json:"ipAccessList,omitempty"`
-	PrivateEndpointIds *PrivateEndpointIdsUpdate `json:"privateEndpointIds,omitempty"`
-}
-
-type ServiceScalingUpdate struct {
-	IdleScaling        *bool `json:"idleScaling,omitempty"` // bool pointer so that `false`` is not omitted
-	MinTotalMemoryGb   *int  `json:"minTotalMemoryGb,omitempty"`
-	MaxTotalMemoryGb   *int  `json:"maxTotalMemoryGb,omitempty"`
-	NumReplicas        *int  `json:"numReplicas,omitempty"`
-	IdleTimeoutMinutes *int  `json:"idleTimeoutMinutes,omitempty"`
-}
-
-type ServicePasswordUpdate struct {
-	NewPasswordHash   string `json:"newPasswordHash,omitempty"`
-	NewDoubleSha1Hash string `json:"newDoubleSha1Hash,omitempty"`
-}
-
-func ServicePasswordUpdateFromPlainPassword(password string) ServicePasswordUpdate {
-	hash := sha256.Sum256([]byte(password))
-
-	singleSha1Hash := sha1.Sum([]byte(password))  // nolint:gosec
-	doubleSha1Hash := sha1.Sum(singleSha1Hash[:]) // nolint:gosec
-
-	return ServicePasswordUpdate{
-		NewPasswordHash:   base64.StdEncoding.EncodeToString(hash[:]),
-		NewDoubleSha1Hash: hex.EncodeToString(doubleSha1Hash[:]),
-	}
 }
 
 type ServicePasswordUpdateResult struct {
@@ -166,22 +77,22 @@ type ServicePrivateEndpointConfigResponse struct {
 	Result ServicePrivateEndpointConfig `json:"result"`
 }
 
-func (c *Client) getOrgPath(path string) string {
+func (c *ClientImpl) getOrgPath(path string) string {
 	return fmt.Sprintf("%s/organizations/%s%s", c.BaseUrl, c.OrganizationId, path)
 }
 
-func (c *Client) getServicePath(serviceId string, path string) string {
+func (c *ClientImpl) getServicePath(serviceId string, path string) string {
 	if serviceId == "" {
 		return c.getOrgPath("/services")
 	}
 	return c.getOrgPath(fmt.Sprintf("/services/%s%s", serviceId, path))
 }
 
-func (c *Client) getPrivateEndpointConfigPath(cloudProvider string, region string) string {
+func (c *ClientImpl) getPrivateEndpointConfigPath(cloudProvider string, region string) string {
 	return c.getOrgPath(fmt.Sprintf("/privateEndpointConfig?cloud_provider=%s&region_id=%s", cloudProvider, region))
 }
 
-func (c *Client) doRequest(req *http.Request) ([]byte, error) {
+func (c *ClientImpl) doRequest(req *http.Request) ([]byte, error) {
 	credentials := fmt.Sprintf("%s:%s", c.TokenKey, c.TokenSecret)
 	base64Credentials := base64.StdEncoding.EncodeToString([]byte(credentials))
 	authHeader := fmt.Sprintf("Basic %s", base64Credentials)
@@ -205,7 +116,7 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	return body, err
 }
 
-func (c *Client) checkStatusCode(req *http.Request) (*int, error) {
+func (c *ClientImpl) checkStatusCode(req *http.Request) (*int, error) {
 	credentials := fmt.Sprintf("%s:%s", c.TokenKey, c.TokenSecret)
 	base64Credentials := base64.StdEncoding.EncodeToString([]byte(credentials))
 	authHeader := fmt.Sprintf("Basic %s", base64Credentials)
@@ -221,7 +132,7 @@ func (c *Client) checkStatusCode(req *http.Request) (*int, error) {
 }
 
 // GetService - Returns a specifc order
-func (c *Client) GetService(serviceId string) (*Service, error) {
+func (c *ClientImpl) GetService(serviceId string) (*Service, error) {
 	req, err := http.NewRequest("GET", c.getServicePath(serviceId, ""), nil)
 	if err != nil {
 		return nil, err
@@ -260,7 +171,7 @@ func (c *Client) GetService(serviceId string) (*Service, error) {
 	return &service, nil
 }
 
-func (c *Client) GetOrgPrivateEndpointConfig(cloudProvider string, region string) (*OrgPrivateEndpointConfig, error) {
+func (c *ClientImpl) GetOrgPrivateEndpointConfig(cloudProvider string, region string) (*OrgPrivateEndpointConfig, error) {
 	privateEndpointConfigPath := c.getPrivateEndpointConfigPath(cloudProvider, region)
 
 	req, err := http.NewRequest("GET", privateEndpointConfigPath, nil)
@@ -281,7 +192,7 @@ func (c *Client) GetOrgPrivateEndpointConfig(cloudProvider string, region string
 	return &privateEndpointConfigResponse.Result, nil
 }
 
-func (c *Client) CreateService(s Service) (*Service, string, error) {
+func (c *ClientImpl) CreateService(s Service) (*Service, string, error) {
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, "", err
@@ -308,7 +219,7 @@ func (c *Client) CreateService(s Service) (*Service, string, error) {
 	return &serviceResponse.Result.Service, serviceResponse.Result.Password, nil
 }
 
-func (c *Client) UpdateService(serviceId string, s ServiceUpdate) (*Service, error) {
+func (c *ClientImpl) UpdateService(serviceId string, s ServiceUpdate) (*Service, error) {
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -335,7 +246,7 @@ func (c *Client) UpdateService(serviceId string, s ServiceUpdate) (*Service, err
 	return &serviceResponse.Result, nil
 }
 
-func (c *Client) UpdateServiceScaling(serviceId string, s ServiceScalingUpdate) (*Service, error) {
+func (c *ClientImpl) UpdateServiceScaling(serviceId string, s ServiceScalingUpdate) (*Service, error) {
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -362,7 +273,7 @@ func (c *Client) UpdateServiceScaling(serviceId string, s ServiceScalingUpdate) 
 	return &serviceResponse.Result, nil
 }
 
-func (c *Client) UpdateServicePassword(serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error) {
+func (c *ClientImpl) UpdateServicePassword(serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error) {
 	rb, err := json.Marshal(u)
 	if err != nil {
 		return nil, err
@@ -389,7 +300,7 @@ func (c *Client) UpdateServicePassword(serviceId string, u ServicePasswordUpdate
 	return &serviceResponse, nil
 }
 
-func (c *Client) GetServiceStatusCode(serviceId string) (*int, error) {
+func (c *ClientImpl) GetServiceStatusCode(serviceId string) (*int, error) {
 	req, err := http.NewRequest("GET", c.getServicePath(serviceId, ""), nil)
 	if err != nil {
 		return nil, err
@@ -403,7 +314,7 @@ func (c *Client) GetServiceStatusCode(serviceId string) (*int, error) {
 	return statusCode, nil
 }
 
-func (c *Client) DeleteService(serviceId string) (*Service, error) {
+func (c *ClientImpl) DeleteService(serviceId string) (*Service, error) {
 	service, err := c.GetService(serviceId)
 	if err != nil {
 		return nil, err
@@ -508,7 +419,7 @@ type OrganizationUpdateResponse struct {
 	Result OrgResult `json:"result,omitempty"`
 }
 
-func (c *Client) GetOrganizationPrivateEndpoints() (*[]PrivateEndpoint, error) {
+func (c *ClientImpl) GetOrganizationPrivateEndpoints() (*[]PrivateEndpoint, error) {
 	req, err := http.NewRequest("GET", c.getOrgPath(""), nil)
 	if err != nil {
 		return nil, err
@@ -528,7 +439,7 @@ func (c *Client) GetOrganizationPrivateEndpoints() (*[]PrivateEndpoint, error) {
 	return &orgResponse.Result.PrivateEndpoints, nil
 }
 
-func (c *Client) UpdateOrganizationPrivateEndpoints(orgUpdate OrganizationUpdate) (*[]PrivateEndpoint, error) {
+func (c *ClientImpl) UpdateOrganizationPrivateEndpoints(orgUpdate OrganizationUpdate) (*[]PrivateEndpoint, error) {
 	rb, err := json.Marshal(orgUpdate)
 	if err != nil {
 		return nil, err

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1,4 +1,4 @@
-package clickhouse
+package api
 
 import (
 	"net/http"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	testClient := &Client{
+	testClient := &ClientImpl{
 		BaseUrl: "https://api.clickhouse.cloud/v1",
 		HttpClient: &http.Client{
 			Timeout: time.Second * 30,

--- a/internal/api/constants.go
+++ b/internal/api/constants.go
@@ -1,4 +1,4 @@
-package clickhouse
+package api
 
 const (
 	MaxRetry = 5

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -1,0 +1,14 @@
+package api
+
+type Client interface {
+	GetService(serviceId string) (*Service, error)
+	GetOrgPrivateEndpointConfig(cloudProvider string, region string) (*OrgPrivateEndpointConfig, error)
+	CreateService(s Service) (*Service, string, error)
+	UpdateService(serviceId string, s ServiceUpdate) (*Service, error)
+	UpdateServiceScaling(serviceId string, s ServiceScalingUpdate) (*Service, error)
+	UpdateServicePassword(serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error)
+	GetServiceStatusCode(serviceId string) (*int, error)
+	DeleteService(serviceId string) (*Service, error)
+	GetOrganizationPrivateEndpoints() (*[]PrivateEndpoint, error)
+	UpdateOrganizationPrivateEndpoints(orgUpdate OrganizationUpdate) (*[]PrivateEndpoint, error)
+}

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,7 +1,7 @@
 package api
 
 /****
-	Service
+	Request and Response models for all API calls.
 ****/
 
 type IpAccess struct {

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,0 +1,75 @@
+package api
+
+/****
+	Service
+****/
+
+type IpAccess struct {
+	Source      string `json:"source,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type Endpoint struct {
+	Protocol string `json:"protocol,omitempty"`
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+type IpAccessUpdate struct {
+	Add    []IpAccess `json:"add,omitempty"`
+	Remove []IpAccess `json:"remove,omitempty"`
+}
+
+type PrivateEndpointIdsUpdate struct {
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+}
+
+type ServicePrivateEndpointConfig struct {
+	EndpointServiceId  string `json:"endpointServiceId,omitempty"`
+	PrivateDnsHostname string `json:"privateDnsHostname,omitempty"`
+}
+type ServiceManagedEncryption struct {
+	KeyArn        string `json:"keyArn,omitempty"`
+	AssumeRoleArn string `json:"assumeRoleArn,omitempty"`
+}
+
+type Service struct {
+	Id                              string                        `json:"id,omitempty"`
+	Name                            string                        `json:"name"`
+	Provider                        string                        `json:"provider"`
+	Region                          string                        `json:"region"`
+	Tier                            string                        `json:"tier"`
+	IdleScaling                     bool                          `json:"idleScaling"`
+	IpAccessList                    []IpAccess                    `json:"ipAccessList"`
+	MinTotalMemoryGb                *int                          `json:"minTotalMemoryGb,omitempty"`
+	MaxTotalMemoryGb                *int                          `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas                     *int                          `json:"numReplicas,omitempty"`
+	IdleTimeoutMinutes              *int                          `json:"idleTimeoutMinutes,omitempty"`
+	State                           string                        `json:"state,omitempty"`
+	Endpoints                       []Endpoint                    `json:"endpoints,omitempty"`
+	IAMRole                         string                        `json:"iamRole,omitempty"`
+	PrivateEndpointConfig           *ServicePrivateEndpointConfig `json:"privateEndpointConfig,omitempty"`
+	PrivateEndpointIds              []string                      `json:"privateEndpointIds,omitempty"`
+	EncryptionKey                   string                        `json:"encryptionKey,omitempty"`
+	EncryptionAssumedRoleIdentifier string                        `json:"encryptionAssumedRoleIdentifier,omitempty"`
+}
+
+type ServiceUpdate struct {
+	Name               string                    `json:"name,omitempty"`
+	IpAccessList       *IpAccessUpdate           `json:"ipAccessList,omitempty"`
+	PrivateEndpointIds *PrivateEndpointIdsUpdate `json:"privateEndpointIds,omitempty"`
+}
+
+type ServiceScalingUpdate struct {
+	IdleScaling        *bool `json:"idleScaling,omitempty"` // bool pointer so that `false`` is not omitted
+	MinTotalMemoryGb   *int  `json:"minTotalMemoryGb,omitempty"`
+	MaxTotalMemoryGb   *int  `json:"maxTotalMemoryGb,omitempty"`
+	NumReplicas        *int  `json:"numReplicas,omitempty"`
+	IdleTimeoutMinutes *int  `json:"idleTimeoutMinutes,omitempty"`
+}
+
+type ServicePasswordUpdate struct {
+	NewPasswordHash   string `json:"newPasswordHash,omitempty"`
+	NewDoubleSha1Hash string `json:"newDoubleSha1Hash,omitempty"`
+}


### PR DESCRIPTION
…add interface for mocking purposes

This PR is trying to achieve:

- package isolation by moving CH (control plane) API client to own internal package.
- mockability to allow testing of provider by mocking the CH api client