### PR TITLE
ci(comment): exclude dependabot

### DIFF
--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   check-comment:
     name: Parse action from comment
-    if: github.event.issue.pull_request
+    if: github.event.issue.pull_request && github.actor != 'dependabot[bot]'
     runs-on: k8s-nano
     steps:
       - name: Check comment


### PR DESCRIPTION
# Why

- Workflow fails since dependabot cannot access secrets