### PR TITLE
Fix import of private_endpoint_registration resource

### DIFF
--- a/pkg/resource/private_endpoint_registration.go
+++ b/pkg/resource/private_endpoint_registration.go
@@ -224,7 +224,7 @@ func (r *PrivateEndpointRegistrationResource) Delete(ctx context.Context, req re
 }
 
 func (r *PrivateEndpointRegistrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("private_endpoint_id"), req, resp)
 }
 
 func (r *PrivateEndpointRegistrationResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/166

this is a bug from a previous PR when we renamed one attribute from "id" to "private_endpoint_id".

Unfortunately, I forgot to rename one occourence of the attribute.