### PR TITLE
Fix wrong calculation of memory size while caling services with more than 3 replicas

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
+          status: 'failure'
           notification_title: "E2E tests failed for {branch}"
           footer: "{run_url}"
         env:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ In version 1.1.0 we deprecated the `min_total_memory_gb` and `max_total_memory_g
 
 The intended replacement for those fields are:
 
-- `min_replica_memory_gb`: Minimum memory used by *each replica* during autoscaling 
-- `max_replica_memory_gb`: Maximum memory used by *each replica* during autoscaling
+- `min_replica_memory_gb`: Minimum memory used by *each replica* during auto-scaling 
+- `max_replica_memory_gb`: Maximum memory used by *each replica* during auto-scaling
 
 The key difference between the old and new fields is that the old ones indicated a *total amount of memory* for the whole service (the sum of all replicas) while the new ones act on a *single replica*.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,38 @@ You can find examples in the [examples/full](https://github.com/ClickHouse/terra
 
 Please refer to the [official docs](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs) for more details.
 
-## Breaking changes
+## Breaking changes and deprecations
+
+### Upgrading to version >= 1.1.0
+
+In version 1.1.0 we deprecated the `min_total_memory_gb` and `max_total_memory_gb` fields. You can keep using them, but they will eventually be removed.
+
+The intended replacement for those fields are:
+
+- `min_replica_memory_gb`: Minimum memory used by *each replica* during autoscaling 
+- `max_replica_memory_gb`: Maximum memory used by *each replica* during autoscaling
+
+The key difference between the old and new fields is that the old ones indicated a *total amount of memory* for the whole service (the sum of all replicas) while the new ones act on a *single replica*.
+
+For example, if you had a 3 replica cluster with the following settings:
+
+```terraform
+resource "clickhouse_service" "svc" {
+  ...
+  min_total_memory_gb = 24
+  max_total_memory_gb = 36
+}
+```
+
+you should convert it to
+
+```terraform
+resource "clickhouse_service" "svc" {
+  ...
+  min_replica_memory_gb = 8
+  max_replica_memory_gb = 12
+}
+```
 
 ### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
 
@@ -86,108 +117,6 @@ If everyting is fine, there should be no changes in existing infrastructure but 
 
 If you have trouble, please open an issue and we'll try to help!
 
-## Development
+## Development and contributing
 
-Create a new file called .terraformrc in your home directory (~), then add the dev_overrides block below. Change the `<PATH>` to the full path of the `tmp` directory in this repo. For example:
-
-```t
-provider_installation {
-
-  dev_overrides {
-      "ClickHouse/clickhouse" = "<PATH example /home/user/workdir/terraform-provider-clickhouse/tmp>"
-  }
-
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
-}
-```
-
-Ensure you have [`air`](https://github.com/air-verse/air) or install it with:
-
-```bash
-go install github.com/air-verse/air@latest
-```
-
-Run `air` to automatically build the plugin binary every time you make changes to the code:
-
-```bash
-$ air
-```
-
-You can now run `terraform` and you'll be using the locally built binary. Please note that the `dev_overrides` make it so that you have to skip `terraform init`).
-For example, go to the `examples/basic` directory and :
-
-```bash
-terraform apply -var-file="variables.tfvars"
-╷
-│ Warning: Provider development overrides are in effect
-│
-│ The following provider development overrides are set in the CLI configuration:
-│  - ClickHouse/clickhouse in /home/user/workdir/terraform-provider-clickhouse/tmp
-│
-│ The behavior may therefore not match any released version of the provider and applying changes may
-│ cause the state to become incompatible with published releases.
-╵
-
-Terraform used the selected providers to generate the following execution plan. Resource actions are
-indicated with the following symbols:
-  + create
-
-Terraform will perform the following actions:
-
-  # clickhouse_service.service will be created
-  + resource "clickhouse_service" "service" {
-      + cloud_provider       = "aws"
-      + id                   = (known after apply)
-      + idle_scaling         = true
-      + idle_timeout_minutes = 5
-      + ip_access            = [
-          + {
-              + description = "Test IP"
-              + source      = "192.168.2.63"
-            },
-        ]
-      + last_updated         = (known after apply)
-      + max_total_memory_gb  = 360
-      + min_total_memory_gb  = 24
-      + name                 = "My Service"
-      + region               = "us-east-1"
-      + tier                 = "production"
-    }
-
-Plan: 1 to add, 0 to change, 0 to destroy.
-
-Do you want to perform these actions?
-  Terraform will perform the actions described above.
-  Only 'yes' will be accepted to approve.
-
-  Enter a value:
-```
-
-
-Make sure to change the organization id, token key, and token secret to valid values.
-
-## Git hooks
-
-We suggest to add git hooks to your local repo, by running:
-
-```bash
-make enable_git_hooks
-```
-
-Code will be formatted and docs generated before each commit.
-
-## Docs
-
-If you made any changes to the provider's interface, please run `make docs` to update documentation as well.
-
-NOTE: this is done automatically by git hooks.
-
-## Release
-
-To make a new public release:
-- ensure the `main` branch contains all the changes you want to release
-- Run the [`Release`](https://github.com/ClickHouse/terraform-provider-clickhouse/actions/workflows/release.yaml) workflow against the main branch (enter the desired release version in semver format without leading `v`, example: "1.2.3")
-- Release will be automatically created if end to end tests will be successful.
+Please read the [Development readme](https://github.com/ClickHouse/terraform-provider-clickhouse/blob/main/development/README.md)

--- a/development/README.md
+++ b/development/README.md
@@ -1,0 +1,97 @@
+# Development
+
+Quick start guide for contributors.
+
+## Preparation
+
+Create a new file called .terraformrc in your home directory (~), then add the dev_overrides block below. Change the `<PATH>` to the full path of the `tmp` directory in this repo. For example:
+
+```t
+provider_installation {
+
+  dev_overrides {
+      "ClickHouse/clickhouse" = "<PATH example /home/user/workdir/terraform-provider-clickhouse/tmp>"
+  }
+
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+```
+
+Ensure you have [`air`](https://github.com/air-verse/air) or install it with:
+
+```bash
+go install github.com/air-verse/air@latest
+```
+
+Run `air` to automatically build the plugin binary every time you make changes to the code:
+
+```bash
+$ air
+```
+
+You can now run `terraform` and you'll be using the locally built binary. Please note that the `dev_overrides` make it so that you have to skip `terraform init`).
+For example, go to the `examples/full/basic/aws` directory and :
+
+```bash
+terraform apply -var-file="variables.tfvars"
+╷
+│ Warning: Provider development overrides are in effect
+│
+│ The following provider development overrides are set in the CLI configuration:
+│  - ClickHouse/clickhouse in /home/user/workdir/terraform-provider-clickhouse/tmp
+│
+│ The behavior may therefore not match any released version of the provider and applying changes may
+│ cause the state to become incompatible with published releases.
+╵
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are
+indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # clickhouse_service.service will be created
+  + resource "clickhouse_service" "service" {
+      ...
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value:
+```
+
+
+Make sure to change the organization id, token key, and token secret to valid values.
+
+## Git hooks
+
+We suggest to add git hooks to your local repo, by running:
+
+```bash
+make enable_git_hooks
+```
+
+Code will be formatted and docs generated before each commit.
+
+## Docs
+
+If you made any changes to the provider's interface, please run `make docs` to update documentation as well.
+
+NOTE: this is done automatically by git hooks.
+
+## Release
+
+NOTE: Release process is only possible for ClickHouse employees.
+
+To make a new public release:
+
+- ensure the `main` branch contains all the changes you want to release
+- Run the [`Release`](https://github.com/ClickHouse/terraform-provider-clickhouse/actions/workflows/release.yaml) workflow against the main branch (enter the desired release version in semver format without leading `v`, example: "1.2.3")
+- Release will be automatically created if end to end tests will be successful.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -53,8 +53,10 @@ resource "clickhouse_service" "service" {
 - `encryption_key` (String) Custom encryption key arn
 - `idle_scaling` (Boolean) When set to true the service is allowed to scale down to zero when idle.
 - `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Must be greater than or equal to 5 minutes. Must be set if idle_scaling is enabled
-- `max_total_memory_gb` (Number) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
-- `min_total_memory_gb` (Number) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
+- `max_replica_memory_gb` (Number) Maximum memory of a single replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. max_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.
+- `max_total_memory_gb` (Number, Deprecated) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
+- `min_replica_memory_gb` (Number) Minimum memory of a singe replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. min_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.
+- `min_total_memory_gb` (Number, Deprecated) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
 - `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.
 - `password_hash` (String, Sensitive) SHA256 hash of password for the default user. One of either `password` or `password_hash` must be specified.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -53,9 +53,9 @@ resource "clickhouse_service" "service" {
 - `encryption_key` (String) Custom encryption key arn
 - `idle_scaling` (Boolean) When set to true the service is allowed to scale down to zero when idle.
 - `idle_timeout_minutes` (Number) Set minimum idling timeout (in minutes). Must be greater than or equal to 5 minutes. Must be set if idle_scaling is enabled
-- `max_replica_memory_gb` (Number) Maximum memory of a single replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. max_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.
+- `max_replica_memory_gb` (Number) Maximum memory of a single replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. `max_replica_memory_gb` x `num_replicas` (default 3) must be lower than 360 for non paid services or 720 for paid services.
 - `max_total_memory_gb` (Number, Deprecated) Maximum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than 360 for non paid services or 720 for paid services.
-- `min_replica_memory_gb` (Number) Minimum memory of a singe replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. min_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.
+- `min_replica_memory_gb` (Number) Minimum memory of a singe replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. `min_replica_memory_gb` x `num_replicas` (default 3) must be lower than 360 for non paid services or 720 for paid services.
 - `min_total_memory_gb` (Number, Deprecated) Minimum total memory of all workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than 24.
 - `num_replicas` (Number) Number of replicas for the service. Available only for 'production' services. Must be between 3 and 20. Contact support to enable this feature.
 - `password` (String, Sensitive) Password for the default user. One of either `password` or `password_hash` must be specified.

--- a/examples/full/basic/aws/main.tf
+++ b/examples/full/basic/aws/main.tf
@@ -21,6 +21,7 @@ resource "clickhouse_service" "service" {
   region                    = "us-east-1"
   tier                      = "production"
   idle_scaling              = true
+  idle_timeout_minutes      = 5
   password_hash             = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
 
   ip_access = [
@@ -30,9 +31,8 @@ resource "clickhouse_service" "service" {
     }
   ]
 
-  min_total_memory_gb  = 24
-  max_total_memory_gb  = 360
-  idle_timeout_minutes = 5
+  min_replica_memory_gb = 8
+  max_replica_memory_gb = 120
 }
 
 output "service_endpoints" {

--- a/examples/full/basic/azure/main.tf
+++ b/examples/full/basic/azure/main.tf
@@ -21,6 +21,7 @@ resource "clickhouse_service" "service" {
   region                    = "westus3"
   tier                      = "production"
   idle_scaling              = true
+  idle_timeout_minutes      = 5
   password_hash             = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
 
   ip_access = [
@@ -30,9 +31,8 @@ resource "clickhouse_service" "service" {
     }
   ]
 
-  min_total_memory_gb  = 24
-  max_total_memory_gb  = 360
-  idle_timeout_minutes = 5
+  min_replica_memory_gb  = 8
+  max_replica_memory_gb  = 120
 }
 
 output "service_endpoints" {

--- a/examples/full/basic/gcp/main.tf
+++ b/examples/full/basic/gcp/main.tf
@@ -21,6 +21,7 @@ resource "clickhouse_service" "service" {
   region                    = "europe-west4"
   tier                      = "production"
   idle_scaling              = true
+  idle_timeout_minutes      = 5
   password_hash             = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
 
   ip_access = [
@@ -30,9 +31,8 @@ resource "clickhouse_service" "service" {
     }
   ]
 
-  min_total_memory_gb  = 24
-  max_total_memory_gb  = 360
-  idle_timeout_minutes = 5
+  min_replica_memory_gb  = 8
+  max_replica_memory_gb  = 120
 }
 
 output "service_endpoints" {

--- a/examples/full/private_endpoint/aws/main.tf
+++ b/examples/full/private_endpoint/aws/main.tf
@@ -16,19 +16,19 @@ variable "service_name" {
 }
 
 resource "clickhouse_service" "aws_red" {
-  name           = var.service_name
-  cloud_provider = "aws"
-  region         = var.aws_region
-  tier           = "production"
-  idle_scaling   = true
-  password_hash  = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
+  name                 = var.service_name
+  cloud_provider       = "aws"
+  region               = var.aws_region
+  tier                 = "production"
+  idle_scaling         = true
+  idle_timeout_minutes = 5
+  password_hash        = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
 
   // keep it empty to block access from internet
   ip_access = []
 
-  min_total_memory_gb  = 24
-  max_total_memory_gb  = 360
-  idle_timeout_minutes = 5
+  min_replica_memory_gb = 8
+  max_replica_memory_gb = 120
 }
 
 // add AWS PrivateLink from VPC foo to organization

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -417,7 +417,7 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 		}
 	}
 
-	err = c.WaitForServiceState(ctx, serviceId, func(state string) bool { return state == StateStopped }, 300)
+	err = c.WaitForServiceState(ctx, serviceId, func(state string) bool { return state == StateStopped }, 10*60)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -258,6 +258,7 @@ func (c *ClientImpl) GetOrgPrivateEndpointConfig(ctx context.Context, cloudProvi
 }
 
 func (c *ClientImpl) CreateService(ctx context.Context, s Service) (*Service, string, error) {
+	s.FixReplicas()
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, "", err
@@ -338,13 +339,13 @@ func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s Serv
 	return &serviceResponse.Result, nil
 }
 
-func (c *ClientImpl) UpdateServiceScaling(ctx context.Context, serviceId string, s ServiceScalingUpdate) (*Service, error) {
+func (c *ClientImpl) UpdateReplicaScaling(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (*Service, error) {
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("PATCH", c.getServicePath(serviceId, "/scaling"), strings.NewReader(string(rb)))
+	req, err := http.NewRequest("PATCH", c.getServicePath(serviceId, "/replicaScaling"), strings.NewReader(string(rb)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -258,7 +258,8 @@ func (c *ClientImpl) GetOrgPrivateEndpointConfig(ctx context.Context, cloudProvi
 }
 
 func (c *ClientImpl) CreateService(ctx context.Context, s Service) (*Service, string, error) {
-	s.FixReplicas()
+	// Needed until we have alignment between service creation and replicaScaling calls.
+	s.FixMemoryBounds()
 	rb, err := json.Marshal(s)
 	if err != nil {
 		return nil, "", err

--- a/pkg/internal/api/client_mock.go
+++ b/pkg/internal/api/client_mock.go
@@ -54,6 +54,12 @@ type ClientMock struct {
 	beforeUpdateOrganizationPrivateEndpointsCounter uint64
 	UpdateOrganizationPrivateEndpointsMock          mClientMockUpdateOrganizationPrivateEndpoints
 
+	funcUpdateReplicaScaling          func(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (sp1 *Service, err error)
+	inspectFuncUpdateReplicaScaling   func(ctx context.Context, serviceId string, s ReplicaScalingUpdate)
+	afterUpdateReplicaScalingCounter  uint64
+	beforeUpdateReplicaScalingCounter uint64
+	UpdateReplicaScalingMock          mClientMockUpdateReplicaScaling
+
 	funcUpdateService          func(ctx context.Context, serviceId string, s ServiceUpdate) (sp1 *Service, err error)
 	inspectFuncUpdateService   func(ctx context.Context, serviceId string, s ServiceUpdate)
 	afterUpdateServiceCounter  uint64
@@ -65,12 +71,6 @@ type ClientMock struct {
 	afterUpdateServicePasswordCounter  uint64
 	beforeUpdateServicePasswordCounter uint64
 	UpdateServicePasswordMock          mClientMockUpdateServicePassword
-
-	funcUpdateServiceScaling          func(ctx context.Context, serviceId string, s ServiceScalingUpdate) (sp1 *Service, err error)
-	inspectFuncUpdateServiceScaling   func(ctx context.Context, serviceId string, s ServiceScalingUpdate)
-	afterUpdateServiceScalingCounter  uint64
-	beforeUpdateServiceScalingCounter uint64
-	UpdateServiceScalingMock          mClientMockUpdateServiceScaling
 
 	funcWaitForServiceState          func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) (err error)
 	inspectFuncWaitForServiceState   func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int)
@@ -105,14 +105,14 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 	m.UpdateOrganizationPrivateEndpointsMock = mClientMockUpdateOrganizationPrivateEndpoints{mock: m}
 	m.UpdateOrganizationPrivateEndpointsMock.callArgs = []*ClientMockUpdateOrganizationPrivateEndpointsParams{}
 
+	m.UpdateReplicaScalingMock = mClientMockUpdateReplicaScaling{mock: m}
+	m.UpdateReplicaScalingMock.callArgs = []*ClientMockUpdateReplicaScalingParams{}
+
 	m.UpdateServiceMock = mClientMockUpdateService{mock: m}
 	m.UpdateServiceMock.callArgs = []*ClientMockUpdateServiceParams{}
 
 	m.UpdateServicePasswordMock = mClientMockUpdateServicePassword{mock: m}
 	m.UpdateServicePasswordMock.callArgs = []*ClientMockUpdateServicePasswordParams{}
-
-	m.UpdateServiceScalingMock = mClientMockUpdateServiceScaling{mock: m}
-	m.UpdateServiceScalingMock.callArgs = []*ClientMockUpdateServiceScalingParams{}
 
 	m.WaitForServiceStateMock = mClientMockWaitForServiceState{mock: m}
 	m.WaitForServiceStateMock.callArgs = []*ClientMockWaitForServiceStateParams{}
@@ -2049,6 +2049,355 @@ func (m *ClientMock) MinimockUpdateOrganizationPrivateEndpointsInspect() {
 	}
 }
 
+type mClientMockUpdateReplicaScaling struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockUpdateReplicaScalingExpectation
+	expectations       []*ClientMockUpdateReplicaScalingExpectation
+
+	callArgs []*ClientMockUpdateReplicaScalingParams
+	mutex    sync.RWMutex
+
+	expectedInvocations uint64
+}
+
+// ClientMockUpdateReplicaScalingExpectation specifies expectation struct of the Client.UpdateReplicaScaling
+type ClientMockUpdateReplicaScalingExpectation struct {
+	mock      *ClientMock
+	params    *ClientMockUpdateReplicaScalingParams
+	paramPtrs *ClientMockUpdateReplicaScalingParamPtrs
+	results   *ClientMockUpdateReplicaScalingResults
+	Counter   uint64
+}
+
+// ClientMockUpdateReplicaScalingParams contains parameters of the Client.UpdateReplicaScaling
+type ClientMockUpdateReplicaScalingParams struct {
+	ctx       context.Context
+	serviceId string
+	s         ReplicaScalingUpdate
+}
+
+// ClientMockUpdateReplicaScalingParamPtrs contains pointers to parameters of the Client.UpdateReplicaScaling
+type ClientMockUpdateReplicaScalingParamPtrs struct {
+	ctx       *context.Context
+	serviceId *string
+	s         *ReplicaScalingUpdate
+}
+
+// ClientMockUpdateReplicaScalingResults contains results of the Client.UpdateReplicaScaling
+type ClientMockUpdateReplicaScalingResults struct {
+	sp1 *Service
+	err error
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Optional() *mClientMockUpdateReplicaScaling {
+	mmUpdateReplicaScaling.optional = true
+	return mmUpdateReplicaScaling
+}
+
+// Expect sets up expected params for Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Expect(ctx context.Context, serviceId string, s ReplicaScalingUpdate) *mClientMockUpdateReplicaScaling {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation == nil {
+		mmUpdateReplicaScaling.defaultExpectation = &ClientMockUpdateReplicaScalingExpectation{}
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.paramPtrs != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by ExpectParams functions")
+	}
+
+	mmUpdateReplicaScaling.defaultExpectation.params = &ClientMockUpdateReplicaScalingParams{ctx, serviceId, s}
+	for _, e := range mmUpdateReplicaScaling.expectations {
+		if minimock.Equal(e.params, mmUpdateReplicaScaling.defaultExpectation.params) {
+			mmUpdateReplicaScaling.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmUpdateReplicaScaling.defaultExpectation.params)
+		}
+	}
+
+	return mmUpdateReplicaScaling
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) ExpectCtxParam1(ctx context.Context) *mClientMockUpdateReplicaScaling {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation == nil {
+		mmUpdateReplicaScaling.defaultExpectation = &ClientMockUpdateReplicaScalingExpectation{}
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.params != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Expect")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.paramPtrs == nil {
+		mmUpdateReplicaScaling.defaultExpectation.paramPtrs = &ClientMockUpdateReplicaScalingParamPtrs{}
+	}
+	mmUpdateReplicaScaling.defaultExpectation.paramPtrs.ctx = &ctx
+
+	return mmUpdateReplicaScaling
+}
+
+// ExpectServiceIdParam2 sets up expected param serviceId for Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) ExpectServiceIdParam2(serviceId string) *mClientMockUpdateReplicaScaling {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation == nil {
+		mmUpdateReplicaScaling.defaultExpectation = &ClientMockUpdateReplicaScalingExpectation{}
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.params != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Expect")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.paramPtrs == nil {
+		mmUpdateReplicaScaling.defaultExpectation.paramPtrs = &ClientMockUpdateReplicaScalingParamPtrs{}
+	}
+	mmUpdateReplicaScaling.defaultExpectation.paramPtrs.serviceId = &serviceId
+
+	return mmUpdateReplicaScaling
+}
+
+// ExpectSParam3 sets up expected param s for Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) ExpectSParam3(s ReplicaScalingUpdate) *mClientMockUpdateReplicaScaling {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation == nil {
+		mmUpdateReplicaScaling.defaultExpectation = &ClientMockUpdateReplicaScalingExpectation{}
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.params != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Expect")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation.paramPtrs == nil {
+		mmUpdateReplicaScaling.defaultExpectation.paramPtrs = &ClientMockUpdateReplicaScalingParamPtrs{}
+	}
+	mmUpdateReplicaScaling.defaultExpectation.paramPtrs.s = &s
+
+	return mmUpdateReplicaScaling
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Inspect(f func(ctx context.Context, serviceId string, s ReplicaScalingUpdate)) *mClientMockUpdateReplicaScaling {
+	if mmUpdateReplicaScaling.mock.inspectFuncUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("Inspect function is already set for ClientMock.UpdateReplicaScaling")
+	}
+
+	mmUpdateReplicaScaling.mock.inspectFuncUpdateReplicaScaling = f
+
+	return mmUpdateReplicaScaling
+}
+
+// Return sets up results that will be returned by Client.UpdateReplicaScaling
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Return(sp1 *Service, err error) *ClientMock {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	if mmUpdateReplicaScaling.defaultExpectation == nil {
+		mmUpdateReplicaScaling.defaultExpectation = &ClientMockUpdateReplicaScalingExpectation{mock: mmUpdateReplicaScaling.mock}
+	}
+	mmUpdateReplicaScaling.defaultExpectation.results = &ClientMockUpdateReplicaScalingResults{sp1, err}
+	return mmUpdateReplicaScaling.mock
+}
+
+// Set uses given function f to mock the Client.UpdateReplicaScaling method
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Set(f func(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (sp1 *Service, err error)) *ClientMock {
+	if mmUpdateReplicaScaling.defaultExpectation != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("Default expectation is already set for the Client.UpdateReplicaScaling method")
+	}
+
+	if len(mmUpdateReplicaScaling.expectations) > 0 {
+		mmUpdateReplicaScaling.mock.t.Fatalf("Some expectations are already set for the Client.UpdateReplicaScaling method")
+	}
+
+	mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling = f
+	return mmUpdateReplicaScaling.mock
+}
+
+// When sets expectation for the Client.UpdateReplicaScaling which will trigger the result defined by the following
+// Then helper
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) When(ctx context.Context, serviceId string, s ReplicaScalingUpdate) *ClientMockUpdateReplicaScalingExpectation {
+	if mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.mock.t.Fatalf("ClientMock.UpdateReplicaScaling mock is already set by Set")
+	}
+
+	expectation := &ClientMockUpdateReplicaScalingExpectation{
+		mock:   mmUpdateReplicaScaling.mock,
+		params: &ClientMockUpdateReplicaScalingParams{ctx, serviceId, s},
+	}
+	mmUpdateReplicaScaling.expectations = append(mmUpdateReplicaScaling.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.UpdateReplicaScaling return parameters for the expectation previously defined by the When method
+func (e *ClientMockUpdateReplicaScalingExpectation) Then(sp1 *Service, err error) *ClientMock {
+	e.results = &ClientMockUpdateReplicaScalingResults{sp1, err}
+	return e.mock
+}
+
+// Times sets number of times Client.UpdateReplicaScaling should be invoked
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Times(n uint64) *mClientMockUpdateReplicaScaling {
+	if n == 0 {
+		mmUpdateReplicaScaling.mock.t.Fatalf("Times of ClientMock.UpdateReplicaScaling mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmUpdateReplicaScaling.expectedInvocations, n)
+	return mmUpdateReplicaScaling
+}
+
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) invocationsDone() bool {
+	if len(mmUpdateReplicaScaling.expectations) == 0 && mmUpdateReplicaScaling.defaultExpectation == nil && mmUpdateReplicaScaling.mock.funcUpdateReplicaScaling == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmUpdateReplicaScaling.mock.afterUpdateReplicaScalingCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmUpdateReplicaScaling.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// UpdateReplicaScaling implements Client
+func (mmUpdateReplicaScaling *ClientMock) UpdateReplicaScaling(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (sp1 *Service, err error) {
+	mm_atomic.AddUint64(&mmUpdateReplicaScaling.beforeUpdateReplicaScalingCounter, 1)
+	defer mm_atomic.AddUint64(&mmUpdateReplicaScaling.afterUpdateReplicaScalingCounter, 1)
+
+	if mmUpdateReplicaScaling.inspectFuncUpdateReplicaScaling != nil {
+		mmUpdateReplicaScaling.inspectFuncUpdateReplicaScaling(ctx, serviceId, s)
+	}
+
+	mm_params := ClientMockUpdateReplicaScalingParams{ctx, serviceId, s}
+
+	// Record call args
+	mmUpdateReplicaScaling.UpdateReplicaScalingMock.mutex.Lock()
+	mmUpdateReplicaScaling.UpdateReplicaScalingMock.callArgs = append(mmUpdateReplicaScaling.UpdateReplicaScalingMock.callArgs, &mm_params)
+	mmUpdateReplicaScaling.UpdateReplicaScalingMock.mutex.Unlock()
+
+	for _, e := range mmUpdateReplicaScaling.UpdateReplicaScalingMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp1, e.results.err
+		}
+	}
+
+	if mmUpdateReplicaScaling.UpdateReplicaScalingMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmUpdateReplicaScaling.UpdateReplicaScalingMock.defaultExpectation.Counter, 1)
+		mm_want := mmUpdateReplicaScaling.UpdateReplicaScalingMock.defaultExpectation.params
+		mm_want_ptrs := mmUpdateReplicaScaling.UpdateReplicaScalingMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockUpdateReplicaScalingParams{ctx, serviceId, s}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmUpdateReplicaScaling.t.Errorf("ClientMock.UpdateReplicaScaling got unexpected parameter ctx, want: %#v, got: %#v%s\n", *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
+				mmUpdateReplicaScaling.t.Errorf("ClientMock.UpdateReplicaScaling got unexpected parameter serviceId, want: %#v, got: %#v%s\n", *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
+			}
+
+			if mm_want_ptrs.s != nil && !minimock.Equal(*mm_want_ptrs.s, mm_got.s) {
+				mmUpdateReplicaScaling.t.Errorf("ClientMock.UpdateReplicaScaling got unexpected parameter s, want: %#v, got: %#v%s\n", *mm_want_ptrs.s, mm_got.s, minimock.Diff(*mm_want_ptrs.s, mm_got.s))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmUpdateReplicaScaling.t.Errorf("ClientMock.UpdateReplicaScaling got unexpected parameters, want: %#v, got: %#v%s\n", *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmUpdateReplicaScaling.UpdateReplicaScalingMock.defaultExpectation.results
+		if mm_results == nil {
+			mmUpdateReplicaScaling.t.Fatal("No results are set for the ClientMock.UpdateReplicaScaling")
+		}
+		return (*mm_results).sp1, (*mm_results).err
+	}
+	if mmUpdateReplicaScaling.funcUpdateReplicaScaling != nil {
+		return mmUpdateReplicaScaling.funcUpdateReplicaScaling(ctx, serviceId, s)
+	}
+	mmUpdateReplicaScaling.t.Fatalf("Unexpected call to ClientMock.UpdateReplicaScaling. %v %v %v", ctx, serviceId, s)
+	return
+}
+
+// UpdateReplicaScalingAfterCounter returns a count of finished ClientMock.UpdateReplicaScaling invocations
+func (mmUpdateReplicaScaling *ClientMock) UpdateReplicaScalingAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateReplicaScaling.afterUpdateReplicaScalingCounter)
+}
+
+// UpdateReplicaScalingBeforeCounter returns a count of ClientMock.UpdateReplicaScaling invocations
+func (mmUpdateReplicaScaling *ClientMock) UpdateReplicaScalingBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateReplicaScaling.beforeUpdateReplicaScalingCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.UpdateReplicaScaling.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmUpdateReplicaScaling *mClientMockUpdateReplicaScaling) Calls() []*ClientMockUpdateReplicaScalingParams {
+	mmUpdateReplicaScaling.mutex.RLock()
+
+	argCopy := make([]*ClientMockUpdateReplicaScalingParams, len(mmUpdateReplicaScaling.callArgs))
+	copy(argCopy, mmUpdateReplicaScaling.callArgs)
+
+	mmUpdateReplicaScaling.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockUpdateReplicaScalingDone returns true if the count of the UpdateReplicaScaling invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockUpdateReplicaScalingDone() bool {
+	if m.UpdateReplicaScalingMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.UpdateReplicaScalingMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.UpdateReplicaScalingMock.invocationsDone()
+}
+
+// MinimockUpdateReplicaScalingInspect logs each unmet expectation
+func (m *ClientMock) MinimockUpdateReplicaScalingInspect() {
+	for _, e := range m.UpdateReplicaScalingMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.UpdateReplicaScaling with params: %#v", *e.params)
+		}
+	}
+
+	afterUpdateReplicaScalingCounter := mm_atomic.LoadUint64(&m.afterUpdateReplicaScalingCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.UpdateReplicaScalingMock.defaultExpectation != nil && afterUpdateReplicaScalingCounter < 1 {
+		if m.UpdateReplicaScalingMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to ClientMock.UpdateReplicaScaling")
+		} else {
+			m.t.Errorf("Expected call to ClientMock.UpdateReplicaScaling with params: %#v", *m.UpdateReplicaScalingMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcUpdateReplicaScaling != nil && afterUpdateReplicaScalingCounter < 1 {
+		m.t.Error("Expected call to ClientMock.UpdateReplicaScaling")
+	}
+
+	if !m.UpdateReplicaScalingMock.invocationsDone() && afterUpdateReplicaScalingCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.UpdateReplicaScaling but found %d calls",
+			mm_atomic.LoadUint64(&m.UpdateReplicaScalingMock.expectedInvocations), afterUpdateReplicaScalingCounter)
+	}
+}
+
 type mClientMockUpdateService struct {
 	optional           bool
 	mock               *ClientMock
@@ -2747,355 +3096,6 @@ func (m *ClientMock) MinimockUpdateServicePasswordInspect() {
 	}
 }
 
-type mClientMockUpdateServiceScaling struct {
-	optional           bool
-	mock               *ClientMock
-	defaultExpectation *ClientMockUpdateServiceScalingExpectation
-	expectations       []*ClientMockUpdateServiceScalingExpectation
-
-	callArgs []*ClientMockUpdateServiceScalingParams
-	mutex    sync.RWMutex
-
-	expectedInvocations uint64
-}
-
-// ClientMockUpdateServiceScalingExpectation specifies expectation struct of the Client.UpdateServiceScaling
-type ClientMockUpdateServiceScalingExpectation struct {
-	mock      *ClientMock
-	params    *ClientMockUpdateServiceScalingParams
-	paramPtrs *ClientMockUpdateServiceScalingParamPtrs
-	results   *ClientMockUpdateServiceScalingResults
-	Counter   uint64
-}
-
-// ClientMockUpdateServiceScalingParams contains parameters of the Client.UpdateServiceScaling
-type ClientMockUpdateServiceScalingParams struct {
-	ctx       context.Context
-	serviceId string
-	s         ServiceScalingUpdate
-}
-
-// ClientMockUpdateServiceScalingParamPtrs contains pointers to parameters of the Client.UpdateServiceScaling
-type ClientMockUpdateServiceScalingParamPtrs struct {
-	ctx       *context.Context
-	serviceId *string
-	s         *ServiceScalingUpdate
-}
-
-// ClientMockUpdateServiceScalingResults contains results of the Client.UpdateServiceScaling
-type ClientMockUpdateServiceScalingResults struct {
-	sp1 *Service
-	err error
-}
-
-// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
-// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
-// Optional() makes method check to work in '0 or more' mode.
-// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
-// catch the problems when the expected method call is totally skipped during test run.
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Optional() *mClientMockUpdateServiceScaling {
-	mmUpdateServiceScaling.optional = true
-	return mmUpdateServiceScaling
-}
-
-// Expect sets up expected params for Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Expect(ctx context.Context, serviceId string, s ServiceScalingUpdate) *mClientMockUpdateServiceScaling {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation == nil {
-		mmUpdateServiceScaling.defaultExpectation = &ClientMockUpdateServiceScalingExpectation{}
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.paramPtrs != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by ExpectParams functions")
-	}
-
-	mmUpdateServiceScaling.defaultExpectation.params = &ClientMockUpdateServiceScalingParams{ctx, serviceId, s}
-	for _, e := range mmUpdateServiceScaling.expectations {
-		if minimock.Equal(e.params, mmUpdateServiceScaling.defaultExpectation.params) {
-			mmUpdateServiceScaling.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmUpdateServiceScaling.defaultExpectation.params)
-		}
-	}
-
-	return mmUpdateServiceScaling
-}
-
-// ExpectCtxParam1 sets up expected param ctx for Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) ExpectCtxParam1(ctx context.Context) *mClientMockUpdateServiceScaling {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation == nil {
-		mmUpdateServiceScaling.defaultExpectation = &ClientMockUpdateServiceScalingExpectation{}
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.params != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Expect")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.paramPtrs == nil {
-		mmUpdateServiceScaling.defaultExpectation.paramPtrs = &ClientMockUpdateServiceScalingParamPtrs{}
-	}
-	mmUpdateServiceScaling.defaultExpectation.paramPtrs.ctx = &ctx
-
-	return mmUpdateServiceScaling
-}
-
-// ExpectServiceIdParam2 sets up expected param serviceId for Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) ExpectServiceIdParam2(serviceId string) *mClientMockUpdateServiceScaling {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation == nil {
-		mmUpdateServiceScaling.defaultExpectation = &ClientMockUpdateServiceScalingExpectation{}
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.params != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Expect")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.paramPtrs == nil {
-		mmUpdateServiceScaling.defaultExpectation.paramPtrs = &ClientMockUpdateServiceScalingParamPtrs{}
-	}
-	mmUpdateServiceScaling.defaultExpectation.paramPtrs.serviceId = &serviceId
-
-	return mmUpdateServiceScaling
-}
-
-// ExpectSParam3 sets up expected param s for Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) ExpectSParam3(s ServiceScalingUpdate) *mClientMockUpdateServiceScaling {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation == nil {
-		mmUpdateServiceScaling.defaultExpectation = &ClientMockUpdateServiceScalingExpectation{}
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.params != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Expect")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation.paramPtrs == nil {
-		mmUpdateServiceScaling.defaultExpectation.paramPtrs = &ClientMockUpdateServiceScalingParamPtrs{}
-	}
-	mmUpdateServiceScaling.defaultExpectation.paramPtrs.s = &s
-
-	return mmUpdateServiceScaling
-}
-
-// Inspect accepts an inspector function that has same arguments as the Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Inspect(f func(ctx context.Context, serviceId string, s ServiceScalingUpdate)) *mClientMockUpdateServiceScaling {
-	if mmUpdateServiceScaling.mock.inspectFuncUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("Inspect function is already set for ClientMock.UpdateServiceScaling")
-	}
-
-	mmUpdateServiceScaling.mock.inspectFuncUpdateServiceScaling = f
-
-	return mmUpdateServiceScaling
-}
-
-// Return sets up results that will be returned by Client.UpdateServiceScaling
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Return(sp1 *Service, err error) *ClientMock {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	if mmUpdateServiceScaling.defaultExpectation == nil {
-		mmUpdateServiceScaling.defaultExpectation = &ClientMockUpdateServiceScalingExpectation{mock: mmUpdateServiceScaling.mock}
-	}
-	mmUpdateServiceScaling.defaultExpectation.results = &ClientMockUpdateServiceScalingResults{sp1, err}
-	return mmUpdateServiceScaling.mock
-}
-
-// Set uses given function f to mock the Client.UpdateServiceScaling method
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Set(f func(ctx context.Context, serviceId string, s ServiceScalingUpdate) (sp1 *Service, err error)) *ClientMock {
-	if mmUpdateServiceScaling.defaultExpectation != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("Default expectation is already set for the Client.UpdateServiceScaling method")
-	}
-
-	if len(mmUpdateServiceScaling.expectations) > 0 {
-		mmUpdateServiceScaling.mock.t.Fatalf("Some expectations are already set for the Client.UpdateServiceScaling method")
-	}
-
-	mmUpdateServiceScaling.mock.funcUpdateServiceScaling = f
-	return mmUpdateServiceScaling.mock
-}
-
-// When sets expectation for the Client.UpdateServiceScaling which will trigger the result defined by the following
-// Then helper
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) When(ctx context.Context, serviceId string, s ServiceScalingUpdate) *ClientMockUpdateServiceScalingExpectation {
-	if mmUpdateServiceScaling.mock.funcUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.mock.t.Fatalf("ClientMock.UpdateServiceScaling mock is already set by Set")
-	}
-
-	expectation := &ClientMockUpdateServiceScalingExpectation{
-		mock:   mmUpdateServiceScaling.mock,
-		params: &ClientMockUpdateServiceScalingParams{ctx, serviceId, s},
-	}
-	mmUpdateServiceScaling.expectations = append(mmUpdateServiceScaling.expectations, expectation)
-	return expectation
-}
-
-// Then sets up Client.UpdateServiceScaling return parameters for the expectation previously defined by the When method
-func (e *ClientMockUpdateServiceScalingExpectation) Then(sp1 *Service, err error) *ClientMock {
-	e.results = &ClientMockUpdateServiceScalingResults{sp1, err}
-	return e.mock
-}
-
-// Times sets number of times Client.UpdateServiceScaling should be invoked
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Times(n uint64) *mClientMockUpdateServiceScaling {
-	if n == 0 {
-		mmUpdateServiceScaling.mock.t.Fatalf("Times of ClientMock.UpdateServiceScaling mock can not be zero")
-	}
-	mm_atomic.StoreUint64(&mmUpdateServiceScaling.expectedInvocations, n)
-	return mmUpdateServiceScaling
-}
-
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) invocationsDone() bool {
-	if len(mmUpdateServiceScaling.expectations) == 0 && mmUpdateServiceScaling.defaultExpectation == nil && mmUpdateServiceScaling.mock.funcUpdateServiceScaling == nil {
-		return true
-	}
-
-	totalInvocations := mm_atomic.LoadUint64(&mmUpdateServiceScaling.mock.afterUpdateServiceScalingCounter)
-	expectedInvocations := mm_atomic.LoadUint64(&mmUpdateServiceScaling.expectedInvocations)
-
-	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
-}
-
-// UpdateServiceScaling implements Client
-func (mmUpdateServiceScaling *ClientMock) UpdateServiceScaling(ctx context.Context, serviceId string, s ServiceScalingUpdate) (sp1 *Service, err error) {
-	mm_atomic.AddUint64(&mmUpdateServiceScaling.beforeUpdateServiceScalingCounter, 1)
-	defer mm_atomic.AddUint64(&mmUpdateServiceScaling.afterUpdateServiceScalingCounter, 1)
-
-	if mmUpdateServiceScaling.inspectFuncUpdateServiceScaling != nil {
-		mmUpdateServiceScaling.inspectFuncUpdateServiceScaling(ctx, serviceId, s)
-	}
-
-	mm_params := ClientMockUpdateServiceScalingParams{ctx, serviceId, s}
-
-	// Record call args
-	mmUpdateServiceScaling.UpdateServiceScalingMock.mutex.Lock()
-	mmUpdateServiceScaling.UpdateServiceScalingMock.callArgs = append(mmUpdateServiceScaling.UpdateServiceScalingMock.callArgs, &mm_params)
-	mmUpdateServiceScaling.UpdateServiceScalingMock.mutex.Unlock()
-
-	for _, e := range mmUpdateServiceScaling.UpdateServiceScalingMock.expectations {
-		if minimock.Equal(*e.params, mm_params) {
-			mm_atomic.AddUint64(&e.Counter, 1)
-			return e.results.sp1, e.results.err
-		}
-	}
-
-	if mmUpdateServiceScaling.UpdateServiceScalingMock.defaultExpectation != nil {
-		mm_atomic.AddUint64(&mmUpdateServiceScaling.UpdateServiceScalingMock.defaultExpectation.Counter, 1)
-		mm_want := mmUpdateServiceScaling.UpdateServiceScalingMock.defaultExpectation.params
-		mm_want_ptrs := mmUpdateServiceScaling.UpdateServiceScalingMock.defaultExpectation.paramPtrs
-
-		mm_got := ClientMockUpdateServiceScalingParams{ctx, serviceId, s}
-
-		if mm_want_ptrs != nil {
-
-			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
-				mmUpdateServiceScaling.t.Errorf("ClientMock.UpdateServiceScaling got unexpected parameter ctx, want: %#v, got: %#v%s\n", *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
-			}
-
-			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
-				mmUpdateServiceScaling.t.Errorf("ClientMock.UpdateServiceScaling got unexpected parameter serviceId, want: %#v, got: %#v%s\n", *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
-			}
-
-			if mm_want_ptrs.s != nil && !minimock.Equal(*mm_want_ptrs.s, mm_got.s) {
-				mmUpdateServiceScaling.t.Errorf("ClientMock.UpdateServiceScaling got unexpected parameter s, want: %#v, got: %#v%s\n", *mm_want_ptrs.s, mm_got.s, minimock.Diff(*mm_want_ptrs.s, mm_got.s))
-			}
-
-		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
-			mmUpdateServiceScaling.t.Errorf("ClientMock.UpdateServiceScaling got unexpected parameters, want: %#v, got: %#v%s\n", *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
-		}
-
-		mm_results := mmUpdateServiceScaling.UpdateServiceScalingMock.defaultExpectation.results
-		if mm_results == nil {
-			mmUpdateServiceScaling.t.Fatal("No results are set for the ClientMock.UpdateServiceScaling")
-		}
-		return (*mm_results).sp1, (*mm_results).err
-	}
-	if mmUpdateServiceScaling.funcUpdateServiceScaling != nil {
-		return mmUpdateServiceScaling.funcUpdateServiceScaling(ctx, serviceId, s)
-	}
-	mmUpdateServiceScaling.t.Fatalf("Unexpected call to ClientMock.UpdateServiceScaling. %v %v %v", ctx, serviceId, s)
-	return
-}
-
-// UpdateServiceScalingAfterCounter returns a count of finished ClientMock.UpdateServiceScaling invocations
-func (mmUpdateServiceScaling *ClientMock) UpdateServiceScalingAfterCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmUpdateServiceScaling.afterUpdateServiceScalingCounter)
-}
-
-// UpdateServiceScalingBeforeCounter returns a count of ClientMock.UpdateServiceScaling invocations
-func (mmUpdateServiceScaling *ClientMock) UpdateServiceScalingBeforeCounter() uint64 {
-	return mm_atomic.LoadUint64(&mmUpdateServiceScaling.beforeUpdateServiceScalingCounter)
-}
-
-// Calls returns a list of arguments used in each call to ClientMock.UpdateServiceScaling.
-// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
-func (mmUpdateServiceScaling *mClientMockUpdateServiceScaling) Calls() []*ClientMockUpdateServiceScalingParams {
-	mmUpdateServiceScaling.mutex.RLock()
-
-	argCopy := make([]*ClientMockUpdateServiceScalingParams, len(mmUpdateServiceScaling.callArgs))
-	copy(argCopy, mmUpdateServiceScaling.callArgs)
-
-	mmUpdateServiceScaling.mutex.RUnlock()
-
-	return argCopy
-}
-
-// MinimockUpdateServiceScalingDone returns true if the count of the UpdateServiceScaling invocations corresponds
-// the number of defined expectations
-func (m *ClientMock) MinimockUpdateServiceScalingDone() bool {
-	if m.UpdateServiceScalingMock.optional {
-		// Optional methods provide '0 or more' call count restriction.
-		return true
-	}
-
-	for _, e := range m.UpdateServiceScalingMock.expectations {
-		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			return false
-		}
-	}
-
-	return m.UpdateServiceScalingMock.invocationsDone()
-}
-
-// MinimockUpdateServiceScalingInspect logs each unmet expectation
-func (m *ClientMock) MinimockUpdateServiceScalingInspect() {
-	for _, e := range m.UpdateServiceScalingMock.expectations {
-		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			m.t.Errorf("Expected call to ClientMock.UpdateServiceScaling with params: %#v", *e.params)
-		}
-	}
-
-	afterUpdateServiceScalingCounter := mm_atomic.LoadUint64(&m.afterUpdateServiceScalingCounter)
-	// if default expectation was set then invocations count should be greater than zero
-	if m.UpdateServiceScalingMock.defaultExpectation != nil && afterUpdateServiceScalingCounter < 1 {
-		if m.UpdateServiceScalingMock.defaultExpectation.params == nil {
-			m.t.Error("Expected call to ClientMock.UpdateServiceScaling")
-		} else {
-			m.t.Errorf("Expected call to ClientMock.UpdateServiceScaling with params: %#v", *m.UpdateServiceScalingMock.defaultExpectation.params)
-		}
-	}
-	// if func was set then invocations count should be greater than zero
-	if m.funcUpdateServiceScaling != nil && afterUpdateServiceScalingCounter < 1 {
-		m.t.Error("Expected call to ClientMock.UpdateServiceScaling")
-	}
-
-	if !m.UpdateServiceScalingMock.invocationsDone() && afterUpdateServiceScalingCounter > 0 {
-		m.t.Errorf("Expected %d calls to ClientMock.UpdateServiceScaling but found %d calls",
-			mm_atomic.LoadUint64(&m.UpdateServiceScalingMock.expectedInvocations), afterUpdateServiceScalingCounter)
-	}
-}
-
 type mClientMockWaitForServiceState struct {
 	optional           bool
 	mock               *ClientMock
@@ -3488,11 +3488,11 @@ func (m *ClientMock) MinimockFinish() {
 
 			m.MinimockUpdateOrganizationPrivateEndpointsInspect()
 
+			m.MinimockUpdateReplicaScalingInspect()
+
 			m.MinimockUpdateServiceInspect()
 
 			m.MinimockUpdateServicePasswordInspect()
-
-			m.MinimockUpdateServiceScalingInspect()
 
 			m.MinimockWaitForServiceStateInspect()
 		}
@@ -3524,8 +3524,8 @@ func (m *ClientMock) minimockDone() bool {
 		m.MinimockGetOrganizationPrivateEndpointsDone() &&
 		m.MinimockGetServiceDone() &&
 		m.MinimockUpdateOrganizationPrivateEndpointsDone() &&
+		m.MinimockUpdateReplicaScalingDone() &&
 		m.MinimockUpdateServiceDone() &&
 		m.MinimockUpdateServicePasswordDone() &&
-		m.MinimockUpdateServiceScalingDone() &&
 		m.MinimockWaitForServiceStateDone()
 }

--- a/pkg/internal/api/interface.go
+++ b/pkg/internal/api/interface.go
@@ -10,7 +10,7 @@ type Client interface {
 	CreateService(ctx context.Context, s Service) (*Service, string, error)
 	WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error
 	UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error)
-	UpdateServiceScaling(ctx context.Context, serviceId string, s ServiceScalingUpdate) (*Service, error)
+	UpdateReplicaScaling(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (*Service, error)
 	UpdateServicePassword(ctx context.Context, serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error)
 	DeleteService(ctx context.Context, serviceId string) (*Service, error)
 	GetOrganizationPrivateEndpoints(ctx context.Context) (*[]PrivateEndpoint, error)

--- a/pkg/internal/api/models.go
+++ b/pkg/internal/api/models.go
@@ -57,7 +57,7 @@ type Service struct {
 	EncryptionAssumedRoleIdentifier string                        `json:"encryptionAssumedRoleIdentifier,omitempty"`
 }
 
-func (s *Service) FixReplicas() {
+func (s *Service) FixMemoryBounds() {
 	if s.MinReplicaMemoryGb == nil && s.MinTotalMemoryGb != nil {
 		// Due to a bug on the API, we always assumed the MinTotalMemoryGb value was always related to 3 replicas.
 		// Now we use a per-replica API to set the min total memory so we need to divide by 3 to get the same

--- a/pkg/internal/api/models.go
+++ b/pkg/internal/api/models.go
@@ -57,6 +57,8 @@ type Service struct {
 	EncryptionAssumedRoleIdentifier string                        `json:"encryptionAssumedRoleIdentifier,omitempty"`
 }
 
+// FixMemoryBounds ensures the MinTotalMemoryGb and MaxTotalMemoryGb fields are set before doing an API call to create the service
+// This is needed because there is a different interface between the /replicaScaling and the service creation API calls.
 func (s *Service) FixMemoryBounds() {
 	if s.MinReplicaMemoryGb == nil && s.MinTotalMemoryGb != nil {
 		// Due to a bug on the API, we always assumed the MinTotalMemoryGb value was always related to 3 replicas.

--- a/pkg/internal/api/models.go
+++ b/pkg/internal/api/models.go
@@ -76,7 +76,7 @@ func (s *Service) FixReplicas() {
 
 	if s.MinTotalMemoryGb == nil && s.MinReplicaMemoryGb != nil {
 		// Due to a bug on the API, we always assumed the MinTotalMemoryGb value was always related to 3 replicas.
-		// Now we use a per-replica API to set the min total memory so we need to divide by 3 to get the same
+		// Now we use a per-replica API to set the min total memory so we need to multiply by 3 to get the same
 		// behaviour as before.
 		minTotalMemory := *s.MinReplicaMemoryGb * 3
 		s.MinTotalMemoryGb = &minTotalMemory
@@ -84,7 +84,7 @@ func (s *Service) FixReplicas() {
 
 	if s.MaxTotalMemoryGb == nil && s.MaxReplicaMemoryGb != nil {
 		// Due to a bug on the API, we always assumed the MaxTotalMemoryGb value was always related to 3 replicas.
-		// Now we use a per-replica API to set the min total memory so we need to divide by 3 to get the same
+		// Now we use a per-replica API to set the min total memory so we need to multiply by 3 to get the same
 		// behaviour as before.
 		maxTotalMemory := *s.MaxReplicaMemoryGb * 3
 		s.MaxTotalMemoryGb = &maxTotalMemory

--- a/pkg/resource/models/service_resource.go
+++ b/pkg/resource/models/service_resource.go
@@ -86,6 +86,8 @@ type ServiceResourceModel struct {
 	IpAccessList                    types.List   `tfsdk:"ip_access"`
 	MinTotalMemoryGb                types.Int64  `tfsdk:"min_total_memory_gb"`
 	MaxTotalMemoryGb                types.Int64  `tfsdk:"max_total_memory_gb"`
+	MinReplicaMemoryGb              types.Int64  `tfsdk:"min_replica_memory_gb"`
+	MaxReplicaMemoryGb              types.Int64  `tfsdk:"max_replica_memory_gb"`
 	NumReplicas                     types.Int64  `tfsdk:"num_replicas"`
 	IdleTimeoutMinutes              types.Int64  `tfsdk:"idle_timeout_minutes"`
 	IAMRole                         types.String `tfsdk:"iam_role"`

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -468,7 +468,7 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 300)
+	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 20*60)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error retrieving service state",

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -142,11 +142,11 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				DeprecationMessage: "Please use max_replica_memory_gb instead",
 			},
 			"min_replica_memory_gb": schema.Int64Attribute{
-				Description: "Minimum memory of a singe replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. min_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.",
+				Description: "Minimum memory of a singe replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. `min_replica_memory_gb` x `num_replicas` (default 3) must be lower than 360 for non paid services or 720 for paid services.",
 				Optional:    true,
 			},
 			"max_replica_memory_gb": schema.Int64Attribute{
-				Description: "Maximum memory of a single replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. max_replica_memory_gb x num_replicas (default 3) must be lower than 360 for non paid services or 720 for paid services.",
+				Description: "Maximum memory of a single replica during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 8. `max_replica_memory_gb` x `num_replicas` (default 3) must be lower than 360 for non paid services or 720 for paid services.",
 				Optional:    true,
 			},
 			"num_replicas": schema.Int64Attribute{

--- a/pkg/resource/service_test.go
+++ b/pkg/resource/service_test.go
@@ -149,17 +149,17 @@ func TestServiceResource_syncServiceState(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name:  "Updates MinTotalMemoryGb field when in production tier",
+			name:  "Updates MinReplicaMemoryGb field when in production tier",
 			state: state,
 			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
 				src.Tier = api.TierProduction
-				minTotalMemory := 10
-				src.MinTotalMemoryGb = &minTotalMemory
+				minReplicaMemory := 10
+				src.MinReplicaMemoryGb = &minReplicaMemory
 			}).GetPtr(),
 			responseErr: nil,
 			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
 				src.Tier = types.StringValue(api.TierProduction)
-				src.MinTotalMemoryGb = types.Int64Value(10)
+				src.MinReplicaMemoryGb = types.Int64Value(10)
 			}).Get(),
 			updateTimestamp: false,
 			wantErr:         false,
@@ -169,40 +169,40 @@ func TestServiceResource_syncServiceState(t *testing.T) {
 			state: state,
 			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
 				src.Tier = api.TierDevelopment
-				minTotalMemory := 10
-				src.MinTotalMemoryGb = &minTotalMemory
+				minReplicaMemory := 10
+				src.MinReplicaMemoryGb = &minReplicaMemory
 			}).GetPtr(),
 			responseErr: nil,
 			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
 				src.Tier = types.StringValue(api.TierDevelopment)
-				src.MinTotalMemoryGb = types.Int64{}
+				src.MinReplicaMemoryGb = types.Int64{}
 			}).Get(),
 			updateTimestamp: false,
 			wantErr:         false,
 		},
 		{
-			name:  "Updates MaxTotalMemoryGb field when in production tier",
+			name:  "Updates MaxReplicaMemoryGb field when in production tier",
 			state: state,
 			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
 				src.Tier = api.TierProduction
-				maxTotalMemory := 10
-				src.MaxTotalMemoryGb = &maxTotalMemory
+				maxReplicaMemory := 10
+				src.MaxReplicaMemoryGb = &maxReplicaMemory
 			}).GetPtr(),
 			responseErr: nil,
 			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
 				src.Tier = types.StringValue(api.TierProduction)
-				src.MaxTotalMemoryGb = types.Int64Value(10)
+				src.MaxReplicaMemoryGb = types.Int64Value(10)
 			}).Get(),
 			updateTimestamp: false,
 			wantErr:         false,
 		},
 		{
-			name:  "Does not update MaxTotalMemoryGb field when in development tier",
+			name:  "Does not update MaxReplicaMemoryGb field when in development tier",
 			state: state,
 			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
 				src.Tier = api.TierDevelopment
-				maxTotalMemory := 10
-				src.MaxTotalMemoryGb = &maxTotalMemory
+				maxReplicaMemory := 10
+				src.MaxReplicaMemoryGb = &maxReplicaMemory
 			}).GetPtr(),
 			responseErr: nil,
 			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/sre/issues/89 and https://github.com/ClickHouse/support-escalation/issues/2656

Add 2 new fields `max_replica_memory_gb` and `min_replica_memory_gb` to allow specifying replica size and avoid confusion when the number of replicas is not 3.

The old fields (`max_total_memory_gb` and `min_total_memory_gb`) are kept as deprecated for now and will be remove in a future release.
The buggy behaviour will be kept by always dividing the deprecated fields' value by 3, regardless of the acutal number of replicas in the service.