### PR TITLE
Breaking change documentation and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ For each `clickhouse_service_private_endpoints_attachment` you created in step 2
   terraform import clickhouse_service_private_endpoints_attachment.<name> <clickhouse service id>
 ```
 
+If everyting is fine, there should be no changes in your infrastructure after the upgrade.
+
+If you have trouble, please open an issue and we'll try to help!
+
 ## Development
 
 Create a new file called .terraformrc in your home directory (~), then add the dev_overrides block below. Change the `<PATH>` to the full path of the `tmp` directory in this repo. For example:

--- a/README.md
+++ b/README.md
@@ -82,15 +82,7 @@ resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {
 }
 ```
 
-2c) Import existing `clickhouse_service_private_endpoints_attachment`
-
-For each `clickhouse_service_private_endpoints_attachment` you created in step 2b, import existing state with
-
-```
-  terraform import clickhouse_service_private_endpoints_attachment.<name> <clickhouse service id>
-```
-
-If everyting is fine, there should be no changes in your infrastructure after the upgrade.
+If everyting is fine, there should be no changes in existing infrastructure but only one or more `clickhouse_service_private_endpoints_attachment` should be pending creation. That is the expected status.
 
 If you have trouble, please open an issue and we'll try to help!
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,84 @@ You can find examples in the [examples/full](https://github.com/ClickHouse/terra
 
 Please refer to the [official docs](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) for more details.
 
+## Breaking changes
+
+### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
+
+If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the `clickhouse_private_endpoint_registration` resource or the `private_endpoint_ids` attribute of the `clickhouse_service` resource,
+then a manual process is required after the upgrade.
+
+1) In the `clickhouse_private_endpoint_registration` resource, rename the `id` attribute to `private_endpoint_id`.
+
+Before:
+
+```
+resource "clickhouse_private_endpoint_registration" "example" {
+  id = aws_vpc_endpoint.pl_vpc_foo.id
+  ...
+}
+```
+
+After:
+
+```
+resource "clickhouse_private_endpoint_registration" "example" {
+  private_endpoint_id = aws_vpc_endpoint.pl_vpc_foo.id
+  ...
+}
+```
+
+2) If you used the `private_endpoint_ids` in any of the `clickhouse_service` resources
+
+For each service with `private_endpoint_ids` attribute set:
+
+2a) Create a new `clickhouse_service_private_endpoints_attachment` resource  like this:
+
+```
+resource "clickhouse_service_private_endpoints_attachment" "example" {
+  # The ID of the service with the `private_endpoint_ids` set
+  service_id = clickhouse_service.aws_red.id
+
+  # the same attribute you previously defined in the `clickhouse_service` resource goes here now
+  # Remember to change `id` with `private_endpoint_id` in the `clickhouse_private_endpoint_registration` reference.
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
+}
+```
+
+2b) Remove the `private_endpoint_ids` attribute from the `clickhouse_service` resource.
+
+Example:
+
+Before:
+
+```
+resource "clickhouse_service" "example" {
+  ...
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.id]
+}
+```
+
+After:
+
+```
+resource "clickhouse_service" "example" {
+  ...
+}
+
+resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {
+  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
+  service_id = clickhouse_service.example.id
+}
+```
+
+2c) Import existing `clickhouse_service_private_endpoints_attachment`
+
+For each `clickhouse_service_private_endpoints_attachment` you created in step 2b, import existing state with
+
+```
+  terraform import clickhouse_service_private_endpoints_attachment.<name> <clickhouse service id>
+```
+
 ## Development
 
 Create a new file called .terraformrc in your home directory (~), then add the dev_overrides block below. Change the `<PATH>` to the full path of the `tmp` directory in this repo. For example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,59 +11,7 @@ description: |-
   Breaking changes
   Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
   If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the clickhouse_private_endpoint_registration resource or the private_endpoint_ids attribute of the clickhouse_service resource,
-  then a manual process is required after the upgrade.
-  In the clickhouse_private_endpoint_registration resource, rename the id attribute to private_endpoint_id.
-  Before:
-  
-  resource "clickhouse_private_endpoint_registration" "example" {
-    id = aws_vpc_endpoint.pl_vpc_foo.id
-    ...
-  }
-  
-  After:
-  
-  resource "clickhouse_private_endpoint_registration" "example" {
-    private_endpoint_id = aws_vpc_endpoint.pl_vpc_foo.id
-    ...
-  }
-  
-  If you used the private_endpoint_ids in any of the clickhouse_service resources
-  For each service with private_endpoint_ids attribute set:
-  2a) Create a new clickhouse_service_private_endpoints_attachment resource  like this:
-  
-  resource "clickhouse_service_private_endpoints_attachment" "example" {
-    # The ID of the service with the `private_endpoint_ids` set
-    service_id = clickhouse_service.aws_red.id
-  
-    # the same attribute you previously defined in the `clickhouse_service` resource goes here now
-    # Remember to change `id` with `private_endpoint_id` in the `clickhouse_private_endpoint_registration` reference.
-    private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
-  }
-  
-  2b) Remove the private_endpoint_ids attribute from the clickhouse_service resource.
-  Example:
-  Before:
-  
-  resource "clickhouse_service" "example" {
-    ...
-    private_endpoint_ids = [clickhouse_private_endpoint_registration.example.id]
-  }
-  
-  After:
-  
-  resource "clickhouse_service" "example" {
-    ...
-  }
-  
-  resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {
-    private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
-    service_id = clickhouse_service.example.id
-  }
-  
-  2c) Import existing clickhouse_service_private_endpoints_attachment
-  For each clickhouse_service_private_endpoints_attachment you created in step 2b, import existing state with
-  
-    terraform import clickhouse_service_private_endpoints_attachment.<name> <clickhouse service id>
+  then a manual process is required after the upgrade. Please visit https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes for more details.
 ---
 
 # clickhouse Provider
@@ -83,78 +31,7 @@ Visit [https://clickhouse.com/docs/en/cloud-quick-start](https://clickhouse.com/
 ### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
 
 If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the `clickhouse_private_endpoint_registration` resource or the `private_endpoint_ids` attribute of the `clickhouse_service` resource,
-then a manual process is required after the upgrade.
-
-1) In the `clickhouse_private_endpoint_registration` resource, rename the `id` attribute to `private_endpoint_id`.
-
-Before:
-
-```
-resource "clickhouse_private_endpoint_registration" "example" {
-  id = aws_vpc_endpoint.pl_vpc_foo.id
-  ...
-}
-```
-
-After:
-
-```
-resource "clickhouse_private_endpoint_registration" "example" {
-  private_endpoint_id = aws_vpc_endpoint.pl_vpc_foo.id
-  ...
-}
-```
-
-2) If you used the `private_endpoint_ids` in any of the `clickhouse_service` resources
-
-For each service with `private_endpoint_ids` attribute set:
-
-2a) Create a new `clickhouse_service_private_endpoints_attachment` resource  like this:
-
-```
-resource "clickhouse_service_private_endpoints_attachment" "example" {
-  # The ID of the service with the `private_endpoint_ids` set
-  service_id = clickhouse_service.aws_red.id
-
-  # the same attribute you previously defined in the `clickhouse_service` resource goes here now
-  # Remember to change `id` with `private_endpoint_id` in the `clickhouse_private_endpoint_registration` reference.
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
-}
-```
-
-2b) Remove the `private_endpoint_ids` attribute from the `clickhouse_service` resource.
-
-Example: 
-
-Before:
-
-```
-resource "clickhouse_service" "example" {
-  ...
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.id]
-}
-```
-
-After:
-
-```
-resource "clickhouse_service" "example" {
-  ...
-}
-
-resource "clickhouse_service_private_endpoints_attachment" "red_attachment" {
-  private_endpoint_ids = [clickhouse_private_endpoint_registration.example.private_endpoint_id]
-  service_id = clickhouse_service.example.id
-}
-```
-
-2c) Import existing `clickhouse_service_private_endpoints_attachment`
-
-For each `clickhouse_service_private_endpoints_attachment` you created in step 2b, import existing state with
-
-```
-  terraform import clickhouse_service_private_endpoints_attachment.<name> <clickhouse service id>
-```
+then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes) for more details.
 
 ## Example Usage
 

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -58,7 +58,6 @@ resource "clickhouse_service" "service" {
 - `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.
 - `password_hash` (String, Sensitive) SHA256 hash of password for the default user. One of either `password` or `password_hash` must be specified.
-- `private_endpoint_ids` (List of String, Deprecated) The `private_endpoint_ids` attribute is deprecated and not used. Please use `clickhouse_service_private_endpoint_attachment` resource instead.
 
 ### Read-Only
 

--- a/pkg/provider/README.md
+++ b/pkg/provider/README.md
@@ -1,0 +1,16 @@
+# This is the official provider for ClickHouse Cloud.
+
+With this provider you can deploy a ClickHouse instance on AWS, Google Cloud or Azure Cloud.
+
+To use this provider, you need to [Sign In](https://clickhouse.cloud/signIn) for a ClickHouse Cloud account and generate an [API key](https://clickhouse.com/docs/en/cloud/manage/openapi).
+
+You can find more example on how to use this provider on [Github](https://github.com/ClickHouse/terraform-provider-clickhouse/tree/main/examples/full).
+
+Visit [https://clickhouse.com/docs/en/cloud-quick-start](https://clickhouse.com/docs/en/cloud-quick-start) now to get started using ClickHouse Cloud.
+
+## Breaking changes
+
+### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
+
+If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the `clickhouse_private_endpoint_registration` resource or the `private_endpoint_ids` attribute of the `clickhouse_service` resource,
+then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes) for more details.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	_ "embed"
 	"os"
 
 	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/datasource"
@@ -20,6 +21,9 @@ import (
 var (
 	_ provider.Provider = &clickhouseProvider{}
 )
+
+//go:embed README.md
+var providerDescription string
 
 // New is a helper function to simplify provider server and testing implementation.
 func New() provider.Provider {
@@ -63,16 +67,7 @@ func (p *clickhouseProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 				Sensitive:   true,
 			},
 		},
-		Description: `This is the official provider for ClickHouse Cloud.
-
-With this provider you can deploy a ClickHouse instance on AWS, Google Cloud or Azure Cloud.
-
-To use this provider, you need to [Sign In](https://clickhouse.cloud/signIn) for a ClickHouse Cloud account and generate an [API key](https://clickhouse.com/docs/en/cloud/manage/openapi).
-
-You can find more example on how to use this provider on [Github](https://github.com/ClickHouse/terraform-provider-clickhouse/tree/main/examples/full).
-
-Visit [https://clickhouse.com/docs/en/cloud-quick-start](https://clickhouse.com/docs/en/cloud-quick-start) now to get started using ClickHouse Cloud.
-`,
+		MarkdownDescription: providerDescription,
 	}
 }
 

--- a/pkg/resource/models/service_resource.go
+++ b/pkg/resource/models/service_resource.go
@@ -90,7 +90,6 @@ type ServiceResourceModel struct {
 	IdleTimeoutMinutes              types.Int64  `tfsdk:"idle_timeout_minutes"`
 	IAMRole                         types.String `tfsdk:"iam_role"`
 	PrivateEndpointConfig           types.Object `tfsdk:"private_endpoint_config"`
-	PrivateEndpointIds              types.List   `tfsdk:"private_endpoint_ids"`
 	EncryptionKey                   types.String `tfsdk:"encryption_key"`
 	EncryptionAssumedRoleIdentifier types.String `tfsdk:"encryption_assumed_role_identifier"`
 }

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -173,12 +173,6 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					objectplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"private_endpoint_ids": schema.ListAttribute{
-				Description:        "The `private_endpoint_ids` attribute is deprecated and not used. Please use `clickhouse_service_private_endpoint_attachment` resource instead.",
-				ElementType:        types.StringType,
-				Optional:           true,
-				DeprecationMessage: "The `private_endpoint_ids` attribute is deprecated and not used. Please use `clickhouse_service_private_endpoint_attachment` resource instead.",
-			},
 			"encryption_key": schema.StringAttribute{
 				Description: "Custom encryption key arn",
 				Optional:    true,


### PR DESCRIPTION
In the upcoming 1.0.0 release we were forced to introduce a few breaking changes  to our provider, by some otherwise unsolvable problems.

Unfortunately, these changes (we split a resource in 2 resources) are not automatically handlable via code, and manual steps are required.

This PR adds the needed steps during such upgrade to the github readme and references it in the docs that go in the terraform website.