### PR TITLE
fix(tf-provider): release fails often because we run e2e, import, upgrade in parallel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,7 @@ jobs:
   upgrade:
     outputs:
       status: ${{ steps.status.outputs.status }}
-    needs: [ "validate", "token", "find-tf-releases", "list-examples" ]
+    needs: [ "validate", "token", "find-tf-releases", "list-examples", "e2e", "import" ]
     runs-on: k8s-large
     continue-on-error: true
     permissions:
@@ -219,7 +219,7 @@ jobs:
   import:
     outputs:
       status: ${{ steps.status.outputs.status }}
-    needs: [ "token", "find-tf-releases" ]
+    needs: [ "token", "find-tf-releases" , "e2e"]
     runs-on: k8s-large
     continue-on-error: true
     permissions:


### PR DESCRIPTION
Release fails often because we run e2e, import, upgrade in parallel
Example: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17480382851/job/49649555903
```
    responseBody=
    | {
    |   "error": "TOO_MANY_REQUESTS"
    | }
```