### PR TITLE
Fast fail in case of 500

### DIFF
--- a/pkg/internal/api/errors.go
+++ b/pkg/internal/api/errors.go
@@ -11,3 +11,11 @@ func IsNotFound(err error) bool {
 
 	return strings.HasPrefix(err.Error(), "status: 404")
 }
+
+func is5xx(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), "status: 5")
+}

--- a/pkg/internal/api/service.go
+++ b/pkg/internal/api/service.go
@@ -91,7 +91,11 @@ func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, 
 	// Wait until service is in desired state
 	checkState := func() error {
 		service, err := c.GetService(ctx, serviceId)
-		if err != nil {
+		if is5xx(err) {
+			// 500s are automatically retried in `GetService`.
+			// If we get it here, we consider it an unrecoverable error.
+			return backoff.Permanent(err)
+		} else if err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In case of a 500 (server side error) we don't want to keep retrying too long as there is not much we can do to solve it on the client side.

before this PR there were 2 nested retry loops in case of server side 500 that kept the user waiting uselessly for several minutes.

with this change, in the "external" retry loop we check and return early in case of 500