### PR TITLE
Make idle_scaling field computed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -233,6 +233,9 @@ jobs:
 
             sed -i '1s/^/# This file is generated automatically please do not edit\n/' $dst
           done
+          
+          # Refresh docs because they are generated starting based on files in `examples` folder.
+          make docs
       - name: Commit
         run: |
           git config --global user.name "Release Github Action"

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,15 @@ then a manual process is required after the upgrade. Please visit [https://githu
 ## Example Usage
 
 ```terraform
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "1.2.2"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
 # Configuration-based authentication
 # these keys are for example only and won't work when pointed to a deployed ClickHouse OpenAPI server
 provider "clickhouse" {

--- a/examples/provider/provider.tf.template
+++ b/examples/provider/provider.tf.template
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.2.2"
+      version = "${CLICKHOUSE_TERRAFORM_PROVIDER_VERSION}"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -123,6 +123,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"idle_scaling": schema.BoolAttribute{
 				Description: "When set to true the service is allowed to scale down to zero when idle.",
 				Optional:    true,
+				Computed:    true,
 			},
 			"ip_access": schema.ListNestedAttribute{
 				Description: "List of IP addresses allowed to access the service.",
@@ -456,7 +457,7 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	if plan.IdleTimeoutMinutes.IsNull() && plan.IdleScaling.ValueBool() {
 		resp.Diagnostics.AddError(
 			"Invalid Configuration",
-			"idle_timeout_minutes should be defined if idle_scaling is enabled",
+			"idle_timeout_minutes must be defined if idle_scaling is enabled",
 		)
 	}
 


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/173

The `idle_scaling` field was marked as optional, but it's defaulted on the server side and it was not marked as computed, making `terraform apply` to fail.