### PR TITLE
fix: remove state validation error for backup_configuration with warehouse_id

### DIFF
--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -966,12 +966,11 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 				"backup_configuration cannot be specified when warehouse_id is set",
 			)
 		}
-		if !state.BackupConfiguration.IsNull() {
-			resp.Diagnostics.AddError(
-				"Invalid state for service",
-				"backup_configuration cannot co-exist in terraform state for a service with data_warehouse_id set",
-			)
-		}
+		// Silently nullify backup_configuration in the plan when warehouse_id is set.
+		// The provider's GetService fetches backupConfiguration for all primary services
+		// and stores it in state, even for warehouse-attached services where it's managed
+		// at the warehouse level. Rather than erroring on provider-populated state, we
+		// just ensure it doesn't persist in the plan going forward.
 		plan.BackupConfiguration = types.ObjectNull(models.BackupConfiguration{}.ObjectType().AttrTypes)
 		resp.Plan.Set(ctx, plan)
 	}


### PR DESCRIPTION
## Problem

Every `terraform plan`/`terraform apply` fails on standalone services after initial creation or import:

```
Error: Invalid state for service - backup_configuration cannot co-exist
in terraform state for a service with data_warehouse_id set
```

This affects **every standalone service** because:
1. `GetService` in `pkg/internal/api/service.go:54-61` fetches `backupConfiguration` from the separate `/backupConfiguration` API endpoint for all primary services and stores it in state
2. Every standalone service has an auto-created `warehouse_id` (from the main service API's `dataWarehouseId` field)
3. The `ModifyPlan` validator on line 969-973 rejects `backupConfiguration` in state when `warehouse_id` is present

## Fix

Remove the state validation error (lines 969-973). The plan nullification on line 975 already handles the cleanup correctly — it sets `backupConfiguration` to null in the plan, ensuring it won't persist going forward.

The config validation (lines 963-967) is preserved — users still can't explicitly specify both `backup_configuration` and `warehouse_id` in their Terraform code. Only the provider-populated state is affected.

## Verification

The main service API does NOT return `backupConfiguration` — it's fetched separately by the provider:

```bash
# Main API - no backupConfiguration in response
curl -u "$KEY:$SECRET" "https://api.clickhouse.cloud/v1/organizations/$ORG/services/$SVC" \
  | jq '.result | keys'

# Separate endpoint - returns backup config
curl -u "$KEY:$SECRET" \
  "https://api.clickhouse.cloud/v1/organizations/$ORG/services/$SVC/backupConfiguration"
# Returns: {"result": {"backupPeriodInHours": 24, "backupRetentionPeriodInHours": 24}}
```

The provider merges both into state, then its own validator rejects the combination.

Fixes #514