### PR TITLE
Fix attachment of multiple private endpoints to the same service

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ description: |-
   Breaking changes
   Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
   If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the clickhouse_private_endpoint_registration resource or the private_endpoint_ids attribute of the clickhouse_service resource,
-  then a manual process is required after the upgrade. Please visit https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes for more details.
+  then a manual process is required after the upgrade. Please visit https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations for more details.
 ---
 
 # clickhouse Provider
@@ -31,7 +31,7 @@ Visit [https://clickhouse.com/docs/en/cloud-quick-start](https://clickhouse.com/
 ### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
 
 If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the `clickhouse_private_endpoint_registration` resource or the `private_endpoint_ids` attribute of the `clickhouse_service` resource,
-then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes) for more details.
+then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations) for more details.
 
 ## Example Usage
 

--- a/docs/resources/service_private_endpoints_attachment.md
+++ b/docs/resources/service_private_endpoints_attachment.md
@@ -4,6 +4,8 @@ page_title: "clickhouse_service_private_endpoints_attachment Resource - clickhou
 subcategory: ""
 description: |-
   Use the clickhouse_service_private_endpoints_attachment resource to attach a ClickHouse service to a Private Endpoint.
+  Important: Please note that if you want to attach the same ClickHouse service to multiple Private Endpoints you have to specify all the Private Endpoint IDs in a single clickhouse_service_private_endpoints_attachment resource.
+  Having multiple clickhouse_service_private_endpoints_attachment resources for the same service is unsupported and the outcome is unpredictable.
   See private_endpoint_registration https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/private_endpoint_registration for how to create a private endpoint.
   See full example https://github.com/ClickHouse/terraform-provider-clickhouse/tree/main/examples/full/private_endpoint on GitHub.
 ---
@@ -11,6 +13,8 @@ description: |-
 # clickhouse_service_private_endpoints_attachment (Resource)
 
 Use the *clickhouse_service_private_endpoints_attachment* resource to attach a ClickHouse *service* to a *Private Endpoint*.
+Important: Please note that if you want to attach the same ClickHouse *service* to multiple *Private Endpoints* you have to specify all the *Private Endpoint IDs* in a single *clickhouse_service_private_endpoints_attachment* resource.
+Having multiple *clickhouse_service_private_endpoints_attachment* resources for the same service is unsupported and the outcome is unpredictable.
 
 See [private_endpoint_registration](https://registry.terraform.io/providers/ClickHouse/clickhouse/latest/docs/resources/private_endpoint_registration) for how to create a *private endpoint*.
 

--- a/examples/full/private_endpoint/aws/README.md
+++ b/examples/full/private_endpoint/aws/README.md
@@ -48,7 +48,8 @@ To run this example, the AWS user you provide credentials for needs the followin
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:DeleteSubnet",
                 "ec2:DeleteVpc",
-                "ec2:DeleteSecurityGroup"
+                "ec2:DeleteSecurityGroup",
+                "ec2:DescribeAvailabilityZones"
             ],
             "Resource": "*"
         }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
@@ -12,7 +13,12 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name clickhouse
 
 func main() {
-	providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{ // nolint:errcheck
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+	providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
 		Address: "clickhouse.cloud/terraform/clickhouse",
+		Debug:   debug,
 	})
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
-	providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
+	providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{ //nolint:errcheck
 		Address: "clickhouse.cloud/terraform/clickhouse",
 		Debug:   debug,
 	})

--- a/pkg/provider/README.md
+++ b/pkg/provider/README.md
@@ -13,4 +13,4 @@ Visit [https://clickhouse.com/docs/en/cloud-quick-start](https://clickhouse.com/
 ### Upgrading to version >= 1.0.0 of the Clickhouse Terraform Provider
 
 If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the `clickhouse_private_endpoint_registration` resource or the `private_endpoint_ids` attribute of the `clickhouse_service` resource,
-then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes) for more details.
+then a manual process is required after the upgrade. Please visit [https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations](https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations) for more details.


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/190

fix a bug that prevented multiple private endpoints to be attached to the same service