### PR TITLE
Automatically label issue with 'terraform-provider'

### DIFF
--- a/.github/workflows/autolabel.yaml
+++ b/.github/workflows/autolabel.yaml
@@ -1,0 +1,18 @@
+name: Automatically label issues with 'terraform-provider'
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: terraform-provider


### PR DESCRIPTION
We need this to distribute the issues in the team board