### PR TITLE
Add Azure Blob Storage support to ClickPipe object storage

### DIFF
--- a/examples/clickpipe/object_storage_azure_blob/README.md
+++ b/examples/clickpipe/object_storage_azure_blob/README.md
@@ -1,0 +1,31 @@
+## ClickPipe Object Storage with Azure Blob Storage example
+
+This example demonstrates how to deploy a ClickPipe with an Azure Blob Storage container as the input source,
+authenticated with a connection string.
+
+## Prerequisites
+
+- Azure Storage Account with a blob container
+- Files in the container (e.g., JSON files in `data/` folder)
+- Azure Storage Account connection string
+
+## How to run
+
+- Rename `variables.sample.tfvars` to `variables.tfvars` and fill in all needed data.
+- Run `terraform init`
+- Run `terraform <plan|apply> -var-file=variables.tfvars`
+
+## Azure Blob Storage Configuration
+
+The example uses:
+- `type = "azureblobstorage"` for Azure Blob Storage
+- `authentication = "CONNECTION_STRING"` with Azure connection string
+- `azure_container_name` to specify the container
+- `path` to specify file path within the container (supports wildcards)
+
+## Connection String Format
+
+The Azure connection string should be in the format:
+```
+DefaultEndpointsProtocol=https;AccountName=<account_name>;AccountKey=<account_key>;EndpointSuffix=core.windows.net
+```

--- a/examples/clickpipe/object_storage_azure_blob/main.tf
+++ b/examples/clickpipe/object_storage_azure_blob/main.tf
@@ -68,6 +68,9 @@ resource "clickhouse_clickpipe" "azure_blob" {
     }, {
       source_field      = "user_name"
       destination_field = "name"
+    }, {
+      source_field      = "created_at"
+      destination_field = "timestamp"
     }
   ]
 }

--- a/examples/clickpipe/object_storage_azure_blob/main.tf
+++ b/examples/clickpipe/object_storage_azure_blob/main.tf
@@ -1,0 +1,77 @@
+variable "organization_id" {}
+variable "token_key" {}
+variable "token_secret" {}
+
+variable "service_id" {
+  description = "ClickHouse service ID"
+}
+
+variable "azure_connection_string" {
+  description = "Azure Blob Storage connection string"
+  sensitive   = true
+}
+
+variable "azure_container_name" {
+  description = "Azure Blob Storage container name"
+}
+
+variable "azure_path" {
+  description = "Path to the file(s) within the Azure container"
+  default     = "data/*.json"
+}
+
+resource "clickhouse_clickpipe" "azure_blob" {
+  name        = "Azure Blob Storage 🚀 ClickPipe"
+  service_id = var.service_id
+  state = "Running"
+  source = {
+    object_storage = {
+      type    = "azureblobstorage"
+      format  = "JSONEachRow"
+
+      path                  = var.azure_path
+      azure_container_name  = var.azure_container_name
+      connection_string     = var.azure_connection_string
+
+      authentication = "CONNECTION_STRING"
+    }
+  }
+
+  destination = {
+    table         = "my_azure_data_table"
+    managed_table = true
+
+    table_definition = {
+      engine = {
+        type = "MergeTree"
+      }
+    }
+
+    columns = [
+      {
+        name = "id"
+        type = "UInt64"
+      }, {
+        name = "name"
+        type = "String"
+      }, {
+        name = "timestamp"
+        type = "DateTime"
+      }
+    ]
+  }
+
+  field_mappings = [
+    {
+      source_field      = "user_id"
+      destination_field = "id"
+    }, {
+      source_field      = "user_name"
+      destination_field = "name"
+    }
+  ]
+}
+
+output "clickpipe_id" {
+  value = clickhouse_clickpipe.azure_blob.id
+}

--- a/examples/clickpipe/object_storage_azure_blob/provider.tf
+++ b/examples/clickpipe/object_storage_azure_blob/provider.tf
@@ -1,0 +1,15 @@
+# This file is generated automatically please do not edit
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "3.3.3-alpha3"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/clickpipe/object_storage_azure_blob/provider.tf.template.alpha
+++ b/examples/clickpipe/object_storage_azure_blob/provider.tf.template.alpha
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "${CLICKHOUSE_TERRAFORM_PROVIDER_VERSION}"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/clickpipe/object_storage_azure_blob/variables.sample.tfvars
+++ b/examples/clickpipe/object_storage_azure_blob/variables.sample.tfvars
@@ -1,0 +1,10 @@
+# these keys are for example only and won't work when pointed to a deployed ClickHouse OpenAPI server
+organization_id = "aee076c1-3f83-4637-95b1-ad5a0a825b71"
+token_key       = "avhj1U5QCdWAE9CA9"
+token_secret    = "4b1dROiHQEuSXJHlV8zHFd0S7WQj7CGxz5kGJeJnca"
+service_id      = "aee076c1-3f83-4637-95b1-ad5a0a825b71"
+
+# Azure Blob Storage configuration
+azure_connection_string = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey123;EndpointSuffix=core.windows.net"
+azure_container_name     = "mycontainer"
+azure_path              = "data/*.json"

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -48,6 +48,7 @@ var (
 const (
 	ClickPipeAuthenticationIAMRole = "IAM_ROLE"
 	ClickPipeAuthenticationIAMUser = "IAM_USER"
+	ClickPipeAuthenticationConnectionString = "CONNECTION_STRING"
 
 	ClickPipeKafkaAuthenticationPlain       = "PLAIN"
 	ClickPipeKafkaAuthenticationScramSha256 = "SCRAM-SHA-256"
@@ -83,6 +84,7 @@ var ClickPipeKafkaSourceTypes = []string{
 var ClickPipeObjectStorageAuthenticationMethods = []string{
 	ClickPipeAuthenticationIAMRole,
 	ClickPipeAuthenticationIAMUser,
+	ClickPipeAuthenticationConnectionString,
 }
 
 var ClickPipeKinesisAuthenticationMethods = []string{
@@ -110,13 +112,15 @@ var ClickPipeObjectStorageFormats = []string{
 }
 
 const (
-	ClickPipeObjectStorageS3Type  = "s3"
-	ClickPipeObjectStorageGCSType = "gcs"
+	ClickPipeObjectStorageS3Type    = "s3"
+	ClickPipeObjectStorageGCSType   = "gcs"
+	ClickPipeObjectStorageAzureBlobType = "azureblobstorage"
 )
 
 var ClickPipeObjectStorageTypes = []string{
 	ClickPipeObjectStorageS3Type,
 	ClickPipeObjectStorageGCSType,
+	ClickPipeObjectStorageAzureBlobType,
 }
 
 const (

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -46,8 +46,8 @@ var (
 )
 
 const (
-	ClickPipeAuthenticationIAMRole = "IAM_ROLE"
-	ClickPipeAuthenticationIAMUser = "IAM_USER"
+	ClickPipeAuthenticationIAMRole          = "IAM_ROLE"
+	ClickPipeAuthenticationIAMUser          = "IAM_USER"
 	ClickPipeAuthenticationConnectionString = "CONNECTION_STRING"
 
 	ClickPipeKafkaAuthenticationPlain       = "PLAIN"
@@ -112,8 +112,8 @@ var ClickPipeObjectStorageFormats = []string{
 }
 
 const (
-	ClickPipeObjectStorageS3Type    = "s3"
-	ClickPipeObjectStorageGCSType   = "gcs"
+	ClickPipeObjectStorageS3Type        = "s3"
+	ClickPipeObjectStorageGCSType       = "gcs"
 	ClickPipeObjectStorageAzureBlobType = "azureblobstorage"
 )
 

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -61,7 +61,7 @@ type ClickPipeObjectStorageSource struct {
 	Type   string `json:"type"`
 	Format string `json:"format"`
 
-	URL         string  `json:"url"`
+	URL         string  `json:"url,omitempty"`
 	Delimiter   *string `json:"delimiter,omitempty"`
 	Compression *string `json:"compression,omitempty"`
 

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -72,9 +72,9 @@ type ClickPipeObjectStorageSource struct {
 	IAMRole        *string                   `json:"iamRole,omitempty"`
 
 	// Azure Blob Storage specific fields
-	ConnectionString    *string `json:"connectionString,omitempty"`
-	Path                *string `json:"path,omitempty"`
-	AzureContainerName  *string `json:"azureContainerName,omitempty"`
+	ConnectionString   *string `json:"connectionString,omitempty"`
+	Path               *string `json:"path,omitempty"`
+	AzureContainerName *string `json:"azureContainerName,omitempty"`
 }
 
 type ClickPipeKinesisSource struct {

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -70,6 +70,11 @@ type ClickPipeObjectStorageSource struct {
 	Authentication *string                   `json:"authentication,omitempty"`
 	AccessKey      *ClickPipeSourceAccessKey `json:"accessKey,omitempty"`
 	IAMRole        *string                   `json:"iamRole,omitempty"`
+
+	// Azure Blob Storage specific fields
+	ConnectionString    *string `json:"connectionString,omitempty"`
+	Path                *string `json:"path,omitempty"`
+	AzureContainerName  *string `json:"azureContainerName,omitempty"`
 }
 
 type ClickPipeKinesisSource struct {

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -1221,21 +1221,24 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 		}
 
 		objectStorageModel := models.ClickPipeObjectStorageSourceModel{
-			Type:           types.StringValue(clickPipe.Source.ObjectStorage.Type),
-			Format:         types.StringValue(clickPipe.Source.ObjectStorage.Format),
-			Delimiter:      types.StringPointerValue(clickPipe.Source.ObjectStorage.Delimiter),
-			Compression:    types.StringPointerValue(clickPipe.Source.ObjectStorage.Compression),
-			IsContinuous:   types.BoolValue(clickPipe.Source.ObjectStorage.IsContinuous),
-			Authentication: types.StringPointerValue(clickPipe.Source.ObjectStorage.Authentication),
-			IAMRole:        types.StringPointerValue(clickPipe.Source.ObjectStorage.IAMRole),
+			Type:         types.StringValue(clickPipe.Source.ObjectStorage.Type),
+			Format:       types.StringValue(clickPipe.Source.ObjectStorage.Format),
+			Delimiter:    types.StringPointerValue(clickPipe.Source.ObjectStorage.Delimiter),
+			Compression:  types.StringPointerValue(clickPipe.Source.ObjectStorage.Compression),
+			IsContinuous: types.BoolValue(clickPipe.Source.ObjectStorage.IsContinuous),
+			IAMRole:      types.StringPointerValue(clickPipe.Source.ObjectStorage.IAMRole),
 		}
 
 		// Set storage-type-specific fields
 		if clickPipe.Source.ObjectStorage.Type == api.ClickPipeObjectStorageAzureBlobType {
-			objectStorageModel.ConnectionString = stateObjectStorageModel.ConnectionString // Preserve sensitive value from state
-			objectStorageModel.Path = types.StringPointerValue(clickPipe.Source.ObjectStorage.Path)
-			objectStorageModel.AzureContainerName = types.StringPointerValue(clickPipe.Source.ObjectStorage.AzureContainerName)
+			// For Azure Blob Storage, preserve all fields from state as API doesn't return them
+			objectStorageModel.Authentication = stateObjectStorageModel.Authentication
+			objectStorageModel.ConnectionString = stateObjectStorageModel.ConnectionString
+			objectStorageModel.Path = stateObjectStorageModel.Path
+			objectStorageModel.AzureContainerName = stateObjectStorageModel.AzureContainerName
 		} else {
+			// For S3-compatible storage, use API response values
+			objectStorageModel.Authentication = types.StringPointerValue(clickPipe.Source.ObjectStorage.Authentication)
 			objectStorageModel.URL = types.StringValue(clickPipe.Source.ObjectStorage.URL)
 		}
 

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -421,9 +421,6 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								MarkdownDescription: "Connection string for Azure Blob Storage authentication. Required when authentication is CONNECTION_STRING. Example: `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=mykey;EndpointSuffix=core.windows.net`",
 								Optional:            true,
 								Sensitive:           true,
-								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.RequiresReplace(),
-								},
 							},
 							"path": schema.StringAttribute{
 								MarkdownDescription: "Path to the file(s) within the Azure container. Used for Azure Blob Storage sources. You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations. Example: `data/logs/*.json`",

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -322,7 +322,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						},
 					},
 					"object_storage": schema.SingleNestedAttribute{
-						MarkdownDescription: "The Kafka source configuration for the ClickPipe.",
+						MarkdownDescription: "The compatible object storage source configuration for the ClickPipe.",
 						Optional:            true,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
@@ -356,7 +356,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 							},
 							"url": schema.StringAttribute{
 								MarkdownDescription: "The URL of the S3 bucket. Provide a path to the file(s) you want to ingest. You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations",
-								Required:            true,
+								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),
 								},
@@ -391,11 +391,8 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"authentication": schema.StringAttribute{
-								MarkdownDescription: fmt.Sprintf(
-									"Authentication method. If not provided, no authentication is used. It can be used to access public buckets.. (%s).",
-									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipeObjectStorageAuthenticationMethods),
-								),
-								Optional: true,
+								MarkdownDescription: "CONNECTION_STRING is for Azure Blob Storage. IAM_ROLE and IAM_USER are for AWS S3/GCS/DigitalOcean. If not provided, no authentication is used",
+								Optional:            true,
 								Validators: []validator.String{
 									stringvalidator.OneOf(api.ClickPipeObjectStorageAuthenticationMethods...),
 								},

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -269,36 +269,36 @@ type ClickPipeObjectStorageSourceModel struct {
 func (m ClickPipeObjectStorageSourceModel) ObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"type":                  types.StringType,
-			"format":                types.StringType,
-			"url":                   types.StringType,
-			"delimiter":             types.StringType,
-			"compression":           types.StringType,
-			"is_continuous":         types.BoolType,
-			"authentication":        types.StringType,
-			"access_key":            ClickPipeSourceAccessKeyModel{}.ObjectType(),
-			"iam_role":              types.StringType,
-			"connection_string":     types.StringType,
-			"path":                  types.StringType,
-			"azure_container_name":  types.StringType,
+			"type":                 types.StringType,
+			"format":               types.StringType,
+			"url":                  types.StringType,
+			"delimiter":            types.StringType,
+			"compression":          types.StringType,
+			"is_continuous":        types.BoolType,
+			"authentication":       types.StringType,
+			"access_key":           ClickPipeSourceAccessKeyModel{}.ObjectType(),
+			"iam_role":             types.StringType,
+			"connection_string":    types.StringType,
+			"path":                 types.StringType,
+			"azure_container_name": types.StringType,
 		},
 	}
 }
 
 func (m ClickPipeObjectStorageSourceModel) ObjectValue() types.Object {
 	return types.ObjectValueMust(m.ObjectType().AttrTypes, map[string]attr.Value{
-		"type":                  m.Type,
-		"format":                m.Format,
-		"url":                   m.URL,
-		"delimiter":             m.Delimiter,
-		"compression":           m.Compression,
-		"is_continuous":         m.IsContinuous,
-		"authentication":        m.Authentication,
-		"access_key":            m.AccessKey,
-		"iam_role":              m.IAMRole,
-		"connection_string":     m.ConnectionString,
-		"path":                  m.Path,
-		"azure_container_name":  m.AzureContainerName,
+		"type":                 m.Type,
+		"format":               m.Format,
+		"url":                  m.URL,
+		"delimiter":            m.Delimiter,
+		"compression":          m.Compression,
+		"is_continuous":        m.IsContinuous,
+		"authentication":       m.Authentication,
+		"access_key":           m.AccessKey,
+		"iam_role":             m.IAMRole,
+		"connection_string":    m.ConnectionString,
+		"path":                 m.Path,
+		"azure_container_name": m.AzureContainerName,
 	})
 }
 

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -259,35 +259,46 @@ type ClickPipeObjectStorageSourceModel struct {
 	Authentication types.String `tfsdk:"authentication"`
 	AccessKey      types.Object `tfsdk:"access_key"`
 	IAMRole        types.String `tfsdk:"iam_role"`
+
+	// Azure Blob Storage specific fields
+	ConnectionString   types.String `tfsdk:"connection_string"`
+	Path               types.String `tfsdk:"path"`
+	AzureContainerName types.String `tfsdk:"azure_container_name"`
 }
 
 func (m ClickPipeObjectStorageSourceModel) ObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"type":           types.StringType,
-			"format":         types.StringType,
-			"url":            types.StringType,
-			"delimiter":      types.StringType,
-			"compression":    types.StringType,
-			"is_continuous":  types.BoolType,
-			"authentication": types.StringType,
-			"access_key":     ClickPipeSourceAccessKeyModel{}.ObjectType(),
-			"iam_role":       types.StringType,
+			"type":                  types.StringType,
+			"format":                types.StringType,
+			"url":                   types.StringType,
+			"delimiter":             types.StringType,
+			"compression":           types.StringType,
+			"is_continuous":         types.BoolType,
+			"authentication":        types.StringType,
+			"access_key":            ClickPipeSourceAccessKeyModel{}.ObjectType(),
+			"iam_role":              types.StringType,
+			"connection_string":     types.StringType,
+			"path":                  types.StringType,
+			"azure_container_name":  types.StringType,
 		},
 	}
 }
 
 func (m ClickPipeObjectStorageSourceModel) ObjectValue() types.Object {
 	return types.ObjectValueMust(m.ObjectType().AttrTypes, map[string]attr.Value{
-		"type":           m.Type,
-		"format":         m.Format,
-		"url":            m.URL,
-		"delimiter":      m.Delimiter,
-		"compression":    m.Compression,
-		"is_continuous":  m.IsContinuous,
-		"authentication": m.Authentication,
-		"access_key":     m.AccessKey,
-		"iam_role":       m.IAMRole,
+		"type":                  m.Type,
+		"format":                m.Format,
+		"url":                   m.URL,
+		"delimiter":             m.Delimiter,
+		"compression":           m.Compression,
+		"is_continuous":         m.IsContinuous,
+		"authentication":        m.Authentication,
+		"access_key":            m.AccessKey,
+		"iam_role":              m.IAMRole,
+		"connection_string":     m.ConnectionString,
+		"path":                  m.Path,
+		"azure_container_name":  m.AzureContainerName,
 	})
 }
 


### PR DESCRIPTION
This PR adds support for Azure Blob Storage as a source for ClickPipe data ingestion pipelines, enabling users to ingest data directly from Azure Blob containers.

### Changes:
- **New object storage type:** `azureblobstorage`
- **New authentication method:** `CONNECTION_STRING` for Azure
- **New configuration fields:**
   - `connection_string` - Azure connection string (sensitive)
   - `path` - File path within container with wildcard support
   - `azure_container_name` - Azure container nam
   
Related to https://github.com/ClickHouse/clickpipes-platform/issues/4382