### PR TITLE
allow picking what version to test upgrade from

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -30,6 +30,10 @@ inputs:
     required: false
     default: "false"
     description: "If true it runs a provider upgrade test"
+  upgrade_from:
+    required: false
+    default: ""
+    description: "What version of the terraform provider to try upgrading from. Defaults to latest release."
   skip_build:
     required: false
     default: "false"
@@ -113,8 +117,14 @@ runs:
       if: ${{ inputs.upgrade_test == 'true' && steps.defined.outputs.defined == 'true' }}
       name: Upgrade test - Retrieve latest stable version
       run: |
-        LATEST="$(curl -s -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/ClickHouse/terraform-provider-clickhouse/releases/latest | jq -r '.name')"
-        echo "tag=$LATEST" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.upgrade_from }}" == "" ]
+        then
+          # Get latest stable release
+          LATEST="$(curl -s -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/ClickHouse/terraform-provider-clickhouse/releases/latest | jq -r '.name')"
+          echo "tag=$LATEST" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=${{ inputs.upgrade_from }}" >> "$GITHUB_OUTPUT"
+        fi
 
     - shell: bash
       if: ${{ inputs.upgrade_test == 'true' && steps.defined.outputs.defined == 'true' }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ on:
       upgrade_from:
         type: string
         default: ""
-        description: "What version to test upgrade from. Including leading 'v'. Example 'v.2.3.0'. Defaults to latest stable release."
+        description: "What version to test upgrade from. Including leading 'v'. Example 'v2.3.0'. Defaults to latest stable release."
   schedule:
     - cron: "0 7 * * *"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ on:
       upgrade_from:
         type: string
         default: ""
-        description: "What version to test upgrade from"
+        description: "What version to test upgrade from. Including leading 'v'. Example 'v.2.3.0'. Defaults to latest stable release."
   schedule:
     - cron: "0 7 * * *"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,6 +44,10 @@ on:
         type: boolean
         default: false
         description: "If checked, additionally create service using latest stable version, then upgrade to the current version"
+      upgrade_from:
+        type: string
+        default: ""
+        description: "What version to test upgrade from"
   schedule:
     - cron: "0 7 * * *"
 
@@ -215,6 +219,7 @@ jobs:
           tf_release: ${{ matrix.tf_release }}
           cloud_provider: ${{ matrix.test.cloud }}
           upgrade_test: "true"
+          upgrade_from: ${{ inputs.upgrade_from }}
           skip_build: "false"
           region: ${{ steps.credentials.outputs.region }}
           aws_role_arn: ${{ secrets.AWS_ASSUME_ROLE_ARN }}


### PR DESCRIPTION
Towards: https://github.com/ClickHouse/sre/issues/389

allow picking what version to test upgrade from during e2e tests on a PR