### PR TITLE
Experimental ClickPipe resource fixes

### DIFF
--- a/examples/clickpipe/kafka_azure_eventhub/provider.tf
+++ b/examples/clickpipe/kafka_azure_eventhub/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_confluent/provider.tf
+++ b/examples/clickpipe/kafka_confluent/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_msk_iam_user/provider.tf
+++ b/examples/clickpipe/kafka_msk_iam_user/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_offset_strategy/provider.tf
+++ b/examples/clickpipe/kafka_offset_strategy/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_redpanda_scram/provider.tf
+++ b/examples/clickpipe/kafka_redpanda_scram/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/kafka_schema_registry/provider.tf
+++ b/examples/clickpipe/kafka_schema_registry/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/multiple_pipes_example/README.md
+++ b/examples/clickpipe/multiple_pipes_example/README.md
@@ -1,0 +1,9 @@
+## Multiple ClickPipe Kafka example
+
+This example demonstrates how to deploy multiple Kafka pipes in a single Terraform.
+
+## How to run
+
+- Rename `variables.tfvars.sample` to `variables.tfvars` and fill in all needed data.
+- Run `terraform init`
+- Run `terraform <plan|apply> -var-file=variables.tfvars`

--- a/examples/clickpipe/multiple_pipes_example/main.tf
+++ b/examples/clickpipe/multiple_pipes_example/main.tf
@@ -1,0 +1,185 @@
+variable "service_id" {
+  description = "ClickHouse service ID"
+}
+
+variable "kafka_brokers" {
+  description = "Kafka brokers"
+}
+
+variable "kafka_topics" {
+  description = "Kafka topics"
+}
+
+variable "kafka_username" {
+  description = "Username"
+  sensitive   = true
+}
+
+variable "kafka_password" {
+  description = "Password"
+  sensitive   = true
+}
+
+variable "number_of_pipes" {
+  description = "Number of pipes to create"
+  default     = 5
+}
+
+resource "clickhouse_clickpipe" "multiple" {
+  for_each = toset([for i in range(1, var.number_of_pipes + 1) : tostring(i)])
+
+  name        = "📈 multiple pipe ${each.key}"
+
+  service_id = var.service_id
+
+  scaling = {
+    replicas = tonumber(each.key)
+  }
+
+  state = "Running"
+
+  source = {
+    kafka = {
+      type    = "confluent"
+      format  = "JSONEachRow"
+      brokers = var.kafka_brokers
+      topics  = var.kafka_topics
+
+      credentials = {
+        username = var.kafka_username
+        password = var.kafka_password
+      }
+    }
+  }
+
+  destination = {
+    table    = "multiple_pipes_example_${each.key}"
+    managed_table = true
+
+    table_definition = {
+      engine = {
+        type = "MergeTree"
+      }
+    }
+
+    columns = [
+      {
+        name: "area",
+        type: "Int64"
+      },
+      {
+        name: "averageSignal",
+        type: "Int64"
+      },
+      {
+        name: "cell",
+        type: "Int64"
+      },
+      {
+        name: "changeable",
+        type: "Int64"
+      },
+      {
+        name: "created",
+        type: "DateTime64(9)"
+      },
+      {
+        name: "lat",
+        type: "Float64"
+      },
+      {
+        name: "lon",
+        type: "Float64"
+      },
+      {
+        name: "mcc",
+        type: "Int64"
+      },
+      {
+        name: "net",
+        type: "Int64"
+      },
+      {
+        name: "radio",
+        type: "String"
+      },
+      {
+        name: "range",
+        type: "Int64"
+      },
+      {
+        name: "samples-renamed",
+        type: "Int64"
+      },
+      {
+        name: "unit",
+        type: "Int64"
+      },
+      {
+        name: "updated",
+        type: "DateTime64(9)"
+      }
+    ]
+  }
+
+  field_mappings = [
+    {
+      source_field: "averageSignal",
+      destination_field: "averageSignal"
+    },
+    {
+      source_field: "cell",
+      destination_field: "cell"
+    },
+    {
+      source_field: "changeable",
+      destination_field: "changeable"
+    },
+    {
+      source_field: "created",
+      destination_field: "created"
+    },
+    {
+      source_field: "lat",
+      destination_field: "lat"
+    },
+    {
+      source_field: "lon",
+      destination_field: "lon"
+    },
+    {
+      source_field: "mcc",
+      destination_field: "mcc"
+    },
+    {
+      source_field: "net",
+      destination_field: "net"
+    },
+    {
+      source_field: "radio",
+      destination_field: "radio"
+    },
+    {
+      source_field: "range",
+      destination_field: "range"
+    },
+    {
+      source_field: "samples",
+      destination_field: "samples-renamed"
+    },
+    {
+      source_field: "unit",
+      destination_field: "unit"
+    },
+    {
+      source_field: "updated",
+      destination_field: "updated"
+    }
+  ]
+}
+
+output "clickpipe_ids" {
+  value = {
+    for k, v in clickhouse_clickpipe.multiple : k => v.id
+  }
+}

--- a/examples/clickpipe/multiple_pipes_example/provider.tf
+++ b/examples/clickpipe/multiple_pipes_example/provider.tf
@@ -1,0 +1,23 @@
+# This file is generated automatically please do not edit
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "1.5.0-alpha1"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+  api_url = var.api_url
+}

--- a/examples/clickpipe/multiple_pipes_example/variables.sample.tfvars
+++ b/examples/clickpipe/multiple_pipes_example/variables.sample.tfvars
@@ -1,0 +1,11 @@
+# these keys are for example only and won't work when pointed to a deployed ClickHouse OpenAPI server
+organization_id = "aee076c1-3f83-4637-95b1-ad5a0a825b71"
+token_key       = "avhj1U5QCdWAE9CA9"
+token_secret    = "4b1dROiHQEuSXJHlV8zHFd0S7WQj7CGxz5kGJeJnca"
+service_id      = "aee076c1-3f83-4637-95b1-ad5a0a825b71"
+
+kafka_brokers = "broker.us-east-2.aws.confluent.cloud:9092"
+kafka_topics = "cell_towers"
+
+kafka_username =  ""
+kafka_password = ""

--- a/examples/clickpipe/object_storage_iam_role/provider.tf
+++ b/examples/clickpipe/object_storage_iam_role/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/object_storage_iam_user/provider.tf
+++ b/examples/clickpipe/object_storage_iam_user/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/examples/clickpipe/service_and_clickpipe/provider.tf
+++ b/examples/clickpipe/service_and_clickpipe/provider.tf
@@ -8,8 +8,16 @@ terraform {
   }
 }
 
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+variable "api_url" {
+  default = "https://api.clickhouse.cloud/v1"
+}
+
 provider "clickhouse" {
   organization_id = var.organization_id
   token_key       = var.token_key
   token_secret    = var.token_secret
+  api_url = var.api_url
 }

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	ClickPipeRunningState = "Running"
-	ClickPipeStoppedState = "Stopped"
+	ClickPipeRunningState       = "Running"
+	ClickPipeStoppedState       = "Stopped"
+	ClickPipeFailedState        = "Failed"
+	ClickPipeInternalErrorState = "InternalError"
 )
 
 const (

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -25,7 +25,7 @@ type ClickPipeKafkaSourceCredentials struct {
 
 type ClickPipeKafkaOffset struct {
 	Strategy  string  `json:"strategy"`
-	Timestamp *string `json:"timestamp"`
+	Timestamp *string `json:"timestamp,omitempty"`
 }
 
 type ClickPipeKafkaSchemaRegistry struct {

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -106,7 +106,7 @@ type ClickPipeFieldMapping struct {
 type ClickPipe struct {
 	ID            string                  `json:"id,omitempty"`
 	Name          string                  `json:"name"`
-	Description   string                  `json:"description"`
+	Description   *string                 `json:"description,omitempty"`
 	Scaling       *ClickPipeScaling       `json:"scaling,omitempty"`
 	State         string                  `json:"state,omitempty"`
 	Source        ClickPipeSource         `json:"source"`

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -45,9 +45,6 @@ Known limitations:
 - ClickPipe is immutable. It means, any change to the ClickPipe will require a new resource to be created in-place. This does not apply to scaling and state changes.
 - ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.
 - Provider lacks validation logic. It means, the provider will not validate the ClickPipe configuration against the ClickHouse Cloud API. Any invalid configuration will be rejected by the API.
-
-Known bugs:
-- Kafka pipe without a consumer group provided explicitly can be created, however, in case of any plan changes, provider will require force replace due to "unknown state" of the consumer group.
 `
 
 const (

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -536,7 +536,7 @@ func (c *ClickPipeResource) Create(ctx context.Context, request resource.CreateR
 
 	clickPipe := api.ClickPipe{
 		Name:        plan.Name.ValueString(),
-		Description: plan.Description.ValueString(),
+		Description: plan.Description.ValueStringPointer(),
 	}
 
 	sourceModel := models.ClickPipeSourceModel{}
@@ -790,7 +790,14 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 
 	state.ID = types.StringValue(clickPipe.ID)
 	state.Name = types.StringValue(clickPipe.Name)
-	state.Description = types.StringValue(clickPipe.Description)
+
+	// ideally, we shouldn't receive an empty description from the API, but we should handle it just in case
+	if clickPipe.Description != nil && *clickPipe.Description != "" {
+		state.Description = types.StringPointerValue(clickPipe.Description)
+	} else {
+		state.Description = types.StringNull()
+	}
+
 	state.State = types.StringValue(clickPipe.State)
 
 	if clickPipe.Scaling != nil && clickPipe.Scaling.Replicas != nil {

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -179,6 +179,9 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								MarkdownDescription: "Consumer group of the Kafka source. If not provided `clickpipes-<ID>` will be used.",
 								Computed:            true,
 								Optional:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"offset": schema.SingleNestedAttribute{
 								MarkdownDescription: "The Kafka offset.",

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -29,10 +29,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &ClickPipeResource{}
-	_ resource.ResourceWithModifyPlan  = &ClickPipeResource{}
-	_ resource.ResourceWithConfigure   = &ClickPipeResource{}
-	_ resource.ResourceWithImportState = &ClickPipeResource{}
+	_ resource.Resource               = &ClickPipeResource{}
+	_ resource.ResourceWithModifyPlan = &ClickPipeResource{}
+	_ resource.ResourceWithConfigure  = &ClickPipeResource{}
 )
 
 const clickPipeResourceDescription = `
@@ -49,7 +48,6 @@ Known limitations:
 
 Known bugs:
 - Kafka pipe without a consumer group provided explicitly can be created, however, in case of any plan changes, provider will require force replace due to "unknown state" of the consumer group.
-- Resource import is not functional. It will be implemented in future releases.
 `
 
 const (
@@ -1084,11 +1082,4 @@ func (c *ClickPipeResource) Delete(ctx context.Context, request resource.DeleteR
 			"Could not delete ClickPipe, unexpected error: "+err.Error(),
 		)
 	}
-}
-
-func (c *ClickPipeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to id attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
-
-	// Import seems broken now. Requires further investigation.
 }


### PR DESCRIPTION
- remove import implementation as it's broken now
- Omit empty timestamp in Kafka offset strategy
- Wait desired plan state is reached after scaling ClickPipe
- Restore variables in ClickPipes provider examples
- Add a UseStateForUnknown modifier for Kafka consumer group attribute
- Allow empty description
- Handle ClickPipe state changes more gracefully
- multiple_pipes_example
