### PR TITLE
Avoid marking alpha releases as "pre releases"

### DIFF
--- a/.goreleaser-alpha.yml
+++ b/.goreleaser-alpha.yml
@@ -57,7 +57,7 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  prerelease: true
+  prerelease: false
   make_latest: false
 changelog:
 # skip: true


### PR DESCRIPTION
Marking alpha releases as "pre release" prevent them from being picked up by hashicorp in the public terraform provider page.
We still don't mark the alpha releases as "latest" so it shouldn't change much on github side.