### PR TITLE
rename "id" to "private_endpoint_id" in "private_endpoint_registration"

### DIFF
--- a/docs/resources/private_endpoint_registration.md
+++ b/docs/resources/private_endpoint_registration.md
@@ -20,10 +20,10 @@ Check the [docs](https://clickhouse.com/docs/en/cloud/security/private-link-over
 
 ```terraform
 resource "clickhouse_private_endpoint_registration" "endpoint" {
-  cloud_provider = "aws"
-  id             = "vpce-..."
-  region         = "us-west-2"
-  description    = "Private Link from VPC foo"
+  cloud_provider      = "aws"
+  private_endpoint_id = "vpce-..."
+  region              = "us-west-2"
+  description         = "Private Link from VPC foo"
 }
 ```
 

--- a/docs/resources/private_endpoint_registration.md
+++ b/docs/resources/private_endpoint_registration.md
@@ -33,12 +33,13 @@ resource "clickhouse_private_endpoint_registration" "endpoint" {
 ### Required
 
 - `cloud_provider` (String) Cloud provider of the private endpoint ID
-- `id` (String) ID of the private endpoint
 - `region` (String) Region of the private endpoint
 
 ### Optional
 
 - `description` (String) Description of the private endpoint
+- `id` (String, Deprecated) The `id` attribute is deprecated and will be removed in version 2.0.0. Please use `private_endpoint_id` attribute instead.
+- `private_endpoint_id` (String) ID of the private endpoint (replaces deprecated attribute `id`)
 
 ## Import
 

--- a/docs/resources/private_endpoint_registration.md
+++ b/docs/resources/private_endpoint_registration.md
@@ -33,13 +33,12 @@ resource "clickhouse_private_endpoint_registration" "endpoint" {
 ### Required
 
 - `cloud_provider` (String) Cloud provider of the private endpoint ID
+- `private_endpoint_id` (String) ID of the private endpoint (replaces deprecated attribute `id`)
 - `region` (String) Region of the private endpoint
 
 ### Optional
 
 - `description` (String) Description of the private endpoint
-- `id` (String, Deprecated) The `id` attribute is deprecated and will be removed in version 2.0.0. Please use `private_endpoint_id` attribute instead.
-- `private_endpoint_id` (String) ID of the private endpoint (replaces deprecated attribute `id`)
 
 ## Import
 

--- a/examples/full/private_endpoint/aws/main.tf
+++ b/examples/full/private_endpoint/aws/main.tf
@@ -40,7 +40,7 @@ resource "clickhouse_private_endpoint_registration" "private_endpoint_aws_foo" {
 }
 
 resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.id]
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.private_endpoint_aws_foo.private_endpoint_id]
   service_id = clickhouse_service.aws_red.id
 }
 

--- a/examples/full/private_endpoint/aws/main.tf
+++ b/examples/full/private_endpoint/aws/main.tf
@@ -33,10 +33,10 @@ resource "clickhouse_service" "aws_red" {
 
 // add AWS PrivateLink from VPC foo to organization
 resource "clickhouse_private_endpoint_registration" "private_endpoint_aws_foo" {
-  cloud_provider = "aws"
-  id             = aws_vpc_endpoint.pl_vpc_foo.id
-  region         = var.aws_region
-  description    = "Private Link from VPC foo"
+  cloud_provider      = "aws"
+  private_endpoint_id = aws_vpc_endpoint.pl_vpc_foo.id
+  region              = var.aws_region
+  description         = "Private Link from VPC foo"
 }
 
 resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {

--- a/examples/resources/clickhouse_private_endpoint_registration/resource.tf
+++ b/examples/resources/clickhouse_private_endpoint_registration/resource.tf
@@ -1,6 +1,6 @@
 resource "clickhouse_private_endpoint_registration" "endpoint" {
-  cloud_provider = "aws"
-  id             = "vpce-..."
-  region         = "us-west-2"
-  description    = "Private Link from VPC foo"
+  cloud_provider      = "aws"
+  private_endpoint_id = "vpce-..."
+  region              = "us-west-2"
+  description         = "Private Link from VPC foo"
 }

--- a/pkg/resource/models/private_endpoint_registration.go
+++ b/pkg/resource/models/private_endpoint_registration.go
@@ -9,7 +9,4 @@ type PrivateEndpointRegistration struct {
 	Description   types.String `tfsdk:"description"`
 	EndpointId    types.String `tfsdk:"private_endpoint_id"`
 	Region        types.String `tfsdk:"region"`
-
-	// TODO remove in 2.0.0
-	LegacyEndpointId types.String `tfsdk:"id"`
 }

--- a/pkg/resource/models/private_endpoint_registration.go
+++ b/pkg/resource/models/private_endpoint_registration.go
@@ -7,6 +7,9 @@ import (
 type PrivateEndpointRegistration struct {
 	CloudProvider types.String `tfsdk:"cloud_provider"`
 	Description   types.String `tfsdk:"description"`
-	EndpointId    types.String `tfsdk:"id"`
+	EndpointId    types.String `tfsdk:"private_endpoint_id"`
 	Region        types.String `tfsdk:"region"`
+
+	// TODO remove in 2.0.0
+	LegacyEndpointId types.String `tfsdk:"id"`
 }

--- a/pkg/resource/private_endpoint_registration.go
+++ b/pkg/resource/private_endpoint_registration.go
@@ -41,16 +41,9 @@ func (r *PrivateEndpointRegistrationResource) Schema(_ context.Context, _ resour
 				Description: "Description of the private endpoint",
 				Optional:    true,
 			},
-			// TODO remove in 2.0.0.
-			"id": schema.StringAttribute{
-				Optional:           true,
-				Description:        "The `id` attribute is deprecated and will be removed in version 2.0.0. Please use `private_endpoint_id` attribute instead.",
-				DeprecationMessage: "The `id` attribute is deprecated and will be removed in version 2.0.0. Please use `private_endpoint_id` attribute instead.",
-			},
 			"private_endpoint_id": schema.StringAttribute{
 				Description: "ID of the private endpoint (replaces deprecated attribute `id`)",
-				// TODO mark as required in 2.0.0
-				Optional: true,
+				Required:    true,
 			},
 			"region": schema.StringAttribute{
 				Description: "Region of the private endpoint",
@@ -71,45 +64,6 @@ func (r *PrivateEndpointRegistrationResource) Configure(_ context.Context, req r
 	}
 
 	r.client = req.ProviderData.(api.Client)
-}
-
-func (r *PrivateEndpointRegistrationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
-		// If the entire plan is null, the resource is planned for destruction.
-		return
-	}
-
-	var plan, state models.PrivateEndpointRegistration
-	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
-	if !req.State.Raw.IsNull() {
-		diags = req.State.Get(ctx, &state)
-		resp.Diagnostics.Append(diags...)
-	}
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// TODO remove in 2.0.0
-	{
-		if !plan.EndpointId.IsNull() && !plan.LegacyEndpointId.IsNull() {
-			resp.Diagnostics.AddError(
-				"Invalid Configuration",
-				"Both `id` (deprecated) and `private_endpoint_id` attributes were sepecified. Please remove deprecated `id` field.",
-			)
-		}
-
-		if plan.EndpointId.IsNull() && !plan.LegacyEndpointId.IsNull() {
-			plan.EndpointId = plan.LegacyEndpointId
-		}
-
-		if plan.EndpointId.IsNull() && plan.LegacyEndpointId.IsNull() {
-			resp.Diagnostics.AddError(
-				"Invalid Configuration",
-				"Please specify `private_endpoint_id` attribute.",
-			)
-		}
-	}
 }
 
 func (r *PrivateEndpointRegistrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -181,6 +135,7 @@ func (r *PrivateEndpointRegistrationResource) Read(ctx context.Context, req reso
 		state.Description = types.StringValue(privateEndpoint.Description)
 		state.Region = types.StringValue(privateEndpoint.Region)
 		state.CloudProvider = types.StringValue(privateEndpoint.CloudProvider)
+		state.EndpointId = types.StringValue(privateEndpoint.EndpointId)
 
 		diags = resp.State.Set(ctx, &state)
 		resp.Diagnostics.Append(diags...)

--- a/pkg/resource/private_endpoint_registration.go
+++ b/pkg/resource/private_endpoint_registration.go
@@ -49,7 +49,8 @@ func (r *PrivateEndpointRegistrationResource) Schema(_ context.Context, _ resour
 			},
 			"private_endpoint_id": schema.StringAttribute{
 				Description: "ID of the private endpoint (replaces deprecated attribute `id`)",
-				Optional:    true,
+				// TODO mark as required in 2.0.0
+				Optional: true,
 			},
 			"region": schema.StringAttribute{
 				Description: "Region of the private endpoint",
@@ -100,6 +101,13 @@ func (r *PrivateEndpointRegistrationResource) ModifyPlan(ctx context.Context, re
 
 		if plan.EndpointId.IsNull() && !plan.LegacyEndpointId.IsNull() {
 			plan.EndpointId = plan.LegacyEndpointId
+		}
+
+		if plan.EndpointId.IsNull() && plan.LegacyEndpointId.IsNull() {
+			resp.Diagnostics.AddError(
+				"Invalid Configuration",
+				"Please specify `private_endpoint_id` attribute.",
+			)
 		}
 	}
 }


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/135

Renaming the `id` field in `private_endpoint_registration` to a more appropiare `private_endpoint_id`

as a side effect, we make the provider more "pulumi friendly" as per customer request.