### PR TITLE
Remove description field from clickpipes tf modules and examples

### DIFF
--- a/examples/clickpipe/externally_managed_table/main.tf
+++ b/examples/clickpipe/externally_managed_table/main.tf
@@ -3,34 +3,27 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 variable "table_name" {
-  description = "Table name"
   type        = string
 }
 
 variable "table_columns" {
-  description = "Table columns"
   type = list(object({
     name = string
     type = string
@@ -38,7 +31,6 @@ variable "table_columns" {
 }
 
 variable "field_mappings" {
-  description = "Field mappings"
   type = list(object({
     source_field      = string
     destination_field = string
@@ -47,7 +39,6 @@ variable "field_mappings" {
 
 resource "clickhouse_clickpipe" "kafka_confluent" {
   name        = "Confluent 🚀 ClickPipe"
-  description = "Data pipeline from Confluent to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_azure_eventhub/main.tf
+++ b/examples/clickpipe/kafka_azure_eventhub/main.tf
@@ -3,25 +3,20 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "azure_eventhub_connection_string" {
-  description = "Connection string for Azure EventHub"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_azure_eventhub" {
   name        = "Azure EventHub 🚀 ClickPipe"
-  description = "Data pipeline from Azure EventHub to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_confluent/main.tf
+++ b/examples/clickpipe/kafka_confluent/main.tf
@@ -3,30 +3,24 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_confluent" {
   name        = "Confluent 🚀 ClickPipe"
-  description = "Data pipeline from Confluent to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_msk_iam_role/main.tf
+++ b/examples/clickpipe/kafka_msk_iam_role/main.tf
@@ -3,24 +3,19 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "iam_role" {
-  description = "IAM role ARN"
 }
 
 resource "clickhouse_clickpipe" "kafka_msk" {
   name        = "MSK 🚀 ClickPipe"
-  description = "Data pipeline from MSK to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_msk_iam_user/main.tf
+++ b/examples/clickpipe/kafka_msk_iam_user/main.tf
@@ -3,30 +3,24 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "iam_access_key_id" {
-  description = "IAM access key ID"
   sensitive   = true
 }
 
 variable "iam_secret_key" {
-  description = "IAM secret key"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_msk" {
   name        = "MSK 🚀 ClickPipe"
-  description = "Data pipeline from MSK to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_offset_strategy/main.tf
+++ b/examples/clickpipe/kafka_offset_strategy/main.tf
@@ -3,30 +3,24 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_offset_strategy" {
   name        = "Offset strategy 🚀 ClickPipe"
-  description = "Data pipeline with a custom offset strategy"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_redpanda_scram/main.tf
+++ b/examples/clickpipe/kafka_redpanda_scram/main.tf
@@ -3,30 +3,24 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_redpanda" {
   name        = "Redpanda 🚀 ClickPipe"
-  description = "Data pipeline from Redpanda to ClickHouse"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kafka_schema_registry/main.tf
+++ b/examples/clickpipe/kafka_schema_registry/main.tf
@@ -3,44 +3,35 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 variable "schema_registry_url" {
-  description = "Schema Registry URL"
 }
 
 variable "schema_registry_username" {
-  description = "Schema Registry Username"
   sensitive   = true
 }
 
 variable "schema_registry_password" {
-  description = "Schema Registry Password"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_schema_registry" {
   name        = "Schema Registry 🚀 ClickPipe"
-  description = "Data pipeline with use of Schema Registry"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/kinesis_iam_role/main.tf
+++ b/examples/clickpipe/kinesis_iam_role/main.tf
@@ -1,7 +1,6 @@
 resource "clickhouse_clickpipe" "kinesis_iam_role" {
   service_id  = var.service_id
   name        = var.pipe_name
-  description = var.pipe_description
 
   source = {
     kinesis = {

--- a/examples/clickpipe/kinesis_iam_role/variables.tf
+++ b/examples/clickpipe/kinesis_iam_role/variables.tf
@@ -25,11 +25,6 @@ variable "pipe_name" {
   default     = "kinesis-iam-user-example"
 }
 
-variable "pipe_description" {
-  description = "The description of the ClickPipe"
-  type        = string
-  default     = "Example of a Kinesis ClickPipe using IAM User authentication"
-}
 
 variable "database" {
   description = "The database to store the data"

--- a/examples/clickpipe/kinesis_iam_user/main.tf
+++ b/examples/clickpipe/kinesis_iam_user/main.tf
@@ -1,7 +1,6 @@
 resource "clickhouse_clickpipe" "kinesis_iam_user" {
   service_id  = var.service_id
   name        = var.pipe_name
-  description = var.pipe_description
 
   source = {
     kinesis = {

--- a/examples/clickpipe/kinesis_iam_user/variables.tf
+++ b/examples/clickpipe/kinesis_iam_user/variables.tf
@@ -25,11 +25,6 @@ variable "pipe_name" {
   default     = "kinesis-iam-user-example"
 }
 
-variable "pipe_description" {
-  description = "The description of the ClickPipe"
-  type        = string
-  default     = "Example of a Kinesis ClickPipe using IAM User authentication"
-}
 
 variable "database" {
   description = "The database to store the data"

--- a/examples/clickpipe/multiple_pipes_example/main.tf
+++ b/examples/clickpipe/multiple_pipes_example/main.tf
@@ -1,27 +1,21 @@
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
 variable "number_of_pipes" {
-  description = "Number of pipes to create"
   default     = 5
 }
 

--- a/examples/clickpipe/object_storage_iam_role/main.tf
+++ b/examples/clickpipe/object_storage_iam_role/main.tf
@@ -3,21 +3,17 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "bucket_url" {
-  description = "S3-compatible bucket URL"
 }
 
 variable "iam_role" {
-  description = "IAM role"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_s3" {
   name        = "S3 🚀 ClickPipe with IAM role"
-  description = "Data pipeline from S3 to ClickHouse"
 
   service_id = var.service_id
   

--- a/examples/clickpipe/object_storage_iam_user/main.tf
+++ b/examples/clickpipe/object_storage_iam_user/main.tf
@@ -3,26 +3,21 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "bucket_url" {
-  description = "S3-compatible bucket URL"
 }
 
 variable "iam_access_key_id" {
-  description = "IAM access key ID"
   sensitive   = true
 }
 
 variable "iam_secret_key" {
-  description = "IAM secret key"
   sensitive   = true
 }
 
 resource "clickhouse_clickpipe" "kafka_s3" {
   name        = "S3 🚀 ClickPipe with IAM user"
-  description = "Data pipeline from S3 to ClickHouse"
 
   service_id = var.service_id
   

--- a/examples/clickpipe/reverse_private_endpoint_msk/main.tf
+++ b/examples/clickpipe/reverse_private_endpoint_msk/main.tf
@@ -3,21 +3,17 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "msk_cluster_arn" {
-  description = "MSK cluter ARN"
 }
 
 variable "msk_authentication" {
-  description = "MSK authentication"
   default     = "SASL_SCRAM"
 }
 
 resource "clickhouse_clickpipes_reverse_private_endpoint" "endpoint" {
   service_id         = var.service_id
-  description        = "Reverse private endpoint for ClickPipes"
   type               = "MSK_MULTI_VPC"
   msk_cluster_arn    = var.msk_cluster_arn
   msk_authentication = var.msk_authentication

--- a/examples/clickpipe/reverse_private_endpoint_msk_pipe/clickpipe.tf
+++ b/examples/clickpipe/reverse_private_endpoint_msk_pipe/clickpipe.tf
@@ -5,7 +5,6 @@ locals {
 
 resource "clickhouse_clickpipe" "msk" {
   name        = "MSK pipe using Reverse Private Endpoint"
-  description = "This pipe is using a secure private endpoint to connect to MSK"
 
   service_id = var.service_id
 

--- a/examples/clickpipe/reverse_private_endpoint_msk_pipe/reverse_private_endpoint.tf
+++ b/examples/clickpipe/reverse_private_endpoint_msk_pipe/reverse_private_endpoint.tf
@@ -12,7 +12,6 @@ locals {
 
 resource "clickhouse_clickpipes_reverse_private_endpoint" "endpoint" {
   service_id                = var.service_id
-  description               = "Reverse private endpoint for my ClickPipe"
   type                      = "MSK_MULTI_VPC"
   msk_cluster_arn = var.msk_cluster_arn
   msk_authentication = local.rpe_msk_authentication

--- a/examples/clickpipe/reverse_private_endpoint_vpc_resource/main.tf
+++ b/examples/clickpipe/reverse_private_endpoint_vpc_resource/main.tf
@@ -3,20 +3,16 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "vpc_resource_configuration_id" {
-  description = "VPC resource configuration id"
 }
 
 variable "vpc_resource_share_arn" {
-  description = "VPC resource share ARN"
 }
 
 resource "clickhouse_clickpipes_reverse_private_endpoint" "endpoint" {
   service_id                = var.service_id
-  description               = "Reverse private endpoint for ClickPipes"
   type                      = "VPC_RESOURCE"
   vpc_resource_configuration_id = var.vpc_resource_configuration_id
   vpc_resource_share_arn    = var.vpc_resource_share_arn

--- a/examples/clickpipe/reverse_private_endpoint_vpce_service/main.tf
+++ b/examples/clickpipe/reverse_private_endpoint_vpce_service/main.tf
@@ -3,16 +3,13 @@ variable "token_key" {}
 variable "token_secret" {}
 
 variable "service_id" {
-  description = "ClickHouse service ID"
 }
 
 variable "vpc_endpoint_service_name" {
-  description = "VPC endpoint service name"
 }
 
 resource "clickhouse_clickpipes_reverse_private_endpoint" "endpoint" {
   service_id                = var.service_id
-  description               = "Reverse private endpoint for ClickPipes"
   type                      = "VPC_ENDPOINT_SERVICE"
   vpc_endpoint_service_name = var.vpc_endpoint_service_name
 }

--- a/examples/clickpipe/service_and_clickpipe/main.tf
+++ b/examples/clickpipe/service_and_clickpipe/main.tf
@@ -13,20 +13,16 @@ variable "region" {
 }
 
 variable "kafka_brokers" {
-  description = "Kafka brokers"
 }
 
 variable "kafka_topics" {
-  description = "Kafka topics"
 }
 
 variable "kafka_username" {
-  description = "Username"
   sensitive   = true
 }
 
 variable "kafka_password" {
-  description = "Password"
   sensitive   = true
 }
 
@@ -42,14 +38,12 @@ resource "clickhouse_service" "service" {
   ip_access = [
     {
       source      = "0.0.0.0"
-      description = "Anywhere"
     }
   ]
 }
 
 resource "clickhouse_clickpipe" "kafka_confluent" {
   name        = "🚀 ClickPipe created with Terraform"
-  description = "Data pipeline from Confluent to ClickHouse"
 
   service_id = clickhouse_service.service.id
 

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -130,7 +130,6 @@ type ClickPipeFieldMapping struct {
 type ClickPipe struct {
 	ID            string                  `json:"id,omitempty"`
 	Name          string                  `json:"name"`
-	Description   *string                 `json:"description,omitempty"`
 	Scaling       *ClickPipeScaling       `json:"scaling,omitempty"`
 	State         string                  `json:"state,omitempty"`
 	Source        ClickPipeSource         `json:"source"`
@@ -142,7 +141,6 @@ type ClickPipe struct {
 
 type ClickPipeUpdate struct {
 	Name          *string                     `json:"name,omitempty"`
-	Description   *string                     `json:"description,omitempty"`
 	Source        *ClickPipeSource            `json:"source,omitempty"`
 	Destination   *ClickPipeDestinationUpdate `json:"destination,omitempty"`
 	FieldMappings []ClickPipeFieldMapping     `json:"fieldMappings,omitempty"`

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -99,10 +99,6 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "The name of the ClickPipe.",
 				Required:    true,
 			},
-			"description": schema.StringAttribute{
-				Description: "The description of the ClickPipe.",
-				Optional:    true,
-			},
 			"scaling": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
 					"replicas": schema.Int64Attribute{
@@ -660,8 +656,7 @@ func (c *ClickPipeResource) Create(ctx context.Context, request resource.CreateR
 	serviceID := plan.ServiceID.ValueString()
 
 	clickPipe := api.ClickPipe{
-		Name:        plan.Name.ValueString(),
-		Description: plan.Description.ValueStringPointer(),
+		Name: plan.Name.ValueString(),
 	}
 
 	if source := c.extractSourceFromPlan(ctx, response.Diagnostics, plan, false); source != nil {
@@ -998,13 +993,6 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 	state.ID = types.StringValue(clickPipe.ID)
 	state.Name = types.StringValue(clickPipe.Name)
 
-	// ideally, we shouldn't receive an empty description from the API, but we should handle it just in case
-	if clickPipe.Description != nil && *clickPipe.Description != "" {
-		state.Description = types.StringPointerValue(clickPipe.Description)
-	} else {
-		state.Description = types.StringNull()
-	}
-
 	// In case ClickPipe status is not as expected,
 	// we should return an error that clearly states the issue so the user can take action.
 	if clickPipe.State != state.State.ValueString() {
@@ -1327,11 +1315,6 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 	if !plan.Name.Equal(state.Name) {
 		pipeChanged = true
 		clickPipeUpdate.Name = plan.Name.ValueStringPointer()
-	}
-
-	if !plan.Description.Equal(state.Description) {
-		pipeChanged = true
-		clickPipeUpdate.Description = plan.Description.ValueStringPointer()
 	}
 
 	if !plan.Source.Equal(state.Source) {

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -433,7 +433,6 @@ type ClickPipeResourceModel struct {
 	ID            types.String `tfsdk:"id"`
 	ServiceID     types.String `tfsdk:"service_id"`
 	Name          types.String `tfsdk:"name"`
-	Description   types.String `tfsdk:"description"`
 	Scaling       types.Object `tfsdk:"scaling"`
 	State         types.String `tfsdk:"state"`
 	Source        types.Object `tfsdk:"source"`


### PR DESCRIPTION
This removes the description field from the clickpipes terraform modules and example since we have since removed it from ClickPipes and it causes the creation/update of ClickPipes to fail.