### PR TITLE
fix: don't override CI files during upgrade test at the middle of CI execution

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -172,6 +172,7 @@ runs:
       name: Upgrade test - Run terraform using latest stable version
       run: |
         git checkout tags/${{ steps.get_latest_stable_release.outputs.tag }}
+        git checkout main -- .github/
         if [ $(find examples/full/${{ inputs.test_name }}/${{ inputs.cloud_provider }} -name "*.tf" -type f 2>/dev/null | wc -l) -gt 0 ]
         then
           echo "::group::Run terraform using latest stable version"


### PR DESCRIPTION
Don't override CI files during upgrade test at the middle of CI execution
To address issues like: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17703162399/job/50321988800