### PR TITLE
Pass clickhouse_clickpipe.destination.roles to API call

### DIFF
--- a/examples/clickpipe/kafka_msk_iam_role/main.tf
+++ b/examples/clickpipe/kafka_msk_iam_role/main.tf
@@ -61,6 +61,8 @@ resource "clickhouse_clickpipe" "kafka_msk" {
         type = "UInt64"
       }
     ]
+
+    roles = ["custom_role_1", "custom_role_2"]
   }
 
   field_mappings = [

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -115,6 +115,7 @@ type ClickPipeDestination struct {
 	ManagedTable    bool                                 `json:"managedTable"`
 	TableDefinition *ClickPipeDestinationTableDefinition `json:"tableDefinition,omitempty"`
 	Columns         []ClickPipeDestinationColumn         `json:"columns"`
+	Roles           []string                             `json:"roles,omitempty"`
 }
 
 type ClickPipeDestinationUpdate struct {

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -675,11 +675,19 @@ func (c *ClickPipeResource) Create(ctx context.Context, request resource.CreateR
 	destinationColumnsModels := make([]models.ClickPipeDestinationColumnModel, len(destinationModel.Columns.Elements()))
 	response.Diagnostics.Append(destinationModel.Columns.ElementsAs(ctx, &destinationColumnsModels, false)...)
 
+	// Extract roles from the destination model
+	var rolesSlice []string
+	if !destinationModel.Roles.IsNull() && len(destinationModel.Roles.Elements()) > 0 {
+		rolesSlice = make([]string, len(destinationModel.Roles.Elements()))
+		response.Diagnostics.Append(destinationModel.Roles.ElementsAs(ctx, &rolesSlice, false)...)
+	}
+
 	clickPipe.Destination = api.ClickPipeDestination{
 		Database:     destinationModel.Database.ValueString(),
 		Table:        destinationModel.Table.ValueString(),
 		ManagedTable: destinationModel.ManagedTable.ValueBool(),
 		Columns:      make([]api.ClickPipeDestinationColumn, len(destinationColumnsModels)),
+		Roles:        rolesSlice,
 	}
 
 	if destinationModel.ManagedTable.ValueBool() {


### PR DESCRIPTION
## Fix: Pass `clickhouse_clickpipe.destination.roles` to API call

### 🐛 Problem

The `roles` field in the `clickhouse_clickpipe` resource was defined in the Terraform schema but was not being passed to the ClickHouse API during ClickPipe creation. This meant that users could configure roles in their Terraform configuration, but they would be silently ignored.

```hcl
resource "clickhouse_clickpipe" "example" {
  # ... other configuration ...
  
  destination = {
    # ... other fields ...
    roles = ["custom_role_1", "custom_role_2"]  # ❌ This was being ignored
  }
}
```

### 🔍 Root Cause

The issue had two parts:

1. **Missing API Model Field**: The `ClickPipeDestination` struct in `pkg/internal/api/clickpipe_models.go` was missing the `Roles` field
2. **Missing Extraction Logic**: The `Create` method in `pkg/resource/clickpipe.go` wasn't extracting roles from the Terraform model and passing them to the API

### ✅ Solution

**Added `Roles` field to API model:**
```go
type ClickPipeDestination struct {
    // ... existing fields ...
    Roles []string `json:"roles,omitempty"`
}
```

**Added roles extraction logic in Create method:**
```go
// Extract roles from the destination model
var rolesSlice []string
if !destinationModel.Roles.IsNull() && len(destinationModel.Roles.Elements()) > 0 {
    rolesSlice = make([]string, len(destinationModel.Roles.Elements()))
    response.Diagnostics.Append(destinationModel.Roles.ElementsAs(ctx, &rolesSlice, false)...)
}

clickPipe.Destination = api.ClickPipeDestination{
    // ... other fields ...
    Roles: rolesSlice,
}
```

**Updated example to demonstrate usage:**
```hcl
destination = {
  # ... other fields ...
  roles = ["custom_role_1", "custom_role_2"]
}
```

### 🧪 Testing

- ✅ All existing unit tests pass (46 tests)
- ✅ Provider builds successfully
- ✅ No regressions detected
- ✅ Static analysis (`go vet`) passes clean

### 📝 Changes

- **`pkg/internal/api/clickpipe_models.go`**: Added `Roles []string` field to `ClickPipeDestination` struct
- **`pkg/resource/clickpipe.go`**: Added roles extraction logic in `Create` method with proper null checking and error handling
- **`examples/clickpipe/kafka_msk_iam_role/main.tf`**: Added example usage of the `roles` field

### 🔄 Backward Compatibility

This change is fully backward compatible:
- Existing configurations without `roles` continue to work unchanged
- The `roles` field uses `omitempty` JSON tag, so it's excluded from API calls when not specified
- No breaking changes to existing functionality

### 📚 Context

As noted in the existing code comment: *"Destination roles are not persisted on ClickPipes side. Used only during pipe creation"* - this fix ensures that roles specified in Terraform are properly passed to the ClickHouse API during ClickPipe creation, allowing users to create ClickHouse users with custom roles as intended.

### 🎯 Resolves

Fixes the issue where `clickhouse_clickpipe.destination.roles` configuration was silently ignored during ClickPipe creation.