### PR TITLE
fix(tags): add to upgraded state data

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -2029,6 +2029,7 @@ func (r *ServiceResource) UpgradeState(ctx context.Context) map[int64]resource.S
 					QueryAPIEndpoints:               priorStateData.QueryAPIEndpoints,
 					BackupConfiguration:             priorStateData.BackupConfiguration,
 					TransparentEncryptionData:       models.TransparentEncryptionData{}.ObjectValue(),
+					Tags:                            types.MapNull(types.StringType),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)


### PR DESCRIPTION
Add tags to `upgradedStateData`.

This fixes plans for services created with a provider version `< 3.0.0` and later upgraded to `> 3.5.4`.

```

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Value Conversion Error
│
│ An unexpected error was encountered while verifying an attribute value matched its expected type to prevent unexpected behavior or panics. This is always an error in the
│ provider. Please report the following to the provider developer:
│
│ Expected framework type from provider logic: types.MapType[basetypes.StringType] / underlying type: tftypes.Map[tftypes.String]
│ Received framework type from provider logic: types.MapType[!!! MISSING TYPE !!!] / underlying type: tftypes.Map[tftypes.DynamicPseudoType]
│ Path: tags
```