### PR TITLE
fix: Pass proper service name in Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,7 +144,7 @@ jobs:
           organization_id: ${{ steps.credentials.outputs.organization_id }}
           token_key: ${{ steps.credentials.outputs.api_key_id }}
           token_secret: ${{ steps.credentials.outputs.api_key_secret }}
-          service_name: "[e2e]-${{ matrix.test.name }}-${{ matrix.tf_release }}-${{ matrix.test.cloud }}-${{ needs.token.outputs.token }}"
+          service_name: ${{steps.service_name.outputs.service_name}}
           test_name: ${{ matrix.test.name }}
           tf_release: ${{ matrix.tf_release }}
           cloud_provider: ${{ matrix.test.cloud }}
@@ -224,7 +224,7 @@ jobs:
           organization_id: ${{ steps.credentials.outputs.organization_id }}
           token_key: ${{ steps.credentials.outputs.api_key_id }}
           token_secret: ${{ steps.credentials.outputs.api_key_secret }}
-          service_name: "[upg]-${{ matrix.test.name }}-${{ matrix.tf_release }}-${{ matrix.test.cloud }}-${{ needs.token.outputs.token }}"
+          service_name: ${{steps.service_name.outputs.service_name}}
           test_name: ${{ matrix.test.name }}
           tf_release: ${{ matrix.tf_release }}
           cloud_provider: ${{ matrix.test.cloud }}

--- a/examples/full/private_endpoint/azure/azure.tf
+++ b/examples/full/private_endpoint/azure/azure.tf
@@ -17,17 +17,16 @@ locals {
   tags = {
     Name = var.service_name
   }
-  service_name_normalized = replace(var.service_name, "/\\[|\\]/", "")
 }
 
 resource "azurerm_resource_group" "this" {
-  name     = local.service_name_normalized
+  name     = var.service_name
   location = var.region
   tags     = local.tags
 }
 
 resource "azurerm_virtual_network" "this" {
-  name                = local.service_name_normalized
+  name                = var.service_name
   address_space       = ["10.0.0.0/16"]
   location            = var.region
   resource_group_name = azurerm_resource_group.this.name
@@ -35,30 +34,30 @@ resource "azurerm_virtual_network" "this" {
 }
 
 resource "azurerm_subnet" "this" {
-  name                 = local.service_name_normalized
+  name                 = var.service_name
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = ["10.0.1.0/24"]
 }
 
 resource "azurerm_private_endpoint" "this" {
-  name                = local.service_name_normalized
+  name                = var.service_name
   location            = var.region
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.this.id
 
   private_service_connection {
-    name                              = local.service_name_normalized
+    name                              = var.service_name
     private_connection_resource_alias = clickhouse_service.this.private_endpoint_config.endpoint_service_id
     is_manual_connection              = true
-    request_message                   = "clickhouse-${local.service_name_normalized}"
+    request_message                   = "clickhouse-${var.service_name}"
   }
 
   tags = local.tags
 }
 
 resource "azurerm_network_security_group" "this" {
-  name                = local.service_name_normalized
+  name                = var.service_name
   location            = var.region
   resource_group_name = azurerm_resource_group.this.name
   tags                = local.tags
@@ -70,8 +69,8 @@ resource "azurerm_subnet_network_security_group_association" "this" {
 }
 
 resource "azurerm_network_security_rule" "this" {
-  name              = local.service_name_normalized
-  description       = "Allow subnet to ${local.service_name_normalized}"
+  name              = var.service_name
+  description       = "Allow subnet to ${var.service_name}"
   priority          = 100
   direction         = "Inbound"
   access            = "Allow"


### PR DESCRIPTION
Normalize service name to use in the names of the Azure resources be with requirements of Azure

https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17785231096/job/50551470950
```
Error: name must be between 1 - 80 characters long, begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, periods, hyphens or underscores
  
    with azurerm_private_endpoint.this,
    on azure.tf line 45, in resource "azurerm_private_endpoint" "this":
    45:   name                = var.service_name
  
```

E2E: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17787396035