### PR TITLE
Fix potential nil pointer panic while waiting for an instance to come up

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -433,8 +433,9 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	numErrors := 0
+	id := s.Id
 	for {
-		s, err = r.client.GetService(s.Id)
+		s, err = r.client.GetService(id)
 		if err != nil {
 			numErrors++
 			if numErrors > api.MaxRetry {


### PR DESCRIPTION
In this for loop, we keep assigning the latest service to the `s` variable.
If the API call, `s` becomes niil and the next loop we don't have an ID to get the service for any more.

this PR fixes this issue