### PR TITLE
fix: add ability to rerun failed tests

### DIFF
--- a/.github/actions/import/action.yaml
+++ b/.github/actions/import/action.yaml
@@ -18,9 +18,9 @@ inputs:
     required: true
     default: "service"
     description: "The type of resource to import. Only supported resource is 'service'"
-  resource_name:
+  service_name:
     required: true
-    description: "The name of the existing resource to import"
+    description: "The name of the existing service to import"
   tf_release:
     required: true
     description: "The terraform cli version"
@@ -65,7 +65,7 @@ runs:
         if [ "${{ inputs.resource_type }}" == "service" ]
         then
           cat <<EOF >>tests/import/${{ inputs.resource_type }}/variables.tfvars
-        service_name    = "${{ inputs.resource_name }}"
+        service_name    = "${{ inputs.service_name }}"
         EOF
         fi
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -185,7 +185,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         test: ${{ fromJSON(needs.list-examples.outputs.examples) }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: ./.github/actions/find-tf-releases
         id: find
         with:
-          count: '3'
+          count: "3"
 
   list-examples:
     outputs:
@@ -101,12 +101,9 @@ jobs:
 
   # Run e2e tests
   e2e:
-    outputs:
-      status: ${{ steps.status.outputs.status }}
-    needs: [ "token", "find-tf-releases", "list-examples" ]
+    needs: ["token", "find-tf-releases", "list-examples"]
     runs-on: k8s-large
     environment: default
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -180,20 +177,10 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> "${GITHUB_OUTPUT}"
-          exit 1
-
   upgrade:
-    outputs:
-      status: ${{ steps.status.outputs.status }}
-    needs: [ "token", "find-tf-releases", "list-examples" ]
+    needs: ["token", "find-tf-releases", "list-examples"]
     runs-on: k8s-large
     environment: default
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -269,41 +256,29 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> "${GITHUB_OUTPUT}"
-          exit 1
-
   report:
     runs-on: k8s-nano
-    needs: [ "e2e", "upgrade" ]
-    if: ${{ github.ref_name == 'main' && (needs.e2e.outputs.status == 'failure' || needs.upgrade.outputs.status == 'failure') }}
+    needs: ["e2e", "upgrade"]
+    if: always()
     steps:
       - name: Report Failure on slack
-        if: ${{ github.ref_name == 'main' && (needs.e2e.outputs.status == 'failure' || needs.upgrade.outputs.status == 'failure') }}
+        if: ${{ github.ref_name == 'main' && (needs.e2e.result == 'failure' || needs.upgrade.result == 'failure') }}
         uses: ravsamhq/notify-slack-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          status: 'failure'
+          status: "failure"
           notification_title: "E2E tests failed for {branch}"
           mention_groups: "S099W77RQ7J" # @on-call-terraform-provider
           mention_groups_when: "failure"
           footer: "{run_url}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      - name: Report error on github UI
-        run: |
-          if [ "${{ needs.e2e.outputs.status }}" == 'failure' || needs.upgrade.outputs.status == 'failure' ]
-          then
-            exit 1
-          fi
+
 
   # Delete any leftover service that might have failed deleting
   cleanup:
     runs-on: k8s-small
-    needs: [ "e2e", "upgrade", "token" ]
+    needs: ["e2e", "upgrade", "token"]
     if: always()
     continue-on-error: true
     steps:

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -63,11 +63,8 @@ jobs:
 
   # Run import tests
   import:
-    outputs:
-      status: ${{ steps.status.outputs.status }}
     needs: [ "token", "find-tf-releases" ]
     runs-on: k8s-medium
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -76,11 +73,22 @@ jobs:
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         cloud_provider: [ "aws", "azure", "gcp" ]
+        test_name : ["generic"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Generate service name
+        uses: ./.github/actions/generate-service-name
+        id: service_name
+        with:
+          test_type: import
+          test_name: ${{ matrix.test_name }}
+          tf_release: ${{ matrix.tf_release }}
+          cloud_provider: ${{ matrix.cloud_provider }}
+          token: ${{ needs.token.outputs.token }}
 
       - name: Get API details for env
         id: credentials
@@ -104,29 +112,11 @@ jobs:
           organization_id: ${{ steps.credentials.outputs.organization_id }}
           token_key: ${{ steps.credentials.outputs.api_key_id }}
           token_secret: ${{ steps.credentials.outputs.api_key_secret }}
-          resource_name: "[import]-${{ matrix.tf_release }}-${{ matrix.cloud_provider }}-${{ needs.token.outputs.token }}"
+          service_name: ${{steps.service_name.outputs.service_name}}
           tf_release: ${{ matrix.tf_release }}
           cloud_provider: ${{ matrix.cloud_provider }}
           region: ${{ steps.credentials.outputs.region }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> $GITHUB_OUTPUT
-          exit 1
-
-  report:
-    runs-on: k8s-nano
-    needs: [ "import" ]
-    if: ${{ needs.import.outputs.status == 'failure' }}
-    steps:
-      - name: Report error on github UI
-        run: |
-          if [ "${{ needs.import.outputs.status }}" == 'failure' ]
-          then
-            exit 1
-          fi
 
   # Delete any leftover service that might have failed deleting
   cleanup:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         test: ${{ fromJSON(needs.list-examples.outputs.examples) }}
@@ -173,7 +173,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         test: ${{ fromJSON(needs.list-examples.outputs.examples) }}
@@ -245,7 +245,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
-      max-parallel: 10
+      max-parallel: 5
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         cloud_provider: [ "aws", "azure", "gcp" ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,12 +97,9 @@ jobs:
 
   # Run e2e tests
   e2e:
-    outputs:
-      status: ${{ steps.status.outputs.status }}
     needs: [ "validate", "token", "find-tf-releases", "list-examples" ]
     runs-on: k8s-large
     environment: default
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -167,21 +164,11 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> "${GITHUB_OUTPUT}"
-          exit 1
-
   # Run e2e tests
   upgrade:
-    outputs:
-      status: ${{ steps.status.outputs.status }}
-    needs: [ "validate", "token", "find-tf-releases", "list-examples", "e2e", "import" ]
+    needs: [ "validate", "token", "find-tf-releases", "list-examples" ]
     runs-on: k8s-large
     environment: default
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -247,12 +234,6 @@ jobs:
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> "${GITHUB_OUTPUT}"
-          exit 1
 
   # Run import tests
   import:
@@ -260,7 +241,6 @@ jobs:
       status: ${{ steps.status.outputs.status }}
     needs: [ "token", "find-tf-releases" , "e2e"]
     runs-on: k8s-large
-    continue-on-error: true
     permissions:
       id-token: write
     strategy:
@@ -269,11 +249,22 @@ jobs:
       matrix:
         tf_release: ${{ fromJSON(needs.find-tf-releases.outputs.releases) }}
         cloud_provider: [ "aws", "azure", "gcp" ]
+        test_name : ["generic"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Generate service name
+        uses: ./.github/actions/generate-service-name
+        id: service_name
+        with:
+          test_type: import
+          test_name: ${{ matrix.test_name }}
+          tf_release: ${{ matrix.tf_release }}
+          cloud_provider: ${{ matrix.cloud_provider }}
+          token: ${{ needs.token.outputs.token }}
 
       - name: Get API details for env
         id: credentials
@@ -293,26 +284,20 @@ jobs:
           organization_id: ${{ steps.credentials.outputs.organization_id }}
           token_key: ${{ steps.credentials.outputs.api_key_id }}
           token_secret: ${{ steps.credentials.outputs.api_key_secret }}
-          resource_name: "[import]-${{ matrix.tf_release }}-${{ matrix.cloud_provider }}-${{ needs.token.outputs.token }}"
+          service_name: ${{steps.service_name.outputs.service_name}}
           tf_release: ${{ matrix.tf_release }}
           cloud_provider: ${{ matrix.cloud_provider }}
           region: ${{ steps.credentials.outputs.region }}
 
-      - name: Mark error
-        id: status
-        if: failure()
-        run: |
-          echo "status=failure" >> "${GITHUB_OUTPUT}"
-          exit 1
 
   report:
     runs-on: k8s-nano
     needs: [ "e2e", "import", "upgrade" ]
-    if: ${{ needs.e2e.outputs.status == 'failure' || needs.import.outputs.status == 'failure' || needs.upgrade.outputs.status == 'failure' }}
+    if: always()
     steps:
       - name: Report Failure on slack
+        if: ${{ needs.e2e.result == 'failure' || needs.import.result == 'failure' || needs.upgrade.result == 'failure' }}
         uses: ravsamhq/notify-slack-action@v2
-        if: ${{ needs.e2e.outputs.status == 'failure' || needs.import.outputs.status == 'failure' || needs.upgrade.outputs.status == 'failure' }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           status: 'failure'
@@ -320,10 +305,6 @@ jobs:
           footer: "{run_url}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-      - name: Report error on github UI
-        if: ${{ needs.e2e.outputs.status == 'failure' || needs.import.outputs.status == 'failure' || needs.upgrade.outputs.status == 'failure' }}
-        run: |
-          exit 1
 
   # Delete any leftover service that might have failed deleting
   cleanup:
@@ -356,7 +337,7 @@ jobs:
   # Bump the provider version in the examples directory
   bump-examples:
     needs: [ "validate", "e2e", "import", "upgrade" ]
-    if: ${{ needs.e2e.outputs.status != 'failure' && needs.import.outputs.status != 'failure' && needs.upgrade.outputs.status != 'failure' }}
+    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
     runs-on: k8s-small
     permissions:
       contents: write
@@ -430,7 +411,7 @@ jobs:
       contents: write
       pull-requests: write
     needs: [ "e2e", "import", "upgrade", "bump-examples" ]
-    if: ${{ needs.e2e.outputs.status != 'failure' && needs.import.outputs.status != 'failure' && needs.upgrade.outputs.status != 'failure' }}
+    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -448,7 +429,7 @@ jobs:
       contents: write
     runs-on: k8s-medium
     needs: [ "validate", "tag", "e2e", "import", "upgrade" ]
-    if: ${{ needs.e2e.outputs.status != 'failure' && needs.import.outputs.status != 'failure' && needs.upgrade.outputs.status != 'failure' }}
+    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As the number of end-to-end (E2E) tests increases, the stability of the CI pipeline is decreasing. Test failures often occur for reasons unrelated to Terraform, such as:
	•	Random instance provisioning timeouts
	•	Occasional failures of GitHub runners
	•	Tests being executed across different regions in random rotation, leading to regional issues
	•	etc.

Currently, a single failed test requires rerunning the entire workflow, which makes achieving a “green” pipeline very challenging - especially given the long runtime of each workflow execution, this hurts mostly release workflow

The fix is to add ability to rerun-tests + tuning around

Example of test pipeline: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/17819847509