### PR TITLE
Honor server-side throttling info while dealing with 429 errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 )
 
 require (
@@ -40,7 +41,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/pkg/datasource/datasource.go
+++ b/pkg/datasource/datasource.go
@@ -80,7 +80,7 @@ func (d *privateEndpointConfigDataSource) Read(ctx context.Context, req datasour
 	region := data.Region.ValueString()
 
 	// Make the API request to get the private endpoint config
-	privateEndpointConfig, err := d.client.GetOrgPrivateEndpointConfig(cloudProvider, region)
+	privateEndpointConfig, err := d.client.GetOrgPrivateEndpointConfig(ctx, cloudProvider, region)
 	if err != nil {
 		resp.Diagnostics.AddError("failed get", fmt.Sprintf("error getting privateEndpointConfig: %v", err))
 		return

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -140,7 +140,7 @@ func (c *ClientImpl) doRequest(ctx context.Context, req *http.Request) ([]byte, 
 			ctx = tflog.SetField(ctx, "statusCode", res.StatusCode)
 			ctx = tflog.SetField(ctx, "responseHeaders", res.Header)
 			ctx = tflog.SetField(ctx, "responseBody", string(body))
-			tflog.Debug(ctx, fmt.Sprintf("API request"))
+			tflog.Debug(ctx, "API request")
 
 			if res.StatusCode != http.StatusOK {
 				var resetSeconds float64
@@ -161,7 +161,7 @@ func (c *ClientImpl) doRequest(ctx context.Context, req *http.Request) ([]byte, 
 					}
 				} else if res.StatusCode >= http.StatusInternalServerError { // 500
 					resetSeconds = currentExponentialBackoff
-					tflog.Warn(ctx, fmt.Sprintf("Server side error (5xx): waiting %d seconds before retrying", resetSeconds))
+					tflog.Warn(ctx, fmt.Sprintf("Server side error (5xx): waiting %f.1 seconds before retrying", resetSeconds))
 				} else {
 					return nil, backoff.Permanent(fmt.Errorf("status: %d, body: %s", res.StatusCode, body))
 				}

--- a/pkg/internal/api/constants.go
+++ b/pkg/internal/api/constants.go
@@ -7,4 +7,6 @@ const (
 	StateProvisioning = "provisioning"
 	StateStopped      = "stopped"
 	StateStopping     = "stopping"
+
+	ResponseHeaderRateLimitReset = "X-RateLimit-Reset"
 )

--- a/pkg/internal/api/errors.go
+++ b/pkg/internal/api/errors.go
@@ -11,7 +11,3 @@ func IsNotFound(err error) bool {
 
 	return strings.HasPrefix(err.Error(), "status: 404")
 }
-
-func RetriableError(statusCode int) bool {
-	return statusCode == 429 || statusCode >= 500
-}

--- a/pkg/internal/api/interface.go
+++ b/pkg/internal/api/interface.go
@@ -1,14 +1,18 @@
 package api
 
+import (
+	"context"
+)
+
 type Client interface {
-	GetService(serviceId string) (*Service, error)
-	GetOrgPrivateEndpointConfig(cloudProvider string, region string) (*OrgPrivateEndpointConfig, error)
-	CreateService(s Service) (*Service, string, error)
-	WaitForServiceState(serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error
-	UpdateService(serviceId string, s ServiceUpdate) (*Service, error)
-	UpdateServiceScaling(serviceId string, s ServiceScalingUpdate) (*Service, error)
-	UpdateServicePassword(serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error)
-	DeleteService(serviceId string) (*Service, error)
-	GetOrganizationPrivateEndpoints() (*[]PrivateEndpoint, error)
-	UpdateOrganizationPrivateEndpoints(orgUpdate OrganizationUpdate) (*[]PrivateEndpoint, error)
+	GetService(ctx context.Context, serviceId string) (*Service, error)
+	GetOrgPrivateEndpointConfig(ctx context.Context, cloudProvider string, region string) (*OrgPrivateEndpointConfig, error)
+	CreateService(ctx context.Context, s Service) (*Service, string, error)
+	WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error
+	UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error)
+	UpdateServiceScaling(ctx context.Context, serviceId string, s ServiceScalingUpdate) (*Service, error)
+	UpdateServicePassword(ctx context.Context, serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error)
+	DeleteService(ctx context.Context, serviceId string) (*Service, error)
+	GetOrganizationPrivateEndpoints(ctx context.Context) (*[]PrivateEndpoint, error)
+	UpdateOrganizationPrivateEndpoints(ctx context.Context, orgUpdate OrganizationUpdate) (*[]PrivateEndpoint, error)
 }

--- a/pkg/resource/private_endpoint_registration.go
+++ b/pkg/resource/private_endpoint_registration.go
@@ -89,7 +89,7 @@ func (r *PrivateEndpointRegistrationResource) Create(ctx context.Context, req re
 		},
 	}
 
-	_, err := r.client.UpdateOrganizationPrivateEndpoints(orgUpdate)
+	_, err := r.client.UpdateOrganizationPrivateEndpoints(ctx, orgUpdate)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",
@@ -113,7 +113,7 @@ func (r *PrivateEndpointRegistrationResource) Read(ctx context.Context, req reso
 		return
 	}
 
-	privateEndpoints, err := r.client.GetOrganizationPrivateEndpoints()
+	privateEndpoints, err := r.client.GetOrganizationPrivateEndpoints(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading ClickHouse Organization Private Endpoint IDs",
@@ -175,7 +175,7 @@ func (r *PrivateEndpointRegistrationResource) Update(ctx context.Context, req re
 		},
 	}
 
-	_, err := r.client.UpdateOrganizationPrivateEndpoints(orgUpdate)
+	_, err := r.client.UpdateOrganizationPrivateEndpoints(ctx, orgUpdate)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",
@@ -213,7 +213,7 @@ func (r *PrivateEndpointRegistrationResource) Delete(ctx context.Context, req re
 		},
 	}
 
-	_, err := r.client.UpdateOrganizationPrivateEndpoints(orgUpdate)
+	_, err := r.client.UpdateOrganizationPrivateEndpoints(ctx, orgUpdate)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -703,21 +703,6 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *models.Se
 		return errors.New("service ID must be set to fetch the service")
 	}
 
-	j := 50
-	for j > 0 {
-		j = j - 1
-		// Get latest service value from ClickHouse OpenAPI
-		_, err := r.client.GetService(ctx, state.ID.ValueString())
-		if api.IsNotFound(err) {
-			// Service was deleted outside terraform.
-			state.ID = types.StringNull()
-
-			return nil
-		} else if err != nil {
-			return err
-		}
-	}
-
 	// Get latest service value from ClickHouse OpenAPI
 	service, err := r.client.GetService(ctx, state.ID.ValueString())
 	if api.IsNotFound(err) {

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -404,7 +404,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	service.IpAccessList = ipAccessLists
 
 	// Create new service
-	s, _, err := r.client.CreateService(service)
+	s, _, err := r.client.CreateService(ctx, service)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating service",
@@ -413,7 +413,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	err = r.client.WaitForServiceState(s.Id, func(state string) bool { return state != api.StateProvisioning }, 300)
+	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 300)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error retrieving service state",
@@ -425,7 +425,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 	// Update service password if provided explicitly
 	planPassword := plan.Password.ValueString()
 	if len(planPassword) > 0 {
-		_, err := r.client.UpdateServicePassword(s.Id, servicePasswordUpdateFromPlainPassword(planPassword))
+		_, err := r.client.UpdateServicePassword(ctx, s.Id, servicePasswordUpdateFromPlainPassword(planPassword))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error setting service password",
@@ -445,7 +445,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 			passwordUpdate.NewDoubleSha1Hash = doubleSha1PasswordHash
 		}
 
-		_, err := r.client.UpdateServicePassword(s.Id, passwordUpdate)
+		_, err := r.client.UpdateServicePassword(ctx, s.Id, passwordUpdate)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error setting service password",
@@ -559,7 +559,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	// Update existing service
 	if serviceChange {
 		var err error
-		_, err = r.client.UpdateService(serviceId, service)
+		_, err = r.client.UpdateService(ctx, serviceId, service)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating ClickHouse Service",
@@ -611,7 +611,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	if scalingChange {
 		var err error
-		_, err = r.client.UpdateServiceScaling(serviceId, serviceScaling)
+		_, err = r.client.UpdateServiceScaling(ctx, serviceId, serviceScaling)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating ClickHouse Service Scaling",
@@ -624,7 +624,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 	password := plan.Password.ValueString()
 	if len(password) > 0 && plan.Password != state.Password {
 		password = plan.Password.ValueString()
-		_, err := r.client.UpdateServicePassword(serviceId, servicePasswordUpdateFromPlainPassword(password))
+		_, err := r.client.UpdateServicePassword(ctx, serviceId, servicePasswordUpdateFromPlainPassword(password))
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating ClickHouse Service Password",
@@ -645,7 +645,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 			passwordUpdate.NewDoubleSha1Hash = plan.DoubleSha1PasswordHash.ValueString()
 		}
 
-		_, err := r.client.UpdateServicePassword(serviceId, passwordUpdate)
+		_, err := r.client.UpdateServicePassword(ctx, serviceId, passwordUpdate)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Updating ClickHouse Service Password",
@@ -682,7 +682,7 @@ func (r *ServiceResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	// Delete existing order
-	_, err := r.client.DeleteService(state.ID.ValueString())
+	_, err := r.client.DeleteService(ctx, state.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting ClickHouse Service",
@@ -703,8 +703,23 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *models.Se
 		return errors.New("service ID must be set to fetch the service")
 	}
 
+	j := 50
+	for j > 0 {
+		j = j - 1
+		// Get latest service value from ClickHouse OpenAPI
+		_, err := r.client.GetService(ctx, state.ID.ValueString())
+		if api.IsNotFound(err) {
+			// Service was deleted outside terraform.
+			state.ID = types.StringNull()
+
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+
 	// Get latest service value from ClickHouse OpenAPI
-	service, err := r.client.GetService(state.ID.ValueString())
+	service, err := r.client.GetService(ctx, state.ID.ValueString())
 	if api.IsNotFound(err) {
 		// Service was deleted outside terraform.
 		state.ID = types.StringNull()

--- a/pkg/resource/service_private_endpoints_attachment.go
+++ b/pkg/resource/service_private_endpoints_attachment.go
@@ -117,7 +117,7 @@ func (r *ServicePrivateEndpointsAttachmentResource) Create(ctx context.Context, 
 	// When migrating from 0.3.0 to 1.0.0+ this resource is always created, but the attachment might still exist
 	// We read the service to check for existing attachments in order to not fail creating them
 	{
-		service, err := r.client.GetService(plan.ServiceID.ValueString())
+		service, err := r.client.GetService(ctx, plan.ServiceID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error Reading ClickHouse Service",
@@ -135,7 +135,7 @@ func (r *ServicePrivateEndpointsAttachmentResource) Create(ctx context.Context, 
 		serviceUpdate.PrivateEndpointIds.Add = append(serviceUpdate.PrivateEndpointIds.Add, item.ValueString())
 	}
 
-	_, err := r.client.UpdateService(plan.ServiceID.ValueString(), serviceUpdate)
+	_, err := r.client.UpdateService(ctx, plan.ServiceID.ValueString(), serviceUpdate)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",
@@ -160,7 +160,7 @@ func (r *ServicePrivateEndpointsAttachmentResource) Read(ctx context.Context, re
 	}
 
 	// Get latest service value from ClickHouse OpenAPI
-	service, err := r.client.GetService(state.ServiceID.ValueString())
+	service, err := r.client.GetService(ctx, state.ServiceID.ValueString())
 	if api.IsNotFound(err) {
 		// Service not found, hence attachment cannot exist as well.
 		resp.State.RemoveResource(ctx)
@@ -213,7 +213,7 @@ func (r *ServicePrivateEndpointsAttachmentResource) Update(ctx context.Context, 
 		service.PrivateEndpointIds.Remove = append(service.PrivateEndpointIds.Add, item.ValueString())
 	}
 
-	_, err := r.client.UpdateService(plan.ServiceID.ValueString(), service)
+	_, err := r.client.UpdateService(ctx, plan.ServiceID.ValueString(), service)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",
@@ -249,7 +249,7 @@ func (r *ServicePrivateEndpointsAttachmentResource) Delete(ctx context.Context, 
 		service.PrivateEndpointIds.Remove = append(service.PrivateEndpointIds.Add, item.ValueString())
 	}
 
-	_, err := r.client.UpdateService(state.ServiceID.ValueString(), service)
+	_, err := r.client.UpdateService(ctx, state.ServiceID.ValueString(), service)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Registering ClickHouse Organization Private Endpoint IDs",

--- a/pkg/resource/service_test.go
+++ b/pkg/resource/service_test.go
@@ -368,7 +368,7 @@ func TestServiceResource_syncServiceState(t *testing.T) {
 
 			apiClientMock := api.NewClientMock(mc).
 				GetServiceMock.
-				Expect(tt.state.ID.ValueString()).
+				Expect(context.Background(), tt.state.ID.ValueString()).
 				Return(tt.response, tt.responseErr)
 
 			r := &ServiceResource{


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/148

We want to be more gentle on the backend API, thus we try to honour the response header indicating how long to wait before making another call.

Also fixed debug logging