### PR TITLE
Revert "Bump provider version in examples to 3.14.0"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ then a manual process is required after the upgrade. Please visit [https://githu
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/bigquery_snapshot/provider.tf
+++ b/examples/clickpipe/bigquery_snapshot/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/cdc_postgres/provider.tf
+++ b/examples/clickpipe/cdc_postgres/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/externally_managed_table/provider.tf
+++ b/examples/clickpipe/externally_managed_table/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_azure_eventhub/provider.tf
+++ b/examples/clickpipe/kafka_azure_eventhub/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_confluent/provider.tf
+++ b/examples/clickpipe/kafka_confluent/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_msk_iam_role/provider.tf
+++ b/examples/clickpipe/kafka_msk_iam_role/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_msk_iam_user/provider.tf
+++ b/examples/clickpipe/kafka_msk_iam_user/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_offset_strategy/provider.tf
+++ b/examples/clickpipe/kafka_offset_strategy/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_redpanda_scram/provider.tf
+++ b/examples/clickpipe/kafka_redpanda_scram/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kafka_schema_registry/provider.tf
+++ b/examples/clickpipe/kafka_schema_registry/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kinesis_iam_role/provider.tf
+++ b/examples/clickpipe/kinesis_iam_role/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/kinesis_iam_user/provider.tf
+++ b/examples/clickpipe/kinesis_iam_user/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/multiple_pipes_example/provider.tf
+++ b/examples/clickpipe/multiple_pipes_example/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_azure_blob/provider.tf
+++ b/examples/clickpipe/object_storage_azure_blob/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_gcs_pubsub_service_account/provider.tf
+++ b/examples/clickpipe/object_storage_gcs_pubsub_service_account/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.11.1-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_iam_role/provider.tf
+++ b/examples/clickpipe/object_storage_iam_role/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_iam_user/provider.tf
+++ b/examples/clickpipe/object_storage_iam_user/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_s3_sqs_iam_role/provider.tf
+++ b/examples/clickpipe/object_storage_s3_sqs_iam_role/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/object_storage_s3_sqs_iam_user/provider.tf
+++ b/examples/clickpipe/object_storage_s3_sqs_iam_user/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/reverse_private_endpoint_msk/provider.tf
+++ b/examples/clickpipe/reverse_private_endpoint_msk/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/reverse_private_endpoint_msk_pipe/provider.tf
+++ b/examples/clickpipe/reverse_private_endpoint_msk_pipe/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/reverse_private_endpoint_vpc_resource/provider.tf
+++ b/examples/clickpipe/reverse_private_endpoint_vpc_resource/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/reverse_private_endpoint_vpce_service/provider.tf
+++ b/examples/clickpipe/reverse_private_endpoint_vpce_service/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/clickpipe/service_and_clickpipe/provider.tf
+++ b/examples/clickpipe/service_and_clickpipe/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/basic/aws/provider.tf
+++ b/examples/full/basic/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/basic/azure/provider.tf
+++ b/examples/full/basic/azure/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/basic/gcp/provider.tf
+++ b/examples/full/basic/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/clickpipes/aws/provider.tf
+++ b/examples/full/clickpipes/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.13.0-alpha1"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/hipaa/aws/provider.tf
+++ b/examples/full/hipaa/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/hipaa/gcp/provider.tf
+++ b/examples/full/hipaa/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/organization_settings/aws/provider.tf
+++ b/examples/full/organization_settings/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/pci/aws/provider.tf
+++ b/examples/full/pci/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/pci/gcp/provider.tf
+++ b/examples/full/pci/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/private_endpoint/aws/provider.tf
+++ b/examples/full/private_endpoint/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/private_endpoint/azure/provider.tf
+++ b/examples/full/private_endpoint/azure/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/tde/aws/provider.tf
+++ b/examples/full/tde/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/tde/gcp/provider.tf
+++ b/examples/full/tde/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/warehouse/aws/provider.tf
+++ b/examples/full/warehouse/aws/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/tests/import/service/provider.tf
+++ b/tests/import/service/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.14.0"
+      version = "3.12.0"
       source  = "ClickHouse/clickhouse"
     }
   }


### PR DESCRIPTION
This reverts commit da5aa794cd0b82c9b059ce93c3a2f7ce8e139370.

versions were improperly bumped up due to the gorelease failing after the bump had already happened. Need to revert and run the release again.