### PR TITLE
fix example for importing reverse private endpoint

### DIFF
--- a/examples/resources/clickhouse_clickpipes_reverse_private_endpoint/import.sh
+++ b/examples/resources/clickhouse_clickpipes_reverse_private_endpoint/import.sh
@@ -1,2 +1,2 @@
-# ClickPipes reverse private endpoints can be imported by specifying both service ID and clickpipe ID.
+# ClickPipes reverse private endpoints can be imported by specifying both service ID and reverse private endpoint ID.
 terraform import clickhouse_clickpipes_reverse_private_endpoint.example xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
I noticed that in your docs for [reverse private endpoints](https://registry.terraform.io/providers/ClickHouse/clickhouse/3.4.1-alpha1/docs/resources/clickpipes_reverse_private_endpoint#import), it says that you can import an existing resource with

```
# ClickPipes reverse private endpoints can be imported by specifying both service ID and clickpipe ID.
terraform import clickhouse_clickpipes_reverse_private_endpoint.example xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

But this doesn't actually work! You need to specify the ID of the reverse private endpoint, not the ClickPipe that it's used in. Note that the ID of a reverse private endpoint isn't actually accessible via the UI; I had to use the API to find the ID.

I'm not sure how to update your actual Terraform docs but this is a start.