### PR TITLE
Add user agent

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "./tmp/terraform-provider-clickhouse"
-  cmd = "go build -o ./tmp/terraform-provider-clickhouse ."
+  cmd = "go build -ldflags='-X github.com/ClickHouse/terraform-provider-clickhouse/pkg/project.version=local-dev -X github.com/ClickHouse/terraform-provider-clickhouse/pkg/project.commit=dirty' -o ./tmp/terraform-provider-clickhouse ."
   delay = 1000
   exclude_dir = ["tmp"]
   exclude_file = []

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,4 +240,3 @@ jobs:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X github.com/ClickHouse/terraform-provider-clickhouse/pkg/project.version={{.Version}} -X github.com/ClickHouse/terraform-provider-clickhouse/pkg/project.commit={{.Commit}}'
   goos:
     - freebsd
     - windows

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/project"
 )
 
 type ClientImpl struct {
@@ -102,6 +104,7 @@ func (c *ClientImpl) doRequest(req *http.Request) ([]byte, error) {
 
 	makeRequest := func(req *http.Request) func() ([]byte, error) {
 		return func() ([]byte, error) {
+			req.Header.Set("User-Agent", fmt.Sprintf("terraform-provider-clickhouse/%s Commit/%s", project.Version(), project.Commit()))
 			res, err := c.HttpClient.Do(req)
 			if err != nil {
 				return nil, err

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,14 @@
+package project
+
+var (
+	version = ""
+	commit  = ""
+)
+
+func Version() string {
+	return version
+}
+
+func Commit() string {
+	return commit
+}


### PR DESCRIPTION
For tracking purposes, we want to add a user-agent header to all http requests to the API.
This way we can server side have an idea on how many users are using the terraform provider and which version