### PR TITLE
Fix issue where provider upgrade script did not upgrade version properly for clickpipes E2E test

### DIFF
--- a/examples/full/clickpipes/aws/provider.tf
+++ b/examples/full/clickpipes/aws/provider.tf
@@ -1,9 +1,8 @@
 # This file is generated automatically please do not edit
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.9.0-alpha1"
+      version = "3.10.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/clickpipes/aws/provider.tf.template.alpha
+++ b/examples/full/clickpipes/aws/provider.tf.template.alpha
@@ -1,8 +1,7 @@
-# This file is generated automatically please do not edit
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.9.0-alpha1"
+      version = "${CLICKHOUSE_TERRAFORM_PROVIDER_VERSION}"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -2575,16 +2575,20 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			settingsModel.SnapshotNumberOfParallelTables = types.Int64Null()
 		}
 
-		// EnableFailoverSlots is Optional+Computed with default=false, so always use API value
+		// EnableFailoverSlots: preserve state/plan value when API doesn't return this field
 		if clickPipe.Source.Postgres.Settings.EnableFailoverSlots != nil {
 			settingsModel.EnableFailoverSlots = types.BoolValue(*clickPipe.Source.Postgres.Settings.EnableFailoverSlots)
+		} else if !stateSettingsModel.EnableFailoverSlots.IsNull() {
+			settingsModel.EnableFailoverSlots = stateSettingsModel.EnableFailoverSlots
 		} else {
 			settingsModel.EnableFailoverSlots = types.BoolNull()
 		}
 
-		// DeleteOnMerge is Optional+Computed with default=false, so always use API value
+		// DeleteOnMerge: preserve state/plan value when API doesn't return this field
 		if clickPipe.Source.Postgres.Settings.DeleteOnMerge != nil {
 			settingsModel.DeleteOnMerge = types.BoolValue(*clickPipe.Source.Postgres.Settings.DeleteOnMerge)
+		} else if !stateSettingsModel.DeleteOnMerge.IsNull() {
+			settingsModel.DeleteOnMerge = stateSettingsModel.DeleteOnMerge
 		} else {
 			settingsModel.DeleteOnMerge = types.BoolNull()
 		}


### PR DESCRIPTION
This was improperly using `provider.tf.template` when it should have been using `provider.tf.template.alpha` for the upgrade script to properly increment the version for the Upgrade test. Also fixes a possible issue with missing values from the API for CDC settings.