### PR TITLE
Add Protobuf format support for Kafka ClickPipes

### DIFF
--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -45,10 +45,14 @@ var ClickPipeStreamingFormats = []string{
 	ClickPipeAvroConfluentFormat,
 }
 
-var (
-	ClickPipeKafkaFormats   = append([]string{}, append(ClickPipeStreamingFormats, ClickPipeProtobufFormat)...)
-	ClickPipeKinesisFormats = ClickPipeStreamingFormats
-)
+var ClickPipeKafkaFormats = []string{
+	ClickPipeJSONEachRowFormat,
+	ClickPipeAvroFormat,
+	ClickPipeAvroConfluentFormat,
+	ClickPipeProtobufFormat,
+}
+
+var ClickPipeKinesisFormats = ClickPipeStreamingFormats
 
 const (
 	ClickPipeAuthenticationIAMRole          = "IAM_ROLE"


### PR DESCRIPTION
- Added `Protobuf` to the list of supported Kafka formats

Related to https://linear.app/clickhouse/issue/CLP-756/