### PR TITLE
Avoid change fields

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -157,7 +157,6 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"tier": schema.StringAttribute{
 				Description: "Tier of the service: 'development', 'production'. Required for organizations using the Legacy ClickHouse Cloud Tiers, must be omitted for organizations using the new ClickHouse Cloud Tiers.",
 				Optional:    true,
-				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(api.TierDevelopment, api.TierProduction),
 				},

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -71,7 +71,6 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"byoc_id": schema.StringAttribute{
 				Description: "BYOC ID related to the cloud provider account you want to create this service into.",
 				Optional:    true,
-				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},


### PR DESCRIPTION
"Optional, Computed" fields are confusing for customers, as they show up as being changed every time there is an unrelated change in the .tf file.
This PR removes the Computed flag from 2 attributes where it was not really needed