### PR TITLE
fix(import-action): always run cleanup

### DIFF
--- a/.github/actions/import/action.yaml
+++ b/.github/actions/import/action.yaml
@@ -139,6 +139,7 @@ runs:
 
     - shell: bash
       name: Terraform destroy
+      if: always()
       env:
         RESOURCE_TYPE: ${{ inputs.resource_type }}
         API_URL: ${{inputs.api_url}}


### PR DESCRIPTION
If the Terraform import failed, Terraform destroy was skipped, forcing us to remove the service externally to retry.