### PR TITLE
Remove concurrency from terraform provider for clickpipes 

### DIFF
--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -161,7 +161,6 @@ type ClickPipeScalingRequest struct {
 	Replicas             *int64   `json:"replicas,omitempty"`
 	ReplicaCpuMillicores *int64   `json:"replicaCpuMillicores,omitempty"`
 	ReplicaMemoryGb      *float64 `json:"replicaMemoryGb,omitempty"`
-	Concurrency          *int64   `json:"concurrency,omitempty"`
 }
 
 type ClickPipeStateRequest struct {


### PR DESCRIPTION
# Why
We are deprecating the usage of Object Storage concurrency scaling from the scaling endpoint in favor of using the advanced settings endpoint for Object Storage.
# What
This simply removes the concurrency member from the scaling request struct which was used to include it in the request.