### PR TITLE
add the capability to create new services from existing backups

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -54,6 +54,7 @@ resource "clickhouse_service" "service" {
 ### Optional
 
 - `backup_configuration` (Attributes) Configuration of service backup settings. (see [below for nested schema](#nestedatt--backup_configuration))
+- `backup_id` (String) ID of the backup to restore when creating new service. If specified, the service will be created as a restore operation
 - `byoc_id` (String) BYOC ID related to the cloud provider account you want to create this service into.
 - `double_sha1_password_hash` (String, Sensitive) Double SHA1 hash of password for connecting with the MySQL protocol. Cannot be specified if `password` is specified.
 - `encryption_assumed_role_identifier` (String) Custom role identifier ARN.

--- a/pkg/internal/api/models.go
+++ b/pkg/internal/api/models.go
@@ -68,6 +68,7 @@ type Service struct {
 	BackupConfiguration             *BackupConfiguration          `json:"backupConfiguration,omitempty"`
 	ReleaseChannel                  string                        `json:"releaseChannel,omitempty"`
 	QueryAPIEndpoints               *ServiceQueryEndpoint         `json:"-"`
+	BackupID                        *string                       `json:"backupId,omitempty"`
 }
 
 type ServiceUpdate struct {

--- a/pkg/internal/api/service.go
+++ b/pkg/internal/api/service.go
@@ -90,6 +90,8 @@ func (c *ClientImpl) CreateService(ctx context.Context, s Service) (*Service, st
 	if err != nil {
 		return nil, "", err
 	}
+	// Always rewrite the backup ID as we need to make Terraform state to work by API does not return it backup ID
+	serviceResponse.Result.Service.BackupID = s.BackupID
 
 	return &serviceResponse.Result.Service, serviceResponse.Result.Password, nil
 }

--- a/pkg/resource/models/service_resource.go
+++ b/pkg/resource/models/service_resource.go
@@ -232,11 +232,13 @@ type ServiceResourceModel struct {
 	TransparentEncryptionData       types.Object `tfsdk:"transparent_data_encryption"`
 	QueryAPIEndpoints               types.Object `tfsdk:"query_api_endpoints"`
 	BackupConfiguration             types.Object `tfsdk:"backup_configuration"`
+	BackupID                        types.String `tfsdk:"backup_id"`
 }
 
 func (m *ServiceResourceModel) Equals(b ServiceResourceModel) bool {
 	if !m.ID.Equal(b.ID) ||
 		!m.BYOCID.Equal(b.BYOCID) ||
+		!m.BackupID.Equal(b.BackupID) ||
 		!m.DataWarehouseID.Equal(b.DataWarehouseID) ||
 		!m.ReadOnly.Equal(b.ReadOnly) ||
 		!m.IsPrimary.Equal(b.IsPrimary) ||

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -479,7 +479,7 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 			)
 		}
 
-		if !plan.BackupID.IsNull() && !plan.BackupID.IsUnknown() && plan.BackupID != state.BackupID {
+		if plan.BackupID != state.BackupID {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("backup_id"),
 				"Invalid Update",
@@ -974,8 +974,6 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		)
 		return
 	}
-	// Always rewrite the backup ID as we need to make Terraform state to work by API does not return it backup ID
-	s.BackupID = service.BackupID
 
 	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 20*60)
 	if err != nil {
@@ -1713,7 +1711,6 @@ func (r *ServiceResource) UpgradeState(ctx context.Context) map[int64]resource.S
 					EncryptionAssumedRoleIdentifier types.String `tfsdk:"encryption_assumed_role_identifier"`
 					QueryAPIEndpoints               types.Object `tfsdk:"query_api_endpoints"`
 					BackupConfiguration             types.Object `tfsdk:"backup_configuration"`
-					BackupID                        types.String `tfsdk:"backup_id"`
 				}
 
 				var priorStateData oldService
@@ -1778,7 +1775,7 @@ func (r *ServiceResource) UpgradeState(ctx context.Context) map[int64]resource.S
 				upgradedStateData := models.ServiceResourceModel{
 					ID:                              priorStateData.ID,
 					BYOCID:                          priorStateData.BYOCID,
-					BackupID:                        priorStateData.BackupID,
+					BackupID:                        types.StringNull(),
 					DataWarehouseID:                 priorStateData.DataWarehouseID,
 					IsPrimary:                       priorStateData.IsPrimary,
 					ReadOnly:                        priorStateData.ReadOnly,


### PR DESCRIPTION
Added support to restore from a backup when creating a new resource.

When calling

```
POST /v1/organizations/{organizationId}/services
```

to create a new service, allowed passing an optional field

```
"backupId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
```

Ensured:

- [x] It works with unencrypted backups
- [x] It works with encrypted/TDE backups
- [x] The field can be left out
- [x] The field can be set null
- [x] The field canNOT be set to the empty string
- [x] The field cannot be changed or removed from the resource