### PR TITLE
fix(ch-tf-provider): fix issue#357; Failure on terraform apply for backup configuration when user change unrelated to backup configuration settings,  reproduced on `BASIC` tier

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -1515,7 +1515,7 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Set backup settings.
 	{
-		if !plan.BackupConfiguration.IsNull() && !plan.BackupConfiguration.IsUnknown() {
+		if !plan.BackupConfiguration.IsNull() && !plan.BackupConfiguration.IsUnknown() && !plan.BackupConfiguration.Equal(state.BackupConfiguration) {
 			bc := models.BackupConfiguration{}
 			diag := plan.BackupConfiguration.As(ctx, &bc, basetypes.ObjectAsOptions{
 				UnhandledNullAsEmpty:    false,


### PR DESCRIPTION
Failure on terraform apply for backup configuration when user change unrelated to backup configuration settings,  reproduced on `BASIC` tier.
```
Error: Error setting service backup configuration
 
   with module.clickhouse[0].clickhouse_service.service,
   on clickhouse-infra/main.tf line 1, in resource "clickhouse_service" "service":
    1: resource "clickhouse_service" "service" {
 
 Could not update service backup settings, unexpected error:
 status: 403, body:
 {"requestId":"...","error":"FORBIDDEN:
 Cannot use customized backup schedule in BASIC pricing
 package","status":403}
```

Results of E2E tests: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17348677513