### PR TITLE
Fix: Postgres CDC sensitive attributes and table mappings issues

### DIFF
--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -282,7 +282,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									"credentials": schema.SingleNestedAttribute{
 										MarkdownDescription: "The credentials for the Schema Registry.",
 										Required:            true,
-										Senstive:            true,
+										Sensitive:           true,
 										Attributes: map[string]schema.Attribute{
 											"username": schema.StringAttribute{
 												Description: "The username for the Schema Registry.",


### PR DESCRIPTION
Fixes two related issues with PostgreSQL CDC ClickPipes:
- "Provider produced inconsistent result after apply" error on first apply
- Phantom diffs showing identical table_mappings being removed/re-added

Resolves #428 