### PR TITLE
add  400 status code handling in retry logic

### DIFF
--- a/pkg/internal/api/common.go
+++ b/pkg/internal/api/common.go
@@ -138,6 +138,9 @@ func (c *ClientImpl) doRequest(ctx context.Context, req *http.Request) ([]byte, 
 				} else if res.StatusCode >= http.StatusInternalServerError { // 500
 					resetSeconds = currentExponentialBackoff
 					tflog.Warn(ctx, fmt.Sprintf("Server side error (5xx): waiting %f.1 seconds before retrying", resetSeconds))
+				} else if res.StatusCode >= http.StatusBadRequest {
+					resetSeconds = currentExponentialBackoff
+					tflog.Warn(ctx, fmt.Sprintf("Server side error (400): waiting %f.1 seconds before retrying", resetSeconds))
 				} else {
 					return nil, backoff.Permanent(fmt.Errorf("status: %d, body: %s", res.StatusCode, body))
 				}


### PR DESCRIPTION
To mitigate the 400 errors we occasionally get from the API, I would like to improve the retry mechanism on the client side.
Now we only retry calls if they end up in a 5xx status code, we should retry also for 400 (not 4xx) responses as well.

