### PR TITLE
Mark ip_access/description field as required

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -87,11 +87,8 @@ resource "clickhouse_service" "service" {
 
 Required:
 
-- `source` (String) IP address allowed to access the service. In case you want to set the ip_access to anywhere you should set source to 0.0.0.0/0
-
-Optional:
-
 - `description` (String) Description of the IP address.
+- `source` (String) IP address allowed to access the service. In case you want to set the ip_access to anywhere you should set source to 0.0.0.0/0
 
 
 <a id="nestedatt--backup_configuration"></a>

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -187,7 +187,7 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						},
 						"description": schema.StringAttribute{
 							Description: "Description of the IP address.",
-							Optional:    true,
+							Required:    true,
 						},
 					},
 				},


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/252

Mark `ip_access/description` field as required.

Given the bug, there can't be any customer who set it to null.
There might be some who set it to `""`, but that should work.
The description field obviously doesn't serve any practical purpose, so marking as required is both the easiest and the safest choice in this case.