### PR TITLE
add tde field when upgrading schema in clickhouse_service

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -1774,6 +1774,7 @@ func (r *ServiceResource) UpgradeState(ctx context.Context) map[int64]resource.S
 					EncryptionAssumedRoleIdentifier: priorStateData.EncryptionAssumedRoleIdentifier,
 					QueryAPIEndpoints:               priorStateData.QueryAPIEndpoints,
 					BackupConfiguration:             priorStateData.BackupConfiguration,
+					TransparentEncryptionData:       models.TransparentEncryptionData{}.ObjectValue(),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)


### PR DESCRIPTION
towards: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/295

in version 3.0.0 we introduced a schema change in clickhouse_service that required migration, and we did that automatically for our customers.
in 3.1.0 we added a new field to the same schema, but we didn't update the migration code to write the new field.

when customers upgrade a service from <3.0.0 to >= 3.1.0 (skipping 3.0.0) the new field is missing and terraform complains about that.

this PR fixed this mess