### PR TITLE
Update idleScaling and idleTimeoutMinutes for dev tier as well

### DIFF
--- a/clickhouse/service.go
+++ b/clickhouse/service.go
@@ -841,9 +841,12 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *ServiceRe
 	state.CloudProvider = types.StringValue(service.Provider)
 	state.Region = types.StringValue(service.Region)
 	state.Tier = types.StringValue(service.Tier)
+	state.IdleScaling = types.BoolValue(service.IdleScaling)
+	if service.IdleTimeoutMinutes != nil {
+		state.IdleTimeoutMinutes = types.Int64Value(int64(*service.IdleTimeoutMinutes))
+	}
 
 	if service.Tier == api.TierProduction {
-		state.IdleScaling = types.BoolValue(service.IdleScaling)
 		if service.MinTotalMemoryGb != nil {
 			state.MinTotalMemoryGb = types.Int64Value(int64(*service.MinTotalMemoryGb))
 		}
@@ -852,9 +855,6 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *ServiceRe
 		}
 		if service.NumReplicas != nil {
 			state.NumReplicas = types.Int64Value(int64(*service.NumReplicas))
-		}
-		if service.IdleTimeoutMinutes != nil {
-			state.IdleTimeoutMinutes = types.Int64Value(int64(*service.IdleTimeoutMinutes))
 		}
 	}
 


### PR DESCRIPTION
It is possible to change idle settings (enabled/disabled and timeout) for dev tier as well, but terraform provider state doesn't reflect this.

![Screenshot_20240805_093919](https://github.com/user-attachments/assets/6a412797-573a-4dca-8055-fc6e3e481010)
