### PR TITLE
Add support for new table engines for ClickPipes managed table

### DIFF
--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -155,7 +155,9 @@ type ClickPipeDestinationColumn struct {
 }
 
 type ClickPipeDestinationTableEngine struct {
-	Type string `json:"type"`
+	Type             string   `json:"type"`
+	VersionColumnID  *string  `json:"versionColumnId,omitempty"`
+	ColumnIDs        []string `json:"columnIds,omitempty"`
 }
 
 type ClickPipeDestinationTableDefinition struct {

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -348,20 +348,26 @@ func (m ClickPipeDestinationColumnModel) ObjectValue() types.Object {
 }
 
 type ClickPipeDestinationTableEngineModel struct {
-	Type types.String `tfsdk:"type"`
+	Type             types.String `tfsdk:"type"`
+	VersionColumnID  types.String `tfsdk:"version_column_id"`
+	ColumnIDs        types.List   `tfsdk:"column_ids"`
 }
 
 func (m ClickPipeDestinationTableEngineModel) ObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
-			"type": types.StringType,
+			"type":               types.StringType,
+			"version_column_id":  types.StringType,
+			"column_ids":         types.ListType{ElemType: types.StringType},
 		},
 	}
 }
 
 func (m ClickPipeDestinationTableEngineModel) ObjectValue() types.Object {
 	return types.ObjectValueMust(m.ObjectType().AttrTypes, map[string]attr.Value{
-		"type": m.Type,
+		"type":               m.Type,
+		"version_column_id":  m.VersionColumnID,
+		"column_ids":         m.ColumnIDs,
 	})
 }
 


### PR DESCRIPTION
# Overview
This adds support for 3 new table engines in ClickPipe's managed table implementation (ReplacingMergeTree, SummingMergeTree and Null)

## Notes
Straightforward change for the most part, validation is properly done on OpenAPI with helpful error messages. Only thing to note is that VersionColumnID is not returned by the API so we maintain the state here.