### PR TITLE
feat: add GCP PSC Service Attachment support for RPEs

### DIFF
--- a/docs/resources/clickpipes_reverse_private_endpoint.md
+++ b/docs/resources/clickpipes_reverse_private_endpoint.md
@@ -4,7 +4,7 @@ page_title: "clickhouse_clickpipes_reverse_private_endpoint Resource - clickhous
 subcategory: ""
 description: |-
   You can use the clickhouse_clickpipes_reverse_private_endpoint resource to create and manage reverse private endpoints for secure ClickPipes data source connections in ClickHouse Cloud.
-  Supported endpoint types: VPC_ENDPOINT_SERVICE, VPC_RESOURCE, and MSK_MULTI_VPC.
+  Supported endpoint types: VPC_ENDPOINT_SERVICE, VPC_RESOURCE, MSK_MULTI_VPC, and GCP_PSC_SERVICE_ATTACHMENT.
   ~> Note: All fields on this resource are immutable after creation. Any change will force replacement (destroy and recreate).
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 You can use the *clickhouse_clickpipes_reverse_private_endpoint* resource to create and manage reverse private endpoints for secure ClickPipes data source connections in ClickHouse Cloud.
 
-Supported endpoint types: `VPC_ENDPOINT_SERVICE`, `VPC_RESOURCE`, and `MSK_MULTI_VPC`.
+Supported endpoint types: `VPC_ENDPOINT_SERVICE`, `VPC_RESOURCE`, `MSK_MULTI_VPC`, and `GCP_PSC_SERVICE_ATTACHMENT`.
 
 ~> **Note:** All fields on this resource are immutable after creation. Any change will force replacement (destroy and recreate).
 

--- a/docs/resources/clickpipes_reverse_private_endpoint.md
+++ b/docs/resources/clickpipes_reverse_private_endpoint.md
@@ -50,10 +50,11 @@ resource "clickhouse_clickpipes_reverse_private_endpoint" "msk_multi_vpc" {
 
 - `description` (String) Description of the reverse private endpoint
 - `service_id` (String) The ID of the ClickHouse service to associate with this reverse private endpoint
-- `type` (String) Type of the reverse private endpoint (VPC_ENDPOINT_SERVICE, VPC_RESOURCE, or MSK_MULTI_VPC)
+- `type` (String) Type of the reverse private endpoint (VPC_ENDPOINT_SERVICE, VPC_RESOURCE, MSK_MULTI_VPC, or GCP_PSC_SERVICE_ATTACHMENT)
 
 ### Optional
 
+- `gcp_service_attachment` (String) GCP PSC service attachment URI, required for GCP_PSC_SERVICE_ATTACHMENT type. Format: projects/{project}/regions/{region}/serviceAttachments/{name}
 - `msk_authentication` (String) MSK cluster authentication type (SASL_IAM or SASL_SCRAM), required for MSK_MULTI_VPC type
 - `msk_cluster_arn` (String) MSK cluster ARN, required for MSK_MULTI_VPC type
 - `vpc_endpoint_service_name` (String) VPC endpoint service name, required for VPC_ENDPOINT_SERVICE type

--- a/pkg/internal/api/clickpipe_reverse_private_endpoint.go
+++ b/pkg/internal/api/clickpipe_reverse_private_endpoint.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	ReversePrivateEndpointTypeVPCEndpointService = "VPC_ENDPOINT_SERVICE"
-	ReversePrivateEndpointTypeVPCResource        = "VPC_RESOURCE"
-	ReversePrivateEndpointTypeMSKMultiVPC        = "MSK_MULTI_VPC"
+	ReversePrivateEndpointTypeVPCEndpointService      = "VPC_ENDPOINT_SERVICE"
+	ReversePrivateEndpointTypeVPCResource             = "VPC_RESOURCE"
+	ReversePrivateEndpointTypeMSKMultiVPC             = "MSK_MULTI_VPC"
+	ReversePrivateEndpointTypeGcpPscServiceAttachment = "GCP_PSC_SERVICE_ATTACHMENT"
 )
 
 const (
@@ -38,6 +39,7 @@ var (
 		ReversePrivateEndpointTypeVPCEndpointService,
 		ReversePrivateEndpointTypeVPCResource,
 		ReversePrivateEndpointTypeMSKMultiVPC,
+		ReversePrivateEndpointTypeGcpPscServiceAttachment,
 	}
 
 	MSKAuthenticationTypes = []string{

--- a/pkg/internal/api/clickpipe_reverse_private_endpoint_models.go
+++ b/pkg/internal/api/clickpipe_reverse_private_endpoint_models.go
@@ -21,4 +21,5 @@ type CreateReversePrivateEndpoint struct {
 	VPCResourceShareArn        *string `json:"vpcResourceShareArn,omitempty"`
 	MSKClusterArn              *string `json:"mskClusterArn,omitempty"`
 	MSKAuthentication          *string `json:"mskAuthentication,omitempty"`
+	GcpServiceAttachment       *string `json:"gcpServiceAttachment,omitempty"`
 }

--- a/pkg/resource/clickpipe_reverse_private_endpoint.go
+++ b/pkg/resource/clickpipe_reverse_private_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -122,6 +123,12 @@ func (r *ClickPipeReversePrivateEndpointResource) Schema(ctx context.Context, re
 			"gcp_service_attachment": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "GCP PSC service attachment URI, required for GCP_PSC_SERVICE_ATTACHMENT type. Format: projects/{project}/regions/{region}/serviceAttachments/{name}",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^projects/[^/]+/regions/[^/]+/serviceAttachments/[^/]+$`),
+						"must be in the format projects/{project}/regions/{region}/serviceAttachments/{name}",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/pkg/resource/clickpipe_reverse_private_endpoint.go
+++ b/pkg/resource/clickpipe_reverse_private_endpoint.go
@@ -73,7 +73,7 @@ func (r *ClickPipeReversePrivateEndpointResource) Schema(ctx context.Context, re
 			},
 			"type": schema.StringAttribute{
 				Required:            true,
-				MarkdownDescription: "Type of the reverse private endpoint (VPC_ENDPOINT_SERVICE, VPC_RESOURCE, or MSK_MULTI_VPC)",
+				MarkdownDescription: "Type of the reverse private endpoint (VPC_ENDPOINT_SERVICE, VPC_RESOURCE, MSK_MULTI_VPC, or GCP_PSC_SERVICE_ATTACHMENT)",
 				Validators: []validator.String{
 					stringvalidator.OneOf(api.ReversePrivateEndpointTypes...),
 				},
@@ -115,6 +115,13 @@ func (r *ClickPipeReversePrivateEndpointResource) Schema(ctx context.Context, re
 				Validators: []validator.String{
 					stringvalidator.OneOf(api.MSKAuthenticationTypes...),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"gcp_service_attachment": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "GCP PSC service attachment URI, required for GCP_PSC_SERVICE_ATTACHMENT type. Format: projects/{project}/regions/{region}/serviceAttachments/{name}",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -196,6 +203,14 @@ func (r *ClickPipeReversePrivateEndpointResource) Create(ctx context.Context, re
 			)
 			return
 		}
+	case api.ReversePrivateEndpointTypeGcpPscServiceAttachment:
+		if data.GcpServiceAttachment.IsNull() {
+			resp.Diagnostics.AddError(
+				"Missing required field",
+				"gcp_service_attachment is required when type is GCP_PSC_SERVICE_ATTACHMENT",
+			)
+			return
+		}
 	}
 
 	createReq := api.CreateReversePrivateEndpoint{
@@ -223,6 +238,10 @@ func (r *ClickPipeReversePrivateEndpointResource) Create(ctx context.Context, re
 	if !data.MSKAuthentication.IsNull() {
 		value := data.MSKAuthentication.ValueString()
 		createReq.MSKAuthentication = &value
+	}
+	if !data.GcpServiceAttachment.IsNull() {
+		value := data.GcpServiceAttachment.ValueString()
+		createReq.GcpServiceAttachment = &value
 	}
 
 	// Create new reverse private endpoint
@@ -283,6 +302,12 @@ func (r *ClickPipeReversePrivateEndpointResource) Create(ctx context.Context, re
 		data.MSKAuthentication = types.StringValue(*endpoint.MSKAuthentication)
 	} else {
 		data.MSKAuthentication = types.StringNull()
+	}
+
+	if endpoint.GcpServiceAttachment != nil {
+		data.GcpServiceAttachment = types.StringValue(*endpoint.GcpServiceAttachment)
+	} else {
+		data.GcpServiceAttachment = types.StringNull()
 	}
 
 	// Convert string slices to Terraform list values
@@ -362,6 +387,12 @@ func (r *ClickPipeReversePrivateEndpointResource) Read(ctx context.Context, req 
 		data.MSKAuthentication = types.StringValue(*endpoint.MSKAuthentication)
 	} else {
 		data.MSKAuthentication = types.StringNull()
+	}
+
+	if endpoint.GcpServiceAttachment != nil {
+		data.GcpServiceAttachment = types.StringValue(*endpoint.GcpServiceAttachment)
+	} else {
+		data.GcpServiceAttachment = types.StringNull()
 	}
 
 	// Convert string slices to Terraform list values

--- a/pkg/resource/clickpipe_reverse_private_endpoint_test.go
+++ b/pkg/resource/clickpipe_reverse_private_endpoint_test.go
@@ -41,6 +41,9 @@ func TestClickPipeReversePrivateEndpointResource_Schema(t *testing.T) {
 	if attr.Computed {
 		t.Error("Expected gcp_service_attachment to not be Computed")
 	}
+	if len(attr.Validators) != 1 {
+		t.Errorf("Expected gcp_service_attachment to have 1 validator, got %d", len(attr.Validators))
+	}
 
 	if !slices.Contains(api.ReversePrivateEndpointTypes, api.ReversePrivateEndpointTypeGcpPscServiceAttachment) {
 		t.Error("Expected ReversePrivateEndpointTypes to contain GCP_PSC_SERVICE_ATTACHMENT")

--- a/pkg/resource/clickpipe_reverse_private_endpoint_test.go
+++ b/pkg/resource/clickpipe_reverse_private_endpoint_test.go
@@ -1,0 +1,48 @@
+package resource
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
+)
+
+func TestClickPipeReversePrivateEndpointResource_Schema(t *testing.T) {
+	r := &ClickPipeReversePrivateEndpointResource{}
+	req := resource.SchemaRequest{}
+	resp := &resource.SchemaResponse{}
+
+	r.Schema(context.Background(), req, resp)
+
+	if resp.Schema.Attributes == nil {
+		t.Fatal("Expected schema attributes to be set")
+	}
+
+	for _, name := range []string{"id", "service_id", "type", "description", "gcp_service_attachment", "msk_cluster_arn"} {
+		if _, ok := resp.Schema.Attributes[name]; !ok {
+			t.Errorf("Expected %q attribute in schema", name)
+		}
+	}
+
+	attr, ok := resp.Schema.Attributes["gcp_service_attachment"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("Expected gcp_service_attachment to be a StringAttribute, got %T", resp.Schema.Attributes["gcp_service_attachment"])
+	}
+	if !attr.Optional {
+		t.Error("Expected gcp_service_attachment to be Optional")
+	}
+	if attr.Required {
+		t.Error("Expected gcp_service_attachment to not be Required")
+	}
+	if attr.Computed {
+		t.Error("Expected gcp_service_attachment to not be Computed")
+	}
+
+	if !slices.Contains(api.ReversePrivateEndpointTypes, api.ReversePrivateEndpointTypeGcpPscServiceAttachment) {
+		t.Error("Expected ReversePrivateEndpointTypes to contain GCP_PSC_SERVICE_ATTACHMENT")
+	}
+}

--- a/pkg/resource/descriptions/clickpipes_reverse_private_endpoint.md
+++ b/pkg/resource/descriptions/clickpipes_reverse_private_endpoint.md
@@ -1,5 +1,5 @@
 You can use the *clickhouse_clickpipes_reverse_private_endpoint* resource to create and manage reverse private endpoints for secure ClickPipes data source connections in ClickHouse Cloud.
 
-Supported endpoint types: `VPC_ENDPOINT_SERVICE`, `VPC_RESOURCE`, and `MSK_MULTI_VPC`.
+Supported endpoint types: `VPC_ENDPOINT_SERVICE`, `VPC_RESOURCE`, `MSK_MULTI_VPC`, and `GCP_PSC_SERVICE_ATTACHMENT`.
 
 ~> **Note:** All fields on this resource are immutable after creation. Any change will force replacement (destroy and recreate).

--- a/pkg/resource/models/clickpipe_reverse_private_endpoint_resource.go
+++ b/pkg/resource/models/clickpipe_reverse_private_endpoint_resource.go
@@ -15,6 +15,7 @@ type ClickPipeReversePrivateEndpointResourceModel struct {
 	VPCResourceShareArn        types.String `tfsdk:"vpc_resource_share_arn"`
 	MSKClusterArn              types.String `tfsdk:"msk_cluster_arn"`
 	MSKAuthentication          types.String `tfsdk:"msk_authentication"`
+	GcpServiceAttachment       types.String `tfsdk:"gcp_service_attachment"`
 	EndpointID                 types.String `tfsdk:"endpoint_id"`
 	DNSNames                   types.List   `tfsdk:"dns_names"`
 	PrivateDNSNames            types.List   `tfsdk:"private_dns_names"`


### PR DESCRIPTION
## Summary

- Add `GCP_PSC_SERVICE_ATTACHMENT` as a supported type for `clickhouse_clickpipes_reverse_private_endpoint`, with a new optional `gcp_service_attachment`
  attribute (format: `projects/{project}/regions/{region}/serviceAttachments/{name}`).
- Update the embedded resource description and generated docs to list the new type.
- Add a schema unit test to guard the attribute and the extended type enum against regressions.