### PR TITLE
fix(terraform-pipeline): fix cleanup job for alpha docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -451,7 +451,7 @@ jobs:
       - name: Commit
         run: |
           git add docs/resources/
-          git diff --quiet --exit-code && (echo "No changes detected" && exit 0)
+          git diff --cached --quiet --exit-code && (echo "No changes detected" && exit 0)
           git config --global user.name "Release Github Action"
           git config --global user.email "bot@users.noreply.github.com"
           git commit -a -m "Remove alpha docs from main branch"


### PR DESCRIPTION
Fix cleanup job for alpha docs.

Reason for the change is incorrect logic in the cleanup job, which does not verify staged changes against committed.
Example of failed pipelines:
https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/16780395229/job/47517175102?pr=340
https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/16788437465/job/47544753307?pr=341

