### PR TITLE
Add clickpipes secrets to release E2E workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,6 +154,17 @@ jobs:
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          kafka_brokers: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_BROKERS || '' }}
+          kafka_topics: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_TOPICS || '' }}
+          kafka_username: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_USERNAME || '' }}
+          kafka_password: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_PASSWORD || '' }}
+          kinesis_stream_name: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_STREAM_NAME || '' }}
+          kinesis_region: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_REGION || '' }}
+          kinesis_access_key_id: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_ACCESS_KEY_ID || '' }}
+          kinesis_secret_key: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_SECRET_KEY || '' }}
+          s3_bucket_url: ${{ matrix.test.name == 'clickpipes' && secrets.S3_BUCKET_URL || '' }}
+          postgres_host: ${{ matrix.test.name == 'clickpipes' && secrets.POSTGRES_HOST || '' }}
+          postgres_password: ${{ matrix.test.name == 'clickpipes' && secrets.POSTGRES_PASSWORD || '' }}
 
       - name: Cleanup Cloud
         if: always()
@@ -224,6 +235,17 @@ jobs:
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          kafka_brokers: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_BROKERS || '' }}
+          kafka_topics: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_TOPICS || '' }}
+          kafka_username: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_USERNAME || '' }}
+          kafka_password: ${{ matrix.test.name == 'clickpipes' && secrets.KAFKA_PASSWORD || '' }}
+          kinesis_stream_name: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_STREAM_NAME || '' }}
+          kinesis_region: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_REGION || '' }}
+          kinesis_access_key_id: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_ACCESS_KEY_ID || '' }}
+          kinesis_secret_key: ${{ matrix.test.name == 'clickpipes' && secrets.KINESIS_SECRET_KEY || '' }}
+          s3_bucket_url: ${{ matrix.test.name == 'clickpipes' && secrets.S3_BUCKET_URL || '' }}
+          postgres_host: ${{ matrix.test.name == 'clickpipes' && secrets.POSTGRES_HOST || '' }}
+          postgres_password: ${{ matrix.test.name == 'clickpipes' && secrets.POSTGRES_PASSWORD || '' }}
 
       - name: Cleanup Cloud
         if: always()


### PR DESCRIPTION
ClickPipes secrets were already added to the E2E tests but they were missed for the release workflow. This adds them for release workflow as well.