### PR TITLE
improve loggin in case of errors. make client timeout configurable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -238,7 +238,7 @@ jobs:
     if: ${{ needs.e2e.outputs.status == 'failure' }}
     steps:
       - name: Report Failure on slack
-        if: ${{ needs.e2e.outputs.status == 'failure' }}
+        if: ${{ github.ref_name == 'main' && needs.e2e.outputs.status == 'failure' }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,5 +85,6 @@ provider "clickhouse" {
 
 - `api_url` (String) API URL of the ClickHouse OpenAPI the provider will interact with. Alternatively, can be configured using the `CLICKHOUSE_API_URL` environment variable. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against.
 - `organization_id` (String) ID of the organization the provider will create services under. Alternatively, can be configured using the `CLICKHOUSE_ORG_ID` environment variable.
+- `timeout_seconds` (Number) Timeout in seconds for the HTTP client.
 - `token_key` (String) Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_KEY` environment variable.
 - `token_secret` (String, Sensitive) Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_SECRET` environment variable.

--- a/pkg/internal/api/client.go
+++ b/pkg/internal/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 )
@@ -13,15 +14,39 @@ type ClientImpl struct {
 	TokenSecret    string
 }
 
-func NewClient(apiUrl string, organizationId string, tokenKey string, tokenSecret string) (*ClientImpl, error) {
+type ClientConfig struct {
+	ApiURL         string
+	OrganizationID string
+	TokenKey       string
+	TokenSecret    string
+	Timeout        time.Duration
+}
+
+func NewClient(config ClientConfig) (*ClientImpl, error) {
+	if config.ApiURL == "" {
+		return nil, fmt.Errorf("ApiURL cannot be empty")
+	}
+	if config.OrganizationID == "" {
+		return nil, fmt.Errorf("OrganizationID cannot be empty")
+	}
+	if config.TokenKey == "" {
+		return nil, fmt.Errorf("TokenKey cannot be empty")
+	}
+	if config.TokenSecret == "" {
+		return nil, fmt.Errorf("TokenSecret cannot be empty")
+	}
+	if config.Timeout == 0 {
+		config.Timeout = time.Minute * 5
+	}
+
 	client := &ClientImpl{
-		BaseUrl: apiUrl,
+		BaseUrl: config.ApiURL,
 		HttpClient: &http.Client{
-			Timeout: time.Minute * 5,
+			Timeout: config.Timeout,
 		},
-		OrganizationId: organizationId,
-		TokenKey:       tokenKey,
-		TokenSecret:    tokenSecret,
+		OrganizationId: config.OrganizationID,
+		TokenKey:       config.TokenKey,
+		TokenSecret:    config.TokenSecret,
 	}
 
 	return client, nil

--- a/pkg/internal/api/client_test.go
+++ b/pkg/internal/api/client_test.go
@@ -12,14 +12,19 @@ func TestNewClient(t *testing.T) {
 	testClient := &ClientImpl{
 		BaseUrl: "https://api.clickhouse.cloud/v1",
 		HttpClient: &http.Client{
-			Timeout: time.Second * 30,
+			Timeout: time.Minute * 5,
 		},
 		OrganizationId: "10ead720-7ca1-48c9-aaf7-7230f42b56c0",
 		TokenKey:       "dE8jvpSRVurZCLcLZllb",
 		TokenSecret:    "4b1dZbh9bFV9uHQ7Aay4vHHbsTL1HkD2CyZyFBlOLc",
 	}
 
-	client, err := NewClient(testClient.BaseUrl, testClient.OrganizationId, testClient.TokenKey, testClient.TokenSecret)
+	client, err := NewClient(ClientConfig{
+		ApiURL:         testClient.BaseUrl,
+		OrganizationID: testClient.OrganizationId,
+		TokenKey:       testClient.TokenKey,
+		TokenSecret:    testClient.TokenSecret,
+	})
 	if err != nil {
 		t.Fatalf("new client err: %v", err)
 	}

--- a/pkg/internal/api/common.go
+++ b/pkg/internal/api/common.go
@@ -44,8 +44,8 @@ func (c *ClientImpl) getQueryAPIPath(queryAPIBaseUrl string, serviceID string, f
 }
 
 func (c *ClientImpl) doRequest(ctx context.Context, initialReq *http.Request) ([]byte, error) {
-	debugctx := tflog.SetField(ctx, "method", initialReq.Method)
-	debugctx = tflog.SetField(debugctx, "URL", initialReq.URL.String())
+	debugctx := tflog.SetField(ctx, "request", fmt.Sprintf("%s %s", initialReq.Method, initialReq.URL.String()))
+	debugctx = tflog.SetField(debugctx, "clientTimeout", c.HttpClient.Timeout.String())
 
 	initialReq.SetBasicAuth(c.TokenKey, c.TokenSecret)
 
@@ -96,6 +96,8 @@ func (c *ClientImpl) doRequest(ctx context.Context, initialReq *http.Request) ([
 
 		res, err := c.HttpClient.Do(req)
 		if err != nil {
+			debugctx = tflog.SetField(debugctx, "error", err.Error())
+			tflog.Debug(debugctx, "API request failed")
 			return nil, err
 		}
 		defer res.Body.Close()

--- a/pkg/internal/api/service.go
+++ b/pkg/internal/api/service.go
@@ -152,7 +152,10 @@ func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s Serv
 
 func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Service, error) {
 	service, err := c.GetService(ctx, serviceId)
-	if err != nil {
+	if IsNotFound(err) {
+		// That is what we want
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -166,13 +169,19 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 		}
 
 		_, err = c.doRequest(ctx, req)
-		if err != nil {
+		if IsNotFound(err) {
+			// That is what we want
+			return nil, nil
+		} else if err != nil {
 			return nil, err
 		}
 	}
 
 	err = c.WaitForServiceState(ctx, serviceId, func(state string) bool { return state == StateStopped }, 10*60)
-	if err != nil {
+	if IsNotFound(err) {
+		// That is what we want
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -182,7 +191,10 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 	}
 
 	body, err := c.doRequest(ctx, req)
-	if err != nil {
+	if IsNotFound(err) {
+		// That is what we want
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
In case of client timeout we didn't log the requests.
This PR fixes that and adds possibility to change the default HTTP timeout for the API client