### PR TITLE
feat: tune e2e and release workflows(concurrency, cleanup of private link endpoints in TF org)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,8 @@
 name: E2E tests
 
+concurrency:
+  group: ${{ github.workflow }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,8 @@
 name: Release
 
+concurrency:
+  group: ${{ github.workflow }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Tune e2e and release workflows:

1. Set concurrency to 1 for e2e and release workflows due to exceeding rate limit and simplicity for cleanup of resources
2. Add cleanup of private link endpoints in TF org
