### PR TITLE
Fix error when setting backup_configuration.backup_period_in_hours

### DIFF
--- a/examples/full/basic/azure/main.tf
+++ b/examples/full/basic/azure/main.tf
@@ -68,9 +68,9 @@ resource "clickhouse_service" "service" {
   max_replica_memory_gb = 120
 
   backup_configuration = {
-    backup_period_in_hours           = 24
+    backup_period_in_hours           = null
     backup_retention_period_in_hours = 24
-    backup_start_time                = null
+    backup_start_time                = "02:00"
   }
 }
 

--- a/examples/full/basic/gcp/main.tf
+++ b/examples/full/basic/gcp/main.tf
@@ -68,9 +68,7 @@ resource "clickhouse_service" "service" {
   max_replica_memory_gb = 120
 
   backup_configuration = {
-    backup_period_in_hours           = 24
-    backup_retention_period_in_hours = 24
-    backup_start_time                = null
+    backup_retention_period_in_hours = 48
   }
 }
 

--- a/pkg/internal/api/backup_configuration.go
+++ b/pkg/internal/api/backup_configuration.go
@@ -33,9 +33,9 @@ func (c *ClientImpl) GetBackupConfiguration(ctx context.Context, serviceId strin
 	// The API returns a default value of 24 for BackupPeriodInHours field even when BackupStartTime is set.
 	// This is logically wrong as both fields can't be set at the same time.
 	// We fix this by setting BackupPeriodInHours to nil in such case.
-	if backupConfigResponse.Result.BackupStartTime != nil && *backupConfigResponse.Result.BackupStartTime != "" {
-		backupConfigResponse.Result.BackupPeriodInHours = nil
-	}
+	//if backupConfigResponse.Result.BackupStartTime != nil && *backupConfigResponse.Result.BackupStartTime != "" {
+	//	backupConfigResponse.Result.BackupPeriodInHours = nil
+	//}
 
 	return &backupConfigResponse.Result, nil
 }

--- a/pkg/internal/api/backup_configuration.go
+++ b/pkg/internal/api/backup_configuration.go
@@ -30,13 +30,6 @@ func (c *ClientImpl) GetBackupConfiguration(ctx context.Context, serviceId strin
 		return nil, err
 	}
 
-	// The API returns a default value of 24 for BackupPeriodInHours field even when BackupStartTime is set.
-	// This is logically wrong as both fields can't be set at the same time.
-	// We fix this by setting BackupPeriodInHours to nil in such case.
-	//if backupConfigResponse.Result.BackupStartTime != nil && *backupConfigResponse.Result.BackupStartTime != "" {
-	//	backupConfigResponse.Result.BackupPeriodInHours = nil
-	//}
-
 	return &backupConfigResponse.Result, nil
 }
 


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/255

There was a quirk in the API client that made it impossible to set the backup_period_in_hours field