### PR TITLE
fix(claude-permissions): revert read and write scoping

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -88,7 +88,7 @@ jobs:
                 "LANGFUSE_BASE_URL": "${{ secrets.LANGFUSE_BASE_URL }}"
               }
             }
-          claude_args: --allowedTools "Read(pkg/**),Read(/tmp/**),Write(/tmp/release-notes.md),Bash(gh pr view:*),Bash(gh release view:*),Bash(gh release list:*)"
+          claude_args: --allowedTools "Read,Write,Bash(gh pr view:*),Bash(gh release view:*),Bash(gh release list:*)"
           prompt: |
             REPO: ${{ github.repository }}
             VERSION: ${{ inputs.tag || github.ref_name }}


### PR DESCRIPTION
After a change to Claude's permissions made in this [PR](https://github.com/ClickHouse/terraform-provider-clickhouse/pull/502/changes), it stopped working. The Agent SDK doesn't support the current scoping implementation.

We saw an error caused by this change here: https://github.com/ClickHouse/terraform-provider-clickhouse/actions/runs/24249565710/job/70816416070