### PR TITLE
feat(api-env-vars): support CLICKHOUSE_CLOUD_API_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Please refer to the [official docs](https://registry.terraform.io/providers/Clic
 
 ## Breaking changes and deprecations
 
+### Upgrading to version >= 3.15.0
+
+In version 3.15.0 we deprecated the `CLICKHOUSE_TOKEN_KEY` and `CLICKHOUSE_TOKEN_SECRET` environment variables in favor of `CLICKHOUSE_CLOUD_API_KEY` and `CLICKHOUSE_CLOUD_API_SECRET`. The new names align with how API credentials are referred to in the [ClickHouse Cloud UI](https://clickhouse.cloud/) and the [OpenAPI docs](https://clickhouse.com/docs/en/cloud/manage/openapi).
+
+You can keep using the old env vars, but they will be removed in a future release. If both are set, the new ones take precedence.
+
+| Old (deprecated)          | New                           |
+|---------------------------|-------------------------------|
+| `CLICKHOUSE_TOKEN_KEY`    | `CLICKHOUSE_CLOUD_API_KEY`    |
+| `CLICKHOUSE_TOKEN_SECRET` | `CLICKHOUSE_CLOUD_API_SECRET` |
+
 ### Upgrading to version >= 3.2.0
 
 In version 3.2.0 we introduced a change in the `Private Endpoints` feature that requires a change on your side if you use this setting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,5 +91,5 @@ provider "clickhouse" {
 - `api_url` (String) API URL of the ClickHouse OpenAPI the provider will interact with. Alternatively, can be configured using the `CLICKHOUSE_API_URL` environment variable. Only specify if you have a specific deployment of the ClickHouse OpenAPI you want to run against.
 - `organization_id` (String) ID of the organization the provider will create services under. Alternatively, can be configured using the `CLICKHOUSE_ORG_ID` environment variable.
 - `timeout_seconds` (Number) Timeout in seconds for the HTTP client.
-- `token_key` (String) Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_KEY` environment variable.
-- `token_secret` (String, Sensitive) Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_SECRET` environment variable.
+- `token_key` (String) Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_CLOUD_API_KEY` environment variable.
+- `token_secret` (String, Sensitive) Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_CLOUD_API_SECRET` environment variable.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"cmp"
 	"context"
 	_ "embed"
 	"os"
@@ -64,11 +65,11 @@ func (p *clickhouseProvider) Schema(_ context.Context, _ provider.SchemaRequest,
 				Optional:    true,
 			},
 			"token_key": schema.StringAttribute{
-				Description: "Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_KEY` environment variable.",
+				Description: "Token key of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_CLOUD_API_KEY` environment variable.",
 				Optional:    true,
 			},
 			"token_secret": schema.StringAttribute{
-				Description: "Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_TOKEN_SECRET` environment variable.",
+				Description: "Token secret of the key/secret pair. Used to authenticate with OpenAPI. Alternatively, can be configured using the `CLICKHOUSE_CLOUD_API_SECRET` environment variable.",
 				Optional:    true,
 				Sensitive:   true,
 			},
@@ -117,7 +118,7 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 			path.Root("token_key"),
 			"Unknown ClickHouse OpenAPI Token Key",
 			"The provider cannot create the ClickHouse OpenAPI client as there is an unknown configuration value for the token key. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the CLICKHOUSE_TOKEN_KEY environment variable.",
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the CLICKHOUSE_CLOUD_API_KEY environment variable.",
 		)
 	}
 
@@ -126,7 +127,7 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 			path.Root("token_secret"),
 			"Unknown ClickHouse OpenAPI Token Secret",
 			"The provider cannot create the ClickHouse OpenAPI client as there is an unknown configuration value for the token secret. "+
-				"Either target apply the source of the value first, set the value statically in the configuration, or use the CLICKHOUSE_TOKEN_SECRET environment variable.",
+				"Either target apply the source of the value first, set the value statically in the configuration, or use the CLICKHOUSE_CLOUD_API_SECRET environment variable.",
 		)
 	}
 
@@ -139,8 +140,16 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 
 	apiUrl := os.Getenv("CLICKHOUSE_API_URL")
 	organizationId := os.Getenv("CLICKHOUSE_ORG_ID")
-	tokenKey := os.Getenv("CLICKHOUSE_TOKEN_KEY")
-	tokenSecret := os.Getenv("CLICKHOUSE_TOKEN_SECRET")
+	// Read credentials from env: prefer new CLICKHOUSE_CLOUD_API_{KEY,SECRET},
+	// fall back to legacy CLICKHOUSE_TOKEN_{KEY,SECRET}.
+	tokenKey := cmp.Or(
+		os.Getenv("CLICKHOUSE_CLOUD_API_KEY"),
+		os.Getenv("CLICKHOUSE_TOKEN_KEY"),
+	)
+	tokenSecret := cmp.Or(
+		os.Getenv("CLICKHOUSE_CLOUD_API_SECRET"),
+		os.Getenv("CLICKHOUSE_TOKEN_SECRET"),
+	)
 
 	if !config.ApiUrl.IsNull() {
 		apiUrl = config.ApiUrl.ValueString()
@@ -200,7 +209,7 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 				path.Root("token_key"),
 				"Missing ClickHouse OpenAPI Token Key",
 				"The provider cannot create the ClickHouse OpenAPI client: missing or empty value for the token key. "+
-					"Set the token_key value in the configuration or use the CLICKHOUSE_TOKEN_KEY environment variable. "+
+					"Set the token_key value in the configuration or use the CLICKHOUSE_CLOUD_API_KEY environment variable. "+
 					"If either is already set, ensure the value is not empty.",
 			)
 		}
@@ -211,9 +220,9 @@ func (p *clickhouseProvider) Configure(ctx context.Context, req provider.Configu
 		if tokenSecret == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("token_secret"),
-				"Missing ClickHouse OpenAPI Token Key",
+				"Missing ClickHouse OpenAPI Token Secret",
 				"The provider cannot create the ClickHouse OpenAPI client: missing or empty value for the token secret. "+
-					"Set the token_secret value in the configuration or use the CLICKHOUSE_TOKEN_SECRET environment variable. "+
+					"Set the token_secret value in the configuration or use the CLICKHOUSE_CLOUD_API_SECRET environment variable. "+
 					"If either is already set, ensure the value is not empty.",
 			)
 		}


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/terraform-provider-clickhouse/issues/508

In a future iteration, we can accept `api_key` and `api_secret` in addition to the env vars.