### PR TITLE
Improve retriability of e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -125,6 +125,7 @@ jobs:
           echo "Lucky winner region is: $random"
           echo "region=$random" >> $GITHUB_OUTPUT
       - name: e2e
+        id: e2e
         uses: ./.github/actions/e2e
         with:
           organization_id: ${{ secrets.TF_VAR_ORGANIZATION_ID }}
@@ -147,9 +148,15 @@ jobs:
           aws_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
       - name: Mark error
         id: status
-        if: failure()
+        if: always()
         run: |
-          echo "status=failure" >> $GITHUB_OUTPUT
+          if [ "${{ steps.e2e.outcome }}" == "success" ]
+          then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,11 +164,18 @@ jobs:
           upgrade_test: ${{ matrix.upgrade_test }}
           region: ${{steps.region.outputs.region}}
           aws_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+
       - name: Mark error
         id: status
-        if: failure()
+        if: always()
         run: |
-          echo "status=failure" >> $GITHUB_OUTPUT
+          if [ "${{ steps.e2e.outcome }}" == "success" ]
+          then
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+            exit 1
+          fi
 
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently if a test run fails, the whole pipeline is correctly marked as failed as well.
Problem: if we try to "rerun failed jobs" only, even if they pass, the pipeline still is marked as failed.
This PR is an attempt to make the pipleine marked as successful after a successful "rerun failed jobs"