### PR TITLE
allow lowercase letters in grant_privilege

### DIFF
--- a/examples/rbac/main.tf
+++ b/examples/rbac/main.tf
@@ -114,6 +114,15 @@ resource "clickhouse_grant_privilege" "grant_show_to_role" {
 }
 
 # Requires 'query_api_endpoints' to be enabled in the service.
+resource "clickhouse_grant_privilege" "grant_dictget_to_role" {
+  service_id        = clickhouse_service.service.id
+  privilege_name    = "dictGet"
+  database_name     = "default"
+  grantee_role_name = clickhouse_role.writer.name
+  grant_option      = false
+}
+
+# Requires 'query_api_endpoints' to be enabled in the service.
 resource "clickhouse_grant_privilege" "grant_insert_on_table_to_user" {
   service_id        = clickhouse_service.service.id
   privilege_name    = "INSERT"

--- a/pkg/resource/grant_privilege.go
+++ b/pkg/resource/grant_privilege.go
@@ -59,7 +59,7 @@ func (r *GrantPrivilegeResource) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z0-9 ]+$`), "Invalid privilege name"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9 ]+$`), "Invalid privilege name"),
 					stringvalidator.NoneOfCaseInsensitive("ALL"),
 				},
 			},


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/250

Allow lowercase privileges in `clickhouse_grant_privilege`.

This makes UX slightly worse, because a client will be allowed to set "select" as a privilege, but it will be rejected by the server with an error like this:

```
│ Could not create privilege grant, unexpected error: status: 400, body: {"error":{"code":"691","details":"Unknown element 'select' for enum, maybe you meant: ['SELECT']: while converting 'select' to Enum16('SHOW DATABASES' = 0, 'SHOW TABLES' = 1, 'SHOW COLUMNS' = 2, 'SHOW DICTIONARIES' = 3, 'SHOW' =
│ 4, 'SHOW FILESYSTEM CACHES' = 5, 'SELECT' = 6, 'INSERT' = 7, 'ALTER UPDATE' = 8, 'ALTER DELETE' = 9, 'ALTER ADD COLUMN' = 10, 'ALTER MODIFY COLUMN' = 11, 'ALTER DROP COLUMN' = 12, 'ALTER COMMENT COLUMN' = 13, 'ALTER CLEAR COLUMN' = 14, 'ALTER RENAME COLUMN' = 15, 'ALTER MATERIALIZE COLUMN' = 16,
│ 'ALTER COLUMN' = 17, 'ALTER MODIFY COMMENT' = 18, 'ALTER ORDER BY' = 19, 'ALTER SAMPLE BY' = 20, 'ALTER ADD INDEX' = 21, 'ALTER DROP INDEX' = 22, 'ALTER MATERIALIZE INDEX' = 23, 'ALTER CLEAR INDEX' = 24, 'ALTER INDEX' = 25, 'ALTER ADD STATISTICS' = 26, 'ALTER DROP STATISTICS' = 27, 'ALTER MODIFY
│ STATISTICS' = 28, 'ALTER MATERIALIZE STATISTICS' = 29, 'ALTER STATISTICS' = 30, 'ALTER ADD PROJECTION' = 31, 'ALTER DROP PROJECTION' = 32, 'ALTER MATERIALIZE PROJECTION' = 33, 'ALTER CLEAR PROJECTION' = 34, 'ALTER PROJECTION' = 35, 'ALTER ADD CONSTRAINT' = 36, 'ALTER DROP CONSTRAINT' = 37, 'ALTER
│ CONSTRAINT' = 38, 'ALTER TTL' = 39, 'ALTER MATERIALIZE TTL' = 40, 'ALTER SETTINGS' = 41, 'ALTER MOVE PARTITION' = 42, 'ALTER FETCH PARTITION' = 43, 'ALTER FREEZE PARTITION' = 44, 'ALTER DATABASE SETTINGS' = 45, 'ALTER NAMED COLLECTION' = 46, 'ALTER TABLE' = 47, 'ALTER DATABASE' = 48, 'ALTER VIEW
│ MODIFY QUERY' = 49, 'ALTER VIEW MODIFY REFRESH' = 50, 'ALTER VIEW MODIFY SQL SECURITY' = 51, 'ALTER VIEW' = 52, 'ALTER' = 53, 'CREATE DATABASE' = 54, 'CREATE TABLE' = 55, 'CREATE VIEW' = 56, 'CREATE DICTIONARY' = 57, 'CREATE TEMPORARY TABLE' = 58, 'CREATE ARBITRARY TEMPORARY TABLE' = 59, 'CREATE
│ FUNCTION' = 60, 'CREATE NAMED COLLECTION' = 61, 'CREATE' = 62, 'DROP DATABASE' = 63, 'DROP TABLE' = 64, 'DROP VIEW' = 65, 'DROP DICTIONARY' = 66, 'DROP FUNCTION' = 67, 'DROP NAMED COLLECTION' = 68, 'DROP' = 69, 'UNDROP TABLE' = 70, 'TRUNCATE' = 71, 'OPTIMIZE' = 72, 'BACKUP' = 73, 'KILL QUERY' = 74,
│ 'KILL TRANSACTION' = 75, 'MOVE PARTITION BETWEEN SHARDS' = 76, 'CREATE USER' = 77, 'ALTER USER' = 78, 'DROP USER' = 79, 'CREATE ROLE' = 80, 'ALTER ROLE' = 81, 'DROP ROLE' = 82, 'ROLE ADMIN' = 83, 'CREATE ROW POLICY' = 84, 'ALTER ROW POLICY' = 85, 'DROP ROW POLICY' = 86, 'CREATE QUOTA' = 87, 'ALTER
│ QUOTA' = 88, 'DROP QUOTA' = 89, 'CREATE SETTINGS PROFILE' = 90, 'ALTER SETTINGS PROFILE' = 91, 'DROP SETTINGS PROFILE' = 92, 'ALLOW SQL SECURITY NONE' = 93, 'SHOW USERS' = 94, 'SHOW ROLES' = 95, 'SHOW ROW POLICIES' = 96, 'SHOW QUOTAS' = 97, 'SHOW SETTINGS PROFILES' = 98, 'SHOW ACCESS' = 99, 'ACCESS
│ MANAGEMENT' = 100, 'SHOW NAMED COLLECTIONS' = 101, 'SHOW NAMED COLLECTIONS SECRETS' = 102, 'NAMED COLLECTION' = 103, 'NAMED COLLECTION ADMIN' = 104, 'SET DEFINER' = 105, 'TABLE ENGINE' = 106, 'SYSTEM SHUTDOWN' = 107, 'SYSTEM DROP DNS CACHE' = 108, 'SYSTEM DROP CONNECTIONS CACHE' = 109, 'SYSTEM
│ PREWARM MARK CACHE' = 110, 'SYSTEM DROP MARK CACHE' = 111, 'SYSTEM PREWARM PRIMARY INDEX CACHE' = 112, 'SYSTEM DROP PRIMARY INDEX CACHE' = 113, 'SYSTEM DROP UNCOMPRESSED CACHE' = 114, 'SYSTEM DROP MMAP CACHE' = 115, 'SYSTEM DROP QUERY CACHE' = 116, 'SYSTEM DROP COMPILED EXPRESSION CACHE' = 117,
│ 'SYSTEM DROP FILESYSTEM CACHE' = 118, 'SYSTEM DROP DISTRIBUTED CACHE' = 119, 'SYSTEM SYNC FILESYSTEM CACHE' = 120, 'SYSTEM DROP PAGE CACHE' = 121, 'SYSTEM DROP SCHEMA CACHE' = 122, 'SYSTEM DROP FORMAT SCHEMA CACHE' = 123, 'SYSTEM DROP S3 CLIENT CACHE' = 124, 'SYSTEM DROP CACHE' = 125, 'SYSTEM RELOAD
│ CONFIG' = 126, 'SYSTEM RELOAD USERS' = 127, 'SYSTEM RELOAD DICTIONARY' = 128, 'SYSTEM RELOAD MODEL' = 129, 'SYSTEM RELOAD FUNCTION' = 130, 'SYSTEM RELOAD EMBEDDED DICTIONARIES' = 131, 'SYSTEM RELOAD ASYNCHRONOUS METRICS' = 132, 'SYSTEM RELOAD' = 133, 'SYSTEM RESTART DISK' = 134, 'SYSTEM MERGES' =
│ 135, 'SYSTEM TTL MERGES' = 136, 'SYSTEM FETCHES' = 137, 'SYSTEM MOVES' = 138, 'SYSTEM PULLING REPLICATION LOG' = 139, 'SYSTEM CLEANUP' = 140, 'SYSTEM VIEWS' = 141, 'SYSTEM DISTRIBUTED SENDS' = 142, 'SYSTEM REPLICATED SENDS' = 143, 'SYSTEM SENDS' = 144, 'SYSTEM REPLICATION QUEUES' = 145, 'SYSTEM
│ VIRTUAL PARTS UPDATE' = 146, 'SYSTEM REDUCE BLOCKING PARTS' = 147, 'SYSTEM DROP REPLICA' = 148, 'SYSTEM SYNC REPLICA' = 149, 'SYSTEM REPLICA READINESS' = 150, 'SYSTEM RESTART REPLICA' = 151, 'SYSTEM RESTORE REPLICA' = 152, 'SYSTEM WAIT LOADING PARTS' = 153, 'SYSTEM SYNC DATABASE REPLICA' = 154,
│ 'SYSTEM SYNC TRANSACTION LOG' = 155, 'SYSTEM SYNC FILE CACHE' = 156, 'SYSTEM FLUSH DISTRIBUTED' = 157, 'SYSTEM FLUSH LOGS' = 158, 'SYSTEM FLUSH ASYNC INSERT QUEUE' = 159, 'SYSTEM FLUSH' = 160, 'SYSTEM THREAD FUZZER' = 161, 'SYSTEM UNFREEZE' = 162, 'SYSTEM FAILPOINT' = 163, 'SYSTEM LISTEN' = 164,
│ 'SYSTEM JEMALLOC' = 165, 'SYSTEM UNLOAD PRIMARY KEY' = 166, 'SYSTEM' = 167, 'dictGet' = 168, 'displaySecretsInShowAndSelect' = 169, 'addressToLine' = 170, 'addressToLineWithInlines' = 171, 'addressToSymbol' = 172, 'demangle' = 173, 'INTROSPECTION' = 174, 'FILE' = 175, 'URL' = 176, 'REMOTE' = 177,
│ 'MONGO' = 178, 'REDIS' = 179, 'MYSQL' = 180, 'POSTGRES' = 181, 'SQLITE' = 182, 'ODBC' = 183, 'JDBC' = 184, 'HDFS' = 185, 'S3' = 186, 'HIVE' = 187, 'AZURE' = 188, 'KAFKA' = 189, 'NATS' = 190, 'RABBITMQ' = 191, 'SOURCES' = 192, 'CLUSTER' = 193, 'ALL' = 194, 'NONE' = 195). "}}

```

Unfortunately there is no good way to solve this without hardcoding all possible privileges on the client side, which is something I'd like to avoid doing