### PR TITLE
Revert "Bump provider version in examples to 1.5.0-alpha1"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ then a manual process is required after the upgrade. Please visit [https://githu
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_azure_eventhub/provider.tf
+++ b/examples/clickpipe/kafka_azure_eventhub/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_confluent/provider.tf
+++ b/examples/clickpipe/kafka_confluent/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_msk_iam_user/provider.tf
+++ b/examples/clickpipe/kafka_msk_iam_user/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_offset_strategy/provider.tf
+++ b/examples/clickpipe/kafka_offset_strategy/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_redpanda_scram/provider.tf
+++ b/examples/clickpipe/kafka_redpanda_scram/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_schema_registry/provider.tf
+++ b/examples/clickpipe/kafka_schema_registry/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/object_storage_iam_role/provider.tf
+++ b/examples/clickpipe/object_storage_iam_role/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/object_storage_iam_user/provider.tf
+++ b/examples/clickpipe/object_storage_iam_user/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/clickpipe/service_and_clickpipe/provider.tf
+++ b/examples/clickpipe/service_and_clickpipe/provider.tf
@@ -1,15 +1,23 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.3.1"
       source  = "ClickHouse/clickhouse"
     }
   }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
 }
 
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  
+  api_url = var.api_url
 }

--- a/examples/full/development/aws/provider.tf
+++ b/examples/full/development/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/development/gcp/provider.tf
+++ b/examples/full/development/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/private_endpoint/aws/provider.tf
+++ b/examples/full/private_endpoint/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/production/aws/provider.tf
+++ b/examples/full/production/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/production/azure/provider.tf
+++ b/examples/full/production/azure/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/production/gcp/provider.tf
+++ b/examples/full/production/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/tests/import/service/provider.tf
+++ b/tests/import/service/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "1.5.0-alpha1"
+      version = "1.4.0"
       source  = "ClickHouse/clickhouse"
     }
   }


### PR DESCRIPTION
This reverts commit d5c16273e4f414e25aae12ec29147105ee9ffa56.
