### PR TITLE
Disable RBAC resources from the alpha build

### DIFF
--- a/pkg/resource/register_debug.go
+++ b/pkg/resource/register_debug.go
@@ -12,12 +12,7 @@ func GetResourceFactories() []func() upstreamresource.Resource {
 		NewPrivateEndpointRegistrationResource,
 		NewServicePrivateEndpointsAttachmentResource,
 		NewServiceTransparentDataEncryptionKeyAssociationResource,
-		NewDatabaseResource,
 		NewClickPipeResource,
 		NewClickPipeReversePrivateEndpointResource,
-		NewUserResource,
-		NewRoleResource,
-		NewGrantRoleResource,
-		NewGrantPrivilegeResource,
 	}
 }


### PR DESCRIPTION
We switched to the external provider for the same feature.
Proper cleanup will follow