### PR TITLE
Add a nightly run for e2e tests

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -26,6 +26,10 @@ inputs:
     required: false
     default: "false"
     description: "If true it runs a provider upgrade test"
+  skip_build:
+    required: false
+    default: "false"
+    description: "If true it runs tests out of last published terraform provider release"
 
 runs:
   using: "composite"
@@ -76,6 +80,7 @@ runs:
         echo "::endgroup::"
 
     - shell: bash
+      if: ${{ inputs.skip_build == 'false' }}
       name: Build provider from branch and create terraformrc to use it
       run: |
         echo "::group::Build provider from branch and create terraformrc to use it"
@@ -93,9 +98,9 @@ runs:
         echo "::endgroup::"
 
     - shell: bash
-      name: Run terraform using current branch version
+      name: Run terraform
       run: |
-        echo "::group::Run terraform using current branch version"
+        echo "::group::Run terraform"
         cd "examples/${{ inputs.test_name }}"
         terraform init -input=false -upgrade
         terraform plan -no-color

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,104 @@
+name: E2E tests
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Generate a random token to tag the tests with
+  token:
+    outputs:
+      token: ${{ steps.generate.outputs.token }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate
+        id: generate
+        run: |
+          token="$(date '+%s')"
+          echo "token=${token}" >> $GITHUB_OUTPUT
+
+  # Find the 3 most recent releases of terraform CLI (one for each minor)
+  find-tf-releases:
+    outputs:
+      releases: ${{ steps.find.outputs.releases }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/find-tf-releases
+        id: find
+
+  # Run e2e tests
+  e2e:
+    outputs:
+      status: ${{ steps.status.outputs.status }}
+    needs: [ "token", "find-tf-releases" ]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        test: [ "basic" ]
+        tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
+        cloud_provider: [ "aws", "gcp", "azure" ]
+        upgrade_test: ["false"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: e2e
+        uses: ./.github/actions/e2e
+        with:
+          organization_id: ${{ secrets.TF_VAR_ORGANIZATION_ID }}
+          token_key: ${{ secrets.TF_VAR_TOKEN_KEY }}
+          token_secret: ${{ secrets.TF_VAR_TOKEN_SECRET }}
+          token: ${{needs.token.outputs.token}}
+          test_name: ${{ matrix.test }}
+          tf_release: ${{ matrix.tf_release }}
+          cloud_provider: ${{ matrix.cloud_provider }}
+          upgrade_test: ${{ matrix.upgrade_test }}
+          skip_build: "true"
+      - name: Mark error
+        id: status
+        if: failure()
+        run: |
+          echo "status=failure" >> $GITHUB_OUTPUT
+
+  report:
+    runs-on: ubuntu-latest
+    needs: [ "e2e" ]
+    if: ${{ needs.e2e.outputs.status == 'failure' }}
+    steps:
+      - name: Report Failure on slack
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          notification_title: "E2E tests failed during release ${github.ref_name}"
+          footer: "{workflow_url}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
+  # Delete any leftover service that might have failed deleting
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: [ "e2e", "token" ]
+    continue-on-error: true
+    env:
+      organization_id: ${{ secrets.TF_VAR_ORGANIZATION_ID }}
+      token_key: ${{ secrets.TF_VAR_TOKEN_KEY }}
+      token_secret: ${{ secrets.TF_VAR_TOKEN_SECRET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: cleanup
+        uses: ./.github/actions/cleanup
+        with:
+          organization_id: ${{ secrets.TF_VAR_ORGANIZATION_ID }}
+          token_key: ${{ secrets.TF_VAR_TOKEN_KEY }}
+          token_secret: ${{ secrets.TF_VAR_TOKEN_SECRET }}
+          token: ${{needs.token.outputs.token}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,8 +102,13 @@ jobs:
         if: failure()
         run: |
           echo "status=failure" >> $GITHUB_OUTPUT
+
+  report:
+    runs-on: ubuntu-latest
+    needs: [ "e2e" ]
+    if: ${{ needs.e2e.outputs.status == 'failure' }}
+    steps:
       - name: Report Failure on slack
-        if: failure()
         uses: ravsamhq/notify-slack-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -196,6 +201,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{inputs.version}}
+          # Allow goreleaser to access older tag information.
+          fetch-depth: 0
 
       - name: Setup go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Run end to end tests every night.
Helps to find regressions with new releases of terraform cli or with changes in the control plane API