### PR TITLE
Prevent setting idle_timeout_minutes if idle_scaling is false

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -311,6 +311,13 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		)
 	}
 
+	if !plan.IdleTimeoutMinutes.IsNull() && !plan.IdleScaling.ValueBool() {
+		resp.Diagnostics.AddError(
+			"Invalid Configuration",
+			"idle_timeout_minutes must be null if idle_scaling is disabled",
+		)
+	}
+
 	if !plan.Password.IsNull() && !plan.PasswordHash.IsNull() {
 		resp.Diagnostics.AddError(
 			"Invalid Configuration",


### PR DESCRIPTION
Doing this leads to an apply time error, so blocking it