### PR TITLE
feat: add clickhouse_service_upgrade_window resource

### DIFF
--- a/examples/full/upgrade_window/aws/README.md
+++ b/examples/full/upgrade_window/aws/README.md
@@ -1,0 +1,13 @@
+## AWS upgrade-window example
+
+The Terraform code deploys the following resources:
+- 1 ClickHouse service on AWS
+- 1 upgrade window pinned to Wednesday at 12:00 UTC
+
+> **Note:** Scheduled upgrades is a beta feature. The organization must have the `canUseScheduledUpgrades` feature enabled, and the upgrade window can only be set on primary services.
+
+## How to run
+
+- Rename `variables.tfvars.sample` to `variables.tfvars` and fill in all needed data.
+- Run `terraform init`
+- Run `terraform <plan|apply> -var-file=variables.tfvars`

--- a/examples/full/upgrade_window/aws/main.tf
+++ b/examples/full/upgrade_window/aws/main.tf
@@ -1,0 +1,76 @@
+variable "organization_id" {
+  type = string
+}
+
+variable "token_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "token_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "service_name" {
+  type    = string
+  default = "My Terraform Service"
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-2"
+}
+
+variable "release_channel" {
+  type    = string
+  default = "default"
+  validation {
+    condition     = contains(["default", "fast", "slow"], var.release_channel)
+    error_message = "Release channel can be 'default', 'fast' or 'slow'."
+  }
+}
+
+resource "clickhouse_service" "service" {
+  name                 = var.service_name
+  cloud_provider       = "aws"
+  region               = var.region
+  release_channel      = var.release_channel
+  idle_scaling         = true
+  idle_timeout_minutes = 5
+  password_hash        = "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=" # base64 encoded sha256 hash of "test"
+
+  ip_access = [
+    {
+      source      = "0.0.0.0"
+      description = "Anywhere"
+    }
+  ]
+
+  min_replica_memory_gb = 8
+  max_replica_memory_gb = 120
+
+  backup_configuration = {
+    backup_period_in_hours           = 24
+    backup_retention_period_in_hours = 24
+    backup_start_time                = null
+  }
+}
+
+resource "clickhouse_service_upgrade_window" "window" {
+  service_id     = clickhouse_service.service.id
+  weekday        = 3 # Wednesday
+  start_hour_utc = 12
+}
+
+output "service_endpoints" {
+  value = clickhouse_service.service.endpoints
+}
+
+output "service_iam" {
+  value = clickhouse_service.service.iam_role
+}
+
+output "upgrade_window_duration" {
+  value = clickhouse_service_upgrade_window.window.duration
+}

--- a/examples/full/upgrade_window/aws/provider.tf
+++ b/examples/full/upgrade_window/aws/provider.tf
@@ -1,0 +1,15 @@
+# This file is generated automatically please do not edit
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "3.15.0-alpha2"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/full/upgrade_window/aws/provider.tf.template.alpha
+++ b/examples/full/upgrade_window/aws/provider.tf.template.alpha
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "${CLICKHOUSE_TERRAFORM_PROVIDER_VERSION}"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/full/upgrade_window/aws/variables.tfvars.sample
+++ b/examples/full/upgrade_window/aws/variables.tfvars.sample
@@ -1,0 +1,4 @@
+# these keys are for example only and won't work when pointed to a deployed ClickHouse OpenAPI server
+organization_id = "aee076c1-3f83-4637-95b1-ad5a0a825b71"
+token_key       = "avhj1U5QCdWAE9CA9"
+token_secret    = "4b1dROiHQEuSXJHlV8zHFd0S7WQj7CGxz5kGJeJnca"

--- a/examples/resources/clickhouse_service_upgrade_window/import.sh
+++ b/examples/resources/clickhouse_service_upgrade_window/import.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Upgrade window can be imported by specifying the service ID.
+terraform import clickhouse_service_upgrade_window.example xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/examples/resources/clickhouse_service_upgrade_window/resource.tf
+++ b/examples/resources/clickhouse_service_upgrade_window/resource.tf
@@ -1,0 +1,9 @@
+resource "clickhouse_service" "svc" {
+  ...
+}
+
+resource "clickhouse_service_upgrade_window" "example" {
+  service_id     = clickhouse_service.svc.id
+  weekday        = 3 # Wednesday
+  start_hour_utc = 12
+}

--- a/pkg/internal/api/client_mock.go
+++ b/pkg/internal/api/client_mock.go
@@ -103,6 +103,13 @@ type ClientMock struct {
 	beforeDeleteServiceCounter uint64
 	DeleteServiceMock          mClientMockDeleteService
 
+	funcDeleteUpgradeWindow          func(ctx context.Context, serviceId string) (err error)
+	funcDeleteUpgradeWindowOrigin    string
+	inspectFuncDeleteUpgradeWindow   func(ctx context.Context, serviceId string)
+	afterDeleteUpgradeWindowCounter  uint64
+	beforeDeleteUpgradeWindowCounter uint64
+	DeleteUpgradeWindowMock          mClientMockDeleteUpgradeWindow
+
 	funcGetApiKeyID          func(ctx context.Context, name *string) (ap1 *ApiKey, err error)
 	funcGetApiKeyIDOrigin    string
 	inspectFuncGetApiKeyID   func(ctx context.Context, name *string)
@@ -207,6 +214,13 @@ type ClientMock struct {
 	afterGetServiceCounter  uint64
 	beforeGetServiceCounter uint64
 	GetServiceMock          mClientMockGetService
+
+	funcGetUpgradeWindow          func(ctx context.Context, serviceId string) (up1 *UpgradeWindow, err error)
+	funcGetUpgradeWindowOrigin    string
+	inspectFuncGetUpgradeWindow   func(ctx context.Context, serviceId string)
+	afterGetUpgradeWindowCounter  uint64
+	beforeGetUpgradeWindowCounter uint64
+	GetUpgradeWindowMock          mClientMockGetUpgradeWindow
 
 	funcListMembers          func(ctx context.Context) (ma1 []Member, err error)
 	funcListMembersOrigin    string
@@ -320,6 +334,13 @@ type ClientMock struct {
 	beforeUpdateServicePasswordCounter uint64
 	UpdateServicePasswordMock          mClientMockUpdateServicePassword
 
+	funcUpdateUpgradeWindow          func(ctx context.Context, serviceId string, u UpgradeWindowUpdate) (up1 *UpgradeWindow, err error)
+	funcUpdateUpgradeWindowOrigin    string
+	inspectFuncUpdateUpgradeWindow   func(ctx context.Context, serviceId string, u UpgradeWindowUpdate)
+	afterUpdateUpgradeWindowCounter  uint64
+	beforeUpdateUpgradeWindowCounter uint64
+	UpdateUpgradeWindowMock          mClientMockUpdateUpgradeWindow
+
 	funcWaitForClickPipeCdcScaling          func(ctx context.Context, serviceId string, expectedCpuMillicores int64, expectedMemoryGb float64, maxElapsedTime time.Duration) (cp1 *ClickPipeCdcScaling, err error)
 	funcWaitForClickPipeCdcScalingOrigin    string
 	inspectFuncWaitForClickPipeCdcScaling   func(ctx context.Context, serviceId string, expectedCpuMillicores int64, expectedMemoryGb float64, maxElapsedTime time.Duration)
@@ -393,6 +414,9 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 	m.DeleteServiceMock = mClientMockDeleteService{mock: m}
 	m.DeleteServiceMock.callArgs = []*ClientMockDeleteServiceParams{}
 
+	m.DeleteUpgradeWindowMock = mClientMockDeleteUpgradeWindow{mock: m}
+	m.DeleteUpgradeWindowMock.callArgs = []*ClientMockDeleteUpgradeWindowParams{}
+
 	m.GetApiKeyIDMock = mClientMockGetApiKeyID{mock: m}
 	m.GetApiKeyIDMock.callArgs = []*ClientMockGetApiKeyIDParams{}
 
@@ -437,6 +461,9 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 
 	m.GetServiceMock = mClientMockGetService{mock: m}
 	m.GetServiceMock.callArgs = []*ClientMockGetServiceParams{}
+
+	m.GetUpgradeWindowMock = mClientMockGetUpgradeWindow{mock: m}
+	m.GetUpgradeWindowMock.callArgs = []*ClientMockGetUpgradeWindowParams{}
 
 	m.ListMembersMock = mClientMockListMembers{mock: m}
 	m.ListMembersMock.callArgs = []*ClientMockListMembersParams{}
@@ -485,6 +512,9 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 
 	m.UpdateServicePasswordMock = mClientMockUpdateServicePassword{mock: m}
 	m.UpdateServicePasswordMock.callArgs = []*ClientMockUpdateServicePasswordParams{}
+
+	m.UpdateUpgradeWindowMock = mClientMockUpdateUpgradeWindow{mock: m}
+	m.UpdateUpgradeWindowMock.callArgs = []*ClientMockUpdateUpgradeWindowParams{}
 
 	m.WaitForClickPipeCdcScalingMock = mClientMockWaitForClickPipeCdcScaling{mock: m}
 	m.WaitForClickPipeCdcScalingMock.callArgs = []*ClientMockWaitForClickPipeCdcScalingParams{}
@@ -4829,6 +4859,348 @@ func (m *ClientMock) MinimockDeleteServiceInspect() {
 	if !m.DeleteServiceMock.invocationsDone() && afterDeleteServiceCounter > 0 {
 		m.t.Errorf("Expected %d calls to ClientMock.DeleteService at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.DeleteServiceMock.expectedInvocations), m.DeleteServiceMock.expectedInvocationsOrigin, afterDeleteServiceCounter)
+	}
+}
+
+type mClientMockDeleteUpgradeWindow struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockDeleteUpgradeWindowExpectation
+	expectations       []*ClientMockDeleteUpgradeWindowExpectation
+
+	callArgs []*ClientMockDeleteUpgradeWindowParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ClientMockDeleteUpgradeWindowExpectation specifies expectation struct of the Client.DeleteUpgradeWindow
+type ClientMockDeleteUpgradeWindowExpectation struct {
+	mock               *ClientMock
+	params             *ClientMockDeleteUpgradeWindowParams
+	paramPtrs          *ClientMockDeleteUpgradeWindowParamPtrs
+	expectationOrigins ClientMockDeleteUpgradeWindowExpectationOrigins
+	results            *ClientMockDeleteUpgradeWindowResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ClientMockDeleteUpgradeWindowParams contains parameters of the Client.DeleteUpgradeWindow
+type ClientMockDeleteUpgradeWindowParams struct {
+	ctx       context.Context
+	serviceId string
+}
+
+// ClientMockDeleteUpgradeWindowParamPtrs contains pointers to parameters of the Client.DeleteUpgradeWindow
+type ClientMockDeleteUpgradeWindowParamPtrs struct {
+	ctx       *context.Context
+	serviceId *string
+}
+
+// ClientMockDeleteUpgradeWindowResults contains results of the Client.DeleteUpgradeWindow
+type ClientMockDeleteUpgradeWindowResults struct {
+	err error
+}
+
+// ClientMockDeleteUpgradeWindowOrigins contains origins of expectations of the Client.DeleteUpgradeWindow
+type ClientMockDeleteUpgradeWindowExpectationOrigins struct {
+	origin          string
+	originCtx       string
+	originServiceId string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Optional() *mClientMockDeleteUpgradeWindow {
+	mmDeleteUpgradeWindow.optional = true
+	return mmDeleteUpgradeWindow
+}
+
+// Expect sets up expected params for Client.DeleteUpgradeWindow
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Expect(ctx context.Context, serviceId string) *mClientMockDeleteUpgradeWindow {
+	if mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Set")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation == nil {
+		mmDeleteUpgradeWindow.defaultExpectation = &ClientMockDeleteUpgradeWindowExpectation{}
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation.paramPtrs != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by ExpectParams functions")
+	}
+
+	mmDeleteUpgradeWindow.defaultExpectation.params = &ClientMockDeleteUpgradeWindowParams{ctx, serviceId}
+	mmDeleteUpgradeWindow.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmDeleteUpgradeWindow.expectations {
+		if minimock.Equal(e.params, mmDeleteUpgradeWindow.defaultExpectation.params) {
+			mmDeleteUpgradeWindow.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmDeleteUpgradeWindow.defaultExpectation.params)
+		}
+	}
+
+	return mmDeleteUpgradeWindow
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.DeleteUpgradeWindow
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) ExpectCtxParam1(ctx context.Context) *mClientMockDeleteUpgradeWindow {
+	if mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Set")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation == nil {
+		mmDeleteUpgradeWindow.defaultExpectation = &ClientMockDeleteUpgradeWindowExpectation{}
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation.params != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmDeleteUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockDeleteUpgradeWindowParamPtrs{}
+	}
+	mmDeleteUpgradeWindow.defaultExpectation.paramPtrs.ctx = &ctx
+	mmDeleteUpgradeWindow.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmDeleteUpgradeWindow
+}
+
+// ExpectServiceIdParam2 sets up expected param serviceId for Client.DeleteUpgradeWindow
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) ExpectServiceIdParam2(serviceId string) *mClientMockDeleteUpgradeWindow {
+	if mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Set")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation == nil {
+		mmDeleteUpgradeWindow.defaultExpectation = &ClientMockDeleteUpgradeWindowExpectation{}
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation.params != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmDeleteUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockDeleteUpgradeWindowParamPtrs{}
+	}
+	mmDeleteUpgradeWindow.defaultExpectation.paramPtrs.serviceId = &serviceId
+	mmDeleteUpgradeWindow.defaultExpectation.expectationOrigins.originServiceId = minimock.CallerInfo(1)
+
+	return mmDeleteUpgradeWindow
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.DeleteUpgradeWindow
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Inspect(f func(ctx context.Context, serviceId string)) *mClientMockDeleteUpgradeWindow {
+	if mmDeleteUpgradeWindow.mock.inspectFuncDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("Inspect function is already set for ClientMock.DeleteUpgradeWindow")
+	}
+
+	mmDeleteUpgradeWindow.mock.inspectFuncDeleteUpgradeWindow = f
+
+	return mmDeleteUpgradeWindow
+}
+
+// Return sets up results that will be returned by Client.DeleteUpgradeWindow
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Return(err error) *ClientMock {
+	if mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Set")
+	}
+
+	if mmDeleteUpgradeWindow.defaultExpectation == nil {
+		mmDeleteUpgradeWindow.defaultExpectation = &ClientMockDeleteUpgradeWindowExpectation{mock: mmDeleteUpgradeWindow.mock}
+	}
+	mmDeleteUpgradeWindow.defaultExpectation.results = &ClientMockDeleteUpgradeWindowResults{err}
+	mmDeleteUpgradeWindow.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmDeleteUpgradeWindow.mock
+}
+
+// Set uses given function f to mock the Client.DeleteUpgradeWindow method
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Set(f func(ctx context.Context, serviceId string) (err error)) *ClientMock {
+	if mmDeleteUpgradeWindow.defaultExpectation != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("Default expectation is already set for the Client.DeleteUpgradeWindow method")
+	}
+
+	if len(mmDeleteUpgradeWindow.expectations) > 0 {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("Some expectations are already set for the Client.DeleteUpgradeWindow method")
+	}
+
+	mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow = f
+	mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindowOrigin = minimock.CallerInfo(1)
+	return mmDeleteUpgradeWindow.mock
+}
+
+// When sets expectation for the Client.DeleteUpgradeWindow which will trigger the result defined by the following
+// Then helper
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) When(ctx context.Context, serviceId string) *ClientMockDeleteUpgradeWindowExpectation {
+	if mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("ClientMock.DeleteUpgradeWindow mock is already set by Set")
+	}
+
+	expectation := &ClientMockDeleteUpgradeWindowExpectation{
+		mock:               mmDeleteUpgradeWindow.mock,
+		params:             &ClientMockDeleteUpgradeWindowParams{ctx, serviceId},
+		expectationOrigins: ClientMockDeleteUpgradeWindowExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmDeleteUpgradeWindow.expectations = append(mmDeleteUpgradeWindow.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.DeleteUpgradeWindow return parameters for the expectation previously defined by the When method
+func (e *ClientMockDeleteUpgradeWindowExpectation) Then(err error) *ClientMock {
+	e.results = &ClientMockDeleteUpgradeWindowResults{err}
+	return e.mock
+}
+
+// Times sets number of times Client.DeleteUpgradeWindow should be invoked
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Times(n uint64) *mClientMockDeleteUpgradeWindow {
+	if n == 0 {
+		mmDeleteUpgradeWindow.mock.t.Fatalf("Times of ClientMock.DeleteUpgradeWindow mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmDeleteUpgradeWindow.expectedInvocations, n)
+	mmDeleteUpgradeWindow.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmDeleteUpgradeWindow
+}
+
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) invocationsDone() bool {
+	if len(mmDeleteUpgradeWindow.expectations) == 0 && mmDeleteUpgradeWindow.defaultExpectation == nil && mmDeleteUpgradeWindow.mock.funcDeleteUpgradeWindow == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmDeleteUpgradeWindow.mock.afterDeleteUpgradeWindowCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmDeleteUpgradeWindow.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// DeleteUpgradeWindow implements Client
+func (mmDeleteUpgradeWindow *ClientMock) DeleteUpgradeWindow(ctx context.Context, serviceId string) (err error) {
+	mm_atomic.AddUint64(&mmDeleteUpgradeWindow.beforeDeleteUpgradeWindowCounter, 1)
+	defer mm_atomic.AddUint64(&mmDeleteUpgradeWindow.afterDeleteUpgradeWindowCounter, 1)
+
+	mmDeleteUpgradeWindow.t.Helper()
+
+	if mmDeleteUpgradeWindow.inspectFuncDeleteUpgradeWindow != nil {
+		mmDeleteUpgradeWindow.inspectFuncDeleteUpgradeWindow(ctx, serviceId)
+	}
+
+	mm_params := ClientMockDeleteUpgradeWindowParams{ctx, serviceId}
+
+	// Record call args
+	mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.mutex.Lock()
+	mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.callArgs = append(mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.callArgs, &mm_params)
+	mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.mutex.Unlock()
+
+	for _, e := range mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.err
+		}
+	}
+
+	if mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.Counter, 1)
+		mm_want := mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.params
+		mm_want_ptrs := mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockDeleteUpgradeWindowParams{ctx, serviceId}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmDeleteUpgradeWindow.t.Errorf("ClientMock.DeleteUpgradeWindow got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
+				mmDeleteUpgradeWindow.t.Errorf("ClientMock.DeleteUpgradeWindow got unexpected parameter serviceId, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.expectationOrigins.originServiceId, *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmDeleteUpgradeWindow.t.Errorf("ClientMock.DeleteUpgradeWindow got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmDeleteUpgradeWindow.DeleteUpgradeWindowMock.defaultExpectation.results
+		if mm_results == nil {
+			mmDeleteUpgradeWindow.t.Fatal("No results are set for the ClientMock.DeleteUpgradeWindow")
+		}
+		return (*mm_results).err
+	}
+	if mmDeleteUpgradeWindow.funcDeleteUpgradeWindow != nil {
+		return mmDeleteUpgradeWindow.funcDeleteUpgradeWindow(ctx, serviceId)
+	}
+	mmDeleteUpgradeWindow.t.Fatalf("Unexpected call to ClientMock.DeleteUpgradeWindow. %v %v", ctx, serviceId)
+	return
+}
+
+// DeleteUpgradeWindowAfterCounter returns a count of finished ClientMock.DeleteUpgradeWindow invocations
+func (mmDeleteUpgradeWindow *ClientMock) DeleteUpgradeWindowAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmDeleteUpgradeWindow.afterDeleteUpgradeWindowCounter)
+}
+
+// DeleteUpgradeWindowBeforeCounter returns a count of ClientMock.DeleteUpgradeWindow invocations
+func (mmDeleteUpgradeWindow *ClientMock) DeleteUpgradeWindowBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmDeleteUpgradeWindow.beforeDeleteUpgradeWindowCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.DeleteUpgradeWindow.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmDeleteUpgradeWindow *mClientMockDeleteUpgradeWindow) Calls() []*ClientMockDeleteUpgradeWindowParams {
+	mmDeleteUpgradeWindow.mutex.RLock()
+
+	argCopy := make([]*ClientMockDeleteUpgradeWindowParams, len(mmDeleteUpgradeWindow.callArgs))
+	copy(argCopy, mmDeleteUpgradeWindow.callArgs)
+
+	mmDeleteUpgradeWindow.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockDeleteUpgradeWindowDone returns true if the count of the DeleteUpgradeWindow invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockDeleteUpgradeWindowDone() bool {
+	if m.DeleteUpgradeWindowMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.DeleteUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.DeleteUpgradeWindowMock.invocationsDone()
+}
+
+// MinimockDeleteUpgradeWindowInspect logs each unmet expectation
+func (m *ClientMock) MinimockDeleteUpgradeWindowInspect() {
+	for _, e := range m.DeleteUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.DeleteUpgradeWindow at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterDeleteUpgradeWindowCounter := mm_atomic.LoadUint64(&m.afterDeleteUpgradeWindowCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.DeleteUpgradeWindowMock.defaultExpectation != nil && afterDeleteUpgradeWindowCounter < 1 {
+		if m.DeleteUpgradeWindowMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ClientMock.DeleteUpgradeWindow at\n%s", m.DeleteUpgradeWindowMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ClientMock.DeleteUpgradeWindow at\n%s with params: %#v", m.DeleteUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *m.DeleteUpgradeWindowMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcDeleteUpgradeWindow != nil && afterDeleteUpgradeWindowCounter < 1 {
+		m.t.Errorf("Expected call to ClientMock.DeleteUpgradeWindow at\n%s", m.funcDeleteUpgradeWindowOrigin)
+	}
+
+	if !m.DeleteUpgradeWindowMock.invocationsDone() && afterDeleteUpgradeWindowCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.DeleteUpgradeWindow at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.DeleteUpgradeWindowMock.expectedInvocations), m.DeleteUpgradeWindowMock.expectedInvocationsOrigin, afterDeleteUpgradeWindowCounter)
 	}
 }
 
@@ -10035,6 +10407,349 @@ func (m *ClientMock) MinimockGetServiceInspect() {
 	if !m.GetServiceMock.invocationsDone() && afterGetServiceCounter > 0 {
 		m.t.Errorf("Expected %d calls to ClientMock.GetService at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.GetServiceMock.expectedInvocations), m.GetServiceMock.expectedInvocationsOrigin, afterGetServiceCounter)
+	}
+}
+
+type mClientMockGetUpgradeWindow struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockGetUpgradeWindowExpectation
+	expectations       []*ClientMockGetUpgradeWindowExpectation
+
+	callArgs []*ClientMockGetUpgradeWindowParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ClientMockGetUpgradeWindowExpectation specifies expectation struct of the Client.GetUpgradeWindow
+type ClientMockGetUpgradeWindowExpectation struct {
+	mock               *ClientMock
+	params             *ClientMockGetUpgradeWindowParams
+	paramPtrs          *ClientMockGetUpgradeWindowParamPtrs
+	expectationOrigins ClientMockGetUpgradeWindowExpectationOrigins
+	results            *ClientMockGetUpgradeWindowResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ClientMockGetUpgradeWindowParams contains parameters of the Client.GetUpgradeWindow
+type ClientMockGetUpgradeWindowParams struct {
+	ctx       context.Context
+	serviceId string
+}
+
+// ClientMockGetUpgradeWindowParamPtrs contains pointers to parameters of the Client.GetUpgradeWindow
+type ClientMockGetUpgradeWindowParamPtrs struct {
+	ctx       *context.Context
+	serviceId *string
+}
+
+// ClientMockGetUpgradeWindowResults contains results of the Client.GetUpgradeWindow
+type ClientMockGetUpgradeWindowResults struct {
+	up1 *UpgradeWindow
+	err error
+}
+
+// ClientMockGetUpgradeWindowOrigins contains origins of expectations of the Client.GetUpgradeWindow
+type ClientMockGetUpgradeWindowExpectationOrigins struct {
+	origin          string
+	originCtx       string
+	originServiceId string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Optional() *mClientMockGetUpgradeWindow {
+	mmGetUpgradeWindow.optional = true
+	return mmGetUpgradeWindow
+}
+
+// Expect sets up expected params for Client.GetUpgradeWindow
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Expect(ctx context.Context, serviceId string) *mClientMockGetUpgradeWindow {
+	if mmGetUpgradeWindow.mock.funcGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Set")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation == nil {
+		mmGetUpgradeWindow.defaultExpectation = &ClientMockGetUpgradeWindowExpectation{}
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation.paramPtrs != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by ExpectParams functions")
+	}
+
+	mmGetUpgradeWindow.defaultExpectation.params = &ClientMockGetUpgradeWindowParams{ctx, serviceId}
+	mmGetUpgradeWindow.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmGetUpgradeWindow.expectations {
+		if minimock.Equal(e.params, mmGetUpgradeWindow.defaultExpectation.params) {
+			mmGetUpgradeWindow.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetUpgradeWindow.defaultExpectation.params)
+		}
+	}
+
+	return mmGetUpgradeWindow
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.GetUpgradeWindow
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) ExpectCtxParam1(ctx context.Context) *mClientMockGetUpgradeWindow {
+	if mmGetUpgradeWindow.mock.funcGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Set")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation == nil {
+		mmGetUpgradeWindow.defaultExpectation = &ClientMockGetUpgradeWindowExpectation{}
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation.params != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmGetUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockGetUpgradeWindowParamPtrs{}
+	}
+	mmGetUpgradeWindow.defaultExpectation.paramPtrs.ctx = &ctx
+	mmGetUpgradeWindow.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmGetUpgradeWindow
+}
+
+// ExpectServiceIdParam2 sets up expected param serviceId for Client.GetUpgradeWindow
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) ExpectServiceIdParam2(serviceId string) *mClientMockGetUpgradeWindow {
+	if mmGetUpgradeWindow.mock.funcGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Set")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation == nil {
+		mmGetUpgradeWindow.defaultExpectation = &ClientMockGetUpgradeWindowExpectation{}
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation.params != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmGetUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockGetUpgradeWindowParamPtrs{}
+	}
+	mmGetUpgradeWindow.defaultExpectation.paramPtrs.serviceId = &serviceId
+	mmGetUpgradeWindow.defaultExpectation.expectationOrigins.originServiceId = minimock.CallerInfo(1)
+
+	return mmGetUpgradeWindow
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.GetUpgradeWindow
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Inspect(f func(ctx context.Context, serviceId string)) *mClientMockGetUpgradeWindow {
+	if mmGetUpgradeWindow.mock.inspectFuncGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("Inspect function is already set for ClientMock.GetUpgradeWindow")
+	}
+
+	mmGetUpgradeWindow.mock.inspectFuncGetUpgradeWindow = f
+
+	return mmGetUpgradeWindow
+}
+
+// Return sets up results that will be returned by Client.GetUpgradeWindow
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Return(up1 *UpgradeWindow, err error) *ClientMock {
+	if mmGetUpgradeWindow.mock.funcGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Set")
+	}
+
+	if mmGetUpgradeWindow.defaultExpectation == nil {
+		mmGetUpgradeWindow.defaultExpectation = &ClientMockGetUpgradeWindowExpectation{mock: mmGetUpgradeWindow.mock}
+	}
+	mmGetUpgradeWindow.defaultExpectation.results = &ClientMockGetUpgradeWindowResults{up1, err}
+	mmGetUpgradeWindow.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmGetUpgradeWindow.mock
+}
+
+// Set uses given function f to mock the Client.GetUpgradeWindow method
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Set(f func(ctx context.Context, serviceId string) (up1 *UpgradeWindow, err error)) *ClientMock {
+	if mmGetUpgradeWindow.defaultExpectation != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("Default expectation is already set for the Client.GetUpgradeWindow method")
+	}
+
+	if len(mmGetUpgradeWindow.expectations) > 0 {
+		mmGetUpgradeWindow.mock.t.Fatalf("Some expectations are already set for the Client.GetUpgradeWindow method")
+	}
+
+	mmGetUpgradeWindow.mock.funcGetUpgradeWindow = f
+	mmGetUpgradeWindow.mock.funcGetUpgradeWindowOrigin = minimock.CallerInfo(1)
+	return mmGetUpgradeWindow.mock
+}
+
+// When sets expectation for the Client.GetUpgradeWindow which will trigger the result defined by the following
+// Then helper
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) When(ctx context.Context, serviceId string) *ClientMockGetUpgradeWindowExpectation {
+	if mmGetUpgradeWindow.mock.funcGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.mock.t.Fatalf("ClientMock.GetUpgradeWindow mock is already set by Set")
+	}
+
+	expectation := &ClientMockGetUpgradeWindowExpectation{
+		mock:               mmGetUpgradeWindow.mock,
+		params:             &ClientMockGetUpgradeWindowParams{ctx, serviceId},
+		expectationOrigins: ClientMockGetUpgradeWindowExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmGetUpgradeWindow.expectations = append(mmGetUpgradeWindow.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.GetUpgradeWindow return parameters for the expectation previously defined by the When method
+func (e *ClientMockGetUpgradeWindowExpectation) Then(up1 *UpgradeWindow, err error) *ClientMock {
+	e.results = &ClientMockGetUpgradeWindowResults{up1, err}
+	return e.mock
+}
+
+// Times sets number of times Client.GetUpgradeWindow should be invoked
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Times(n uint64) *mClientMockGetUpgradeWindow {
+	if n == 0 {
+		mmGetUpgradeWindow.mock.t.Fatalf("Times of ClientMock.GetUpgradeWindow mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmGetUpgradeWindow.expectedInvocations, n)
+	mmGetUpgradeWindow.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmGetUpgradeWindow
+}
+
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) invocationsDone() bool {
+	if len(mmGetUpgradeWindow.expectations) == 0 && mmGetUpgradeWindow.defaultExpectation == nil && mmGetUpgradeWindow.mock.funcGetUpgradeWindow == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmGetUpgradeWindow.mock.afterGetUpgradeWindowCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmGetUpgradeWindow.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// GetUpgradeWindow implements Client
+func (mmGetUpgradeWindow *ClientMock) GetUpgradeWindow(ctx context.Context, serviceId string) (up1 *UpgradeWindow, err error) {
+	mm_atomic.AddUint64(&mmGetUpgradeWindow.beforeGetUpgradeWindowCounter, 1)
+	defer mm_atomic.AddUint64(&mmGetUpgradeWindow.afterGetUpgradeWindowCounter, 1)
+
+	mmGetUpgradeWindow.t.Helper()
+
+	if mmGetUpgradeWindow.inspectFuncGetUpgradeWindow != nil {
+		mmGetUpgradeWindow.inspectFuncGetUpgradeWindow(ctx, serviceId)
+	}
+
+	mm_params := ClientMockGetUpgradeWindowParams{ctx, serviceId}
+
+	// Record call args
+	mmGetUpgradeWindow.GetUpgradeWindowMock.mutex.Lock()
+	mmGetUpgradeWindow.GetUpgradeWindowMock.callArgs = append(mmGetUpgradeWindow.GetUpgradeWindowMock.callArgs, &mm_params)
+	mmGetUpgradeWindow.GetUpgradeWindowMock.mutex.Unlock()
+
+	for _, e := range mmGetUpgradeWindow.GetUpgradeWindowMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.up1, e.results.err
+		}
+	}
+
+	if mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.Counter, 1)
+		mm_want := mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.params
+		mm_want_ptrs := mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockGetUpgradeWindowParams{ctx, serviceId}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmGetUpgradeWindow.t.Errorf("ClientMock.GetUpgradeWindow got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
+				mmGetUpgradeWindow.t.Errorf("ClientMock.GetUpgradeWindow got unexpected parameter serviceId, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.expectationOrigins.originServiceId, *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmGetUpgradeWindow.t.Errorf("ClientMock.GetUpgradeWindow got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmGetUpgradeWindow.GetUpgradeWindowMock.defaultExpectation.results
+		if mm_results == nil {
+			mmGetUpgradeWindow.t.Fatal("No results are set for the ClientMock.GetUpgradeWindow")
+		}
+		return (*mm_results).up1, (*mm_results).err
+	}
+	if mmGetUpgradeWindow.funcGetUpgradeWindow != nil {
+		return mmGetUpgradeWindow.funcGetUpgradeWindow(ctx, serviceId)
+	}
+	mmGetUpgradeWindow.t.Fatalf("Unexpected call to ClientMock.GetUpgradeWindow. %v %v", ctx, serviceId)
+	return
+}
+
+// GetUpgradeWindowAfterCounter returns a count of finished ClientMock.GetUpgradeWindow invocations
+func (mmGetUpgradeWindow *ClientMock) GetUpgradeWindowAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetUpgradeWindow.afterGetUpgradeWindowCounter)
+}
+
+// GetUpgradeWindowBeforeCounter returns a count of ClientMock.GetUpgradeWindow invocations
+func (mmGetUpgradeWindow *ClientMock) GetUpgradeWindowBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetUpgradeWindow.beforeGetUpgradeWindowCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.GetUpgradeWindow.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmGetUpgradeWindow *mClientMockGetUpgradeWindow) Calls() []*ClientMockGetUpgradeWindowParams {
+	mmGetUpgradeWindow.mutex.RLock()
+
+	argCopy := make([]*ClientMockGetUpgradeWindowParams, len(mmGetUpgradeWindow.callArgs))
+	copy(argCopy, mmGetUpgradeWindow.callArgs)
+
+	mmGetUpgradeWindow.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockGetUpgradeWindowDone returns true if the count of the GetUpgradeWindow invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockGetUpgradeWindowDone() bool {
+	if m.GetUpgradeWindowMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.GetUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.GetUpgradeWindowMock.invocationsDone()
+}
+
+// MinimockGetUpgradeWindowInspect logs each unmet expectation
+func (m *ClientMock) MinimockGetUpgradeWindowInspect() {
+	for _, e := range m.GetUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.GetUpgradeWindow at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterGetUpgradeWindowCounter := mm_atomic.LoadUint64(&m.afterGetUpgradeWindowCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.GetUpgradeWindowMock.defaultExpectation != nil && afterGetUpgradeWindowCounter < 1 {
+		if m.GetUpgradeWindowMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ClientMock.GetUpgradeWindow at\n%s", m.GetUpgradeWindowMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ClientMock.GetUpgradeWindow at\n%s with params: %#v", m.GetUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *m.GetUpgradeWindowMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcGetUpgradeWindow != nil && afterGetUpgradeWindowCounter < 1 {
+		m.t.Errorf("Expected call to ClientMock.GetUpgradeWindow at\n%s", m.funcGetUpgradeWindowOrigin)
+	}
+
+	if !m.GetUpgradeWindowMock.invocationsDone() && afterGetUpgradeWindowCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.GetUpgradeWindow at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.GetUpgradeWindowMock.expectedInvocations), m.GetUpgradeWindowMock.expectedInvocationsOrigin, afterGetUpgradeWindowCounter)
 	}
 }
 
@@ -15897,6 +16612,380 @@ func (m *ClientMock) MinimockUpdateServicePasswordInspect() {
 	}
 }
 
+type mClientMockUpdateUpgradeWindow struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockUpdateUpgradeWindowExpectation
+	expectations       []*ClientMockUpdateUpgradeWindowExpectation
+
+	callArgs []*ClientMockUpdateUpgradeWindowParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ClientMockUpdateUpgradeWindowExpectation specifies expectation struct of the Client.UpdateUpgradeWindow
+type ClientMockUpdateUpgradeWindowExpectation struct {
+	mock               *ClientMock
+	params             *ClientMockUpdateUpgradeWindowParams
+	paramPtrs          *ClientMockUpdateUpgradeWindowParamPtrs
+	expectationOrigins ClientMockUpdateUpgradeWindowExpectationOrigins
+	results            *ClientMockUpdateUpgradeWindowResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ClientMockUpdateUpgradeWindowParams contains parameters of the Client.UpdateUpgradeWindow
+type ClientMockUpdateUpgradeWindowParams struct {
+	ctx       context.Context
+	serviceId string
+	u         UpgradeWindowUpdate
+}
+
+// ClientMockUpdateUpgradeWindowParamPtrs contains pointers to parameters of the Client.UpdateUpgradeWindow
+type ClientMockUpdateUpgradeWindowParamPtrs struct {
+	ctx       *context.Context
+	serviceId *string
+	u         *UpgradeWindowUpdate
+}
+
+// ClientMockUpdateUpgradeWindowResults contains results of the Client.UpdateUpgradeWindow
+type ClientMockUpdateUpgradeWindowResults struct {
+	up1 *UpgradeWindow
+	err error
+}
+
+// ClientMockUpdateUpgradeWindowOrigins contains origins of expectations of the Client.UpdateUpgradeWindow
+type ClientMockUpdateUpgradeWindowExpectationOrigins struct {
+	origin          string
+	originCtx       string
+	originServiceId string
+	originU         string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Optional() *mClientMockUpdateUpgradeWindow {
+	mmUpdateUpgradeWindow.optional = true
+	return mmUpdateUpgradeWindow
+}
+
+// Expect sets up expected params for Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Expect(ctx context.Context, serviceId string, u UpgradeWindowUpdate) *mClientMockUpdateUpgradeWindow {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation == nil {
+		mmUpdateUpgradeWindow.defaultExpectation = &ClientMockUpdateUpgradeWindowExpectation{}
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.paramPtrs != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by ExpectParams functions")
+	}
+
+	mmUpdateUpgradeWindow.defaultExpectation.params = &ClientMockUpdateUpgradeWindowParams{ctx, serviceId, u}
+	mmUpdateUpgradeWindow.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmUpdateUpgradeWindow.expectations {
+		if minimock.Equal(e.params, mmUpdateUpgradeWindow.defaultExpectation.params) {
+			mmUpdateUpgradeWindow.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmUpdateUpgradeWindow.defaultExpectation.params)
+		}
+	}
+
+	return mmUpdateUpgradeWindow
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) ExpectCtxParam1(ctx context.Context) *mClientMockUpdateUpgradeWindow {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation == nil {
+		mmUpdateUpgradeWindow.defaultExpectation = &ClientMockUpdateUpgradeWindowExpectation{}
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.params != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmUpdateUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockUpdateUpgradeWindowParamPtrs{}
+	}
+	mmUpdateUpgradeWindow.defaultExpectation.paramPtrs.ctx = &ctx
+	mmUpdateUpgradeWindow.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmUpdateUpgradeWindow
+}
+
+// ExpectServiceIdParam2 sets up expected param serviceId for Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) ExpectServiceIdParam2(serviceId string) *mClientMockUpdateUpgradeWindow {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation == nil {
+		mmUpdateUpgradeWindow.defaultExpectation = &ClientMockUpdateUpgradeWindowExpectation{}
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.params != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmUpdateUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockUpdateUpgradeWindowParamPtrs{}
+	}
+	mmUpdateUpgradeWindow.defaultExpectation.paramPtrs.serviceId = &serviceId
+	mmUpdateUpgradeWindow.defaultExpectation.expectationOrigins.originServiceId = minimock.CallerInfo(1)
+
+	return mmUpdateUpgradeWindow
+}
+
+// ExpectUParam3 sets up expected param u for Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) ExpectUParam3(u UpgradeWindowUpdate) *mClientMockUpdateUpgradeWindow {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation == nil {
+		mmUpdateUpgradeWindow.defaultExpectation = &ClientMockUpdateUpgradeWindowExpectation{}
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.params != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Expect")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation.paramPtrs == nil {
+		mmUpdateUpgradeWindow.defaultExpectation.paramPtrs = &ClientMockUpdateUpgradeWindowParamPtrs{}
+	}
+	mmUpdateUpgradeWindow.defaultExpectation.paramPtrs.u = &u
+	mmUpdateUpgradeWindow.defaultExpectation.expectationOrigins.originU = minimock.CallerInfo(1)
+
+	return mmUpdateUpgradeWindow
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Inspect(f func(ctx context.Context, serviceId string, u UpgradeWindowUpdate)) *mClientMockUpdateUpgradeWindow {
+	if mmUpdateUpgradeWindow.mock.inspectFuncUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("Inspect function is already set for ClientMock.UpdateUpgradeWindow")
+	}
+
+	mmUpdateUpgradeWindow.mock.inspectFuncUpdateUpgradeWindow = f
+
+	return mmUpdateUpgradeWindow
+}
+
+// Return sets up results that will be returned by Client.UpdateUpgradeWindow
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Return(up1 *UpgradeWindow, err error) *ClientMock {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	if mmUpdateUpgradeWindow.defaultExpectation == nil {
+		mmUpdateUpgradeWindow.defaultExpectation = &ClientMockUpdateUpgradeWindowExpectation{mock: mmUpdateUpgradeWindow.mock}
+	}
+	mmUpdateUpgradeWindow.defaultExpectation.results = &ClientMockUpdateUpgradeWindowResults{up1, err}
+	mmUpdateUpgradeWindow.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmUpdateUpgradeWindow.mock
+}
+
+// Set uses given function f to mock the Client.UpdateUpgradeWindow method
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Set(f func(ctx context.Context, serviceId string, u UpgradeWindowUpdate) (up1 *UpgradeWindow, err error)) *ClientMock {
+	if mmUpdateUpgradeWindow.defaultExpectation != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("Default expectation is already set for the Client.UpdateUpgradeWindow method")
+	}
+
+	if len(mmUpdateUpgradeWindow.expectations) > 0 {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("Some expectations are already set for the Client.UpdateUpgradeWindow method")
+	}
+
+	mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow = f
+	mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindowOrigin = minimock.CallerInfo(1)
+	return mmUpdateUpgradeWindow.mock
+}
+
+// When sets expectation for the Client.UpdateUpgradeWindow which will trigger the result defined by the following
+// Then helper
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) When(ctx context.Context, serviceId string, u UpgradeWindowUpdate) *ClientMockUpdateUpgradeWindowExpectation {
+	if mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("ClientMock.UpdateUpgradeWindow mock is already set by Set")
+	}
+
+	expectation := &ClientMockUpdateUpgradeWindowExpectation{
+		mock:               mmUpdateUpgradeWindow.mock,
+		params:             &ClientMockUpdateUpgradeWindowParams{ctx, serviceId, u},
+		expectationOrigins: ClientMockUpdateUpgradeWindowExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmUpdateUpgradeWindow.expectations = append(mmUpdateUpgradeWindow.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.UpdateUpgradeWindow return parameters for the expectation previously defined by the When method
+func (e *ClientMockUpdateUpgradeWindowExpectation) Then(up1 *UpgradeWindow, err error) *ClientMock {
+	e.results = &ClientMockUpdateUpgradeWindowResults{up1, err}
+	return e.mock
+}
+
+// Times sets number of times Client.UpdateUpgradeWindow should be invoked
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Times(n uint64) *mClientMockUpdateUpgradeWindow {
+	if n == 0 {
+		mmUpdateUpgradeWindow.mock.t.Fatalf("Times of ClientMock.UpdateUpgradeWindow mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmUpdateUpgradeWindow.expectedInvocations, n)
+	mmUpdateUpgradeWindow.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmUpdateUpgradeWindow
+}
+
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) invocationsDone() bool {
+	if len(mmUpdateUpgradeWindow.expectations) == 0 && mmUpdateUpgradeWindow.defaultExpectation == nil && mmUpdateUpgradeWindow.mock.funcUpdateUpgradeWindow == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmUpdateUpgradeWindow.mock.afterUpdateUpgradeWindowCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmUpdateUpgradeWindow.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// UpdateUpgradeWindow implements Client
+func (mmUpdateUpgradeWindow *ClientMock) UpdateUpgradeWindow(ctx context.Context, serviceId string, u UpgradeWindowUpdate) (up1 *UpgradeWindow, err error) {
+	mm_atomic.AddUint64(&mmUpdateUpgradeWindow.beforeUpdateUpgradeWindowCounter, 1)
+	defer mm_atomic.AddUint64(&mmUpdateUpgradeWindow.afterUpdateUpgradeWindowCounter, 1)
+
+	mmUpdateUpgradeWindow.t.Helper()
+
+	if mmUpdateUpgradeWindow.inspectFuncUpdateUpgradeWindow != nil {
+		mmUpdateUpgradeWindow.inspectFuncUpdateUpgradeWindow(ctx, serviceId, u)
+	}
+
+	mm_params := ClientMockUpdateUpgradeWindowParams{ctx, serviceId, u}
+
+	// Record call args
+	mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.mutex.Lock()
+	mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.callArgs = append(mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.callArgs, &mm_params)
+	mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.mutex.Unlock()
+
+	for _, e := range mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.up1, e.results.err
+		}
+	}
+
+	if mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.Counter, 1)
+		mm_want := mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.params
+		mm_want_ptrs := mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockUpdateUpgradeWindowParams{ctx, serviceId, u}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmUpdateUpgradeWindow.t.Errorf("ClientMock.UpdateUpgradeWindow got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
+				mmUpdateUpgradeWindow.t.Errorf("ClientMock.UpdateUpgradeWindow got unexpected parameter serviceId, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.expectationOrigins.originServiceId, *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
+			}
+
+			if mm_want_ptrs.u != nil && !minimock.Equal(*mm_want_ptrs.u, mm_got.u) {
+				mmUpdateUpgradeWindow.t.Errorf("ClientMock.UpdateUpgradeWindow got unexpected parameter u, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.expectationOrigins.originU, *mm_want_ptrs.u, mm_got.u, minimock.Diff(*mm_want_ptrs.u, mm_got.u))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmUpdateUpgradeWindow.t.Errorf("ClientMock.UpdateUpgradeWindow got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmUpdateUpgradeWindow.UpdateUpgradeWindowMock.defaultExpectation.results
+		if mm_results == nil {
+			mmUpdateUpgradeWindow.t.Fatal("No results are set for the ClientMock.UpdateUpgradeWindow")
+		}
+		return (*mm_results).up1, (*mm_results).err
+	}
+	if mmUpdateUpgradeWindow.funcUpdateUpgradeWindow != nil {
+		return mmUpdateUpgradeWindow.funcUpdateUpgradeWindow(ctx, serviceId, u)
+	}
+	mmUpdateUpgradeWindow.t.Fatalf("Unexpected call to ClientMock.UpdateUpgradeWindow. %v %v %v", ctx, serviceId, u)
+	return
+}
+
+// UpdateUpgradeWindowAfterCounter returns a count of finished ClientMock.UpdateUpgradeWindow invocations
+func (mmUpdateUpgradeWindow *ClientMock) UpdateUpgradeWindowAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateUpgradeWindow.afterUpdateUpgradeWindowCounter)
+}
+
+// UpdateUpgradeWindowBeforeCounter returns a count of ClientMock.UpdateUpgradeWindow invocations
+func (mmUpdateUpgradeWindow *ClientMock) UpdateUpgradeWindowBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmUpdateUpgradeWindow.beforeUpdateUpgradeWindowCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.UpdateUpgradeWindow.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmUpdateUpgradeWindow *mClientMockUpdateUpgradeWindow) Calls() []*ClientMockUpdateUpgradeWindowParams {
+	mmUpdateUpgradeWindow.mutex.RLock()
+
+	argCopy := make([]*ClientMockUpdateUpgradeWindowParams, len(mmUpdateUpgradeWindow.callArgs))
+	copy(argCopy, mmUpdateUpgradeWindow.callArgs)
+
+	mmUpdateUpgradeWindow.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockUpdateUpgradeWindowDone returns true if the count of the UpdateUpgradeWindow invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockUpdateUpgradeWindowDone() bool {
+	if m.UpdateUpgradeWindowMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.UpdateUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.UpdateUpgradeWindowMock.invocationsDone()
+}
+
+// MinimockUpdateUpgradeWindowInspect logs each unmet expectation
+func (m *ClientMock) MinimockUpdateUpgradeWindowInspect() {
+	for _, e := range m.UpdateUpgradeWindowMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.UpdateUpgradeWindow at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterUpdateUpgradeWindowCounter := mm_atomic.LoadUint64(&m.afterUpdateUpgradeWindowCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.UpdateUpgradeWindowMock.defaultExpectation != nil && afterUpdateUpgradeWindowCounter < 1 {
+		if m.UpdateUpgradeWindowMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ClientMock.UpdateUpgradeWindow at\n%s", m.UpdateUpgradeWindowMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ClientMock.UpdateUpgradeWindow at\n%s with params: %#v", m.UpdateUpgradeWindowMock.defaultExpectation.expectationOrigins.origin, *m.UpdateUpgradeWindowMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcUpdateUpgradeWindow != nil && afterUpdateUpgradeWindowCounter < 1 {
+		m.t.Errorf("Expected call to ClientMock.UpdateUpgradeWindow at\n%s", m.funcUpdateUpgradeWindowOrigin)
+	}
+
+	if !m.UpdateUpgradeWindowMock.invocationsDone() && afterUpdateUpgradeWindowCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.UpdateUpgradeWindow at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.UpdateUpgradeWindowMock.expectedInvocations), m.UpdateUpgradeWindowMock.expectedInvocationsOrigin, afterUpdateUpgradeWindowCounter)
+	}
+}
+
 type mClientMockWaitForClickPipeCdcScaling struct {
 	optional           bool
 	mock               *ClientMock
@@ -17637,6 +18726,8 @@ func (m *ClientMock) MinimockFinish() {
 
 			m.MinimockDeleteServiceInspect()
 
+			m.MinimockDeleteUpgradeWindowInspect()
+
 			m.MinimockGetApiKeyIDInspect()
 
 			m.MinimockGetBackupConfigurationInspect()
@@ -17666,6 +18757,8 @@ func (m *ClientMock) MinimockFinish() {
 			m.MinimockGetScheduledScalingInspect()
 
 			m.MinimockGetServiceInspect()
+
+			m.MinimockGetUpgradeWindowInspect()
 
 			m.MinimockListMembersInspect()
 
@@ -17698,6 +18791,8 @@ func (m *ClientMock) MinimockFinish() {
 			m.MinimockUpdateServiceInspect()
 
 			m.MinimockUpdateServicePasswordInspect()
+
+			m.MinimockUpdateUpgradeWindowInspect()
 
 			m.MinimockWaitForClickPipeCdcScalingInspect()
 
@@ -17741,6 +18836,7 @@ func (m *ClientMock) minimockDone() bool {
 		m.MinimockDeleteRoleDone() &&
 		m.MinimockDeleteScheduledScalingDone() &&
 		m.MinimockDeleteServiceDone() &&
+		m.MinimockDeleteUpgradeWindowDone() &&
 		m.MinimockGetApiKeyIDDone() &&
 		m.MinimockGetBackupConfigurationDone() &&
 		m.MinimockGetClickPipeDone() &&
@@ -17756,6 +18852,7 @@ func (m *ClientMock) minimockDone() bool {
 		m.MinimockGetRoleDone() &&
 		m.MinimockGetScheduledScalingDone() &&
 		m.MinimockGetServiceDone() &&
+		m.MinimockGetUpgradeWindowDone() &&
 		m.MinimockListMembersDone() &&
 		m.MinimockListReversePrivateEndpointsDone() &&
 		m.MinimockListRolesDone() &&
@@ -17772,6 +18869,7 @@ func (m *ClientMock) minimockDone() bool {
 		m.MinimockUpdateScheduledScalingDone() &&
 		m.MinimockUpdateServiceDone() &&
 		m.MinimockUpdateServicePasswordDone() &&
+		m.MinimockUpdateUpgradeWindowDone() &&
 		m.MinimockWaitForClickPipeCdcScalingDone() &&
 		m.MinimockWaitForClickPipeStateDone() &&
 		m.MinimockWaitForReversePrivateEndpointStateDone() &&

--- a/pkg/internal/api/errors.go
+++ b/pkg/internal/api/errors.go
@@ -20,6 +20,26 @@ func IsConflict(err error) bool {
 	return strings.HasPrefix(err.Error(), "status: 409")
 }
 
+func IsForbidden(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), "status: 403")
+}
+
+// IsBadRequestWith returns true when err is a 400 whose body contains needle.
+// Use to specialize diagnostics for documented client errors (e.g. the OpenAPI
+// "cannot set upgrade window on a secondary service" 400).
+func IsBadRequestWith(err error, needle string) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.HasPrefix(msg, "status: 400") && strings.Contains(msg, needle)
+}
+
 func is5xx(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/internal/api/errors_test.go
+++ b/pkg/internal/api/errors_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsForbidden(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "403", err: errors.New("status: 403, body: forbidden"), want: true},
+		{name: "404 is not forbidden", err: errors.New("status: 404, body: not found"), want: false},
+		{name: "non-status error", err: errors.New("connection refused"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsForbidden(tc.err); got != tc.want {
+				t.Errorf("IsForbidden(%v) = %v; want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsBadRequestWith(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		needle string
+		want   bool
+	}{
+		{
+			name:   "400 with matching needle",
+			err:    errors.New("status: 400, body: cannot set upgrade window on a secondary service"),
+			needle: "secondary service",
+			want:   true,
+		},
+		{
+			name:   "400 without matching needle",
+			err:    errors.New("status: 400, body: malformed request"),
+			needle: "secondary service",
+			want:   false,
+		},
+		{
+			name:   "403 even with matching body",
+			err:    errors.New("status: 403, body: secondary service"),
+			needle: "secondary service",
+			want:   false,
+		},
+		{name: "nil", err: nil, needle: "anything", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsBadRequestWith(tc.err, tc.needle); got != tc.want {
+				t.Errorf("IsBadRequestWith(%v, %q) = %v; want %v", tc.err, tc.needle, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/internal/api/interface.go
+++ b/pkg/internal/api/interface.go
@@ -17,6 +17,9 @@ type Client interface {
 	GetScheduledScaling(ctx context.Context, serviceId string) (*AutoScalingSchedule, error)
 	UpdateScheduledScaling(ctx context.Context, serviceId string, s AutoScalingScheduleUpdate) (*AutoScalingSchedule, error)
 	DeleteScheduledScaling(ctx context.Context, serviceId string) error
+	GetUpgradeWindow(ctx context.Context, serviceId string) (*UpgradeWindow, error)
+	UpdateUpgradeWindow(ctx context.Context, serviceId string, u UpgradeWindowUpdate) (*UpgradeWindow, error)
+	DeleteUpgradeWindow(ctx context.Context, serviceId string) error
 	UpdateServicePassword(ctx context.Context, serviceId string, u ServicePasswordUpdate) (*ServicePasswordUpdateResult, error)
 	DeleteService(ctx context.Context, serviceId string) (*Service, error)
 	GetOrganization(ctx context.Context) (*OrgResult, error)

--- a/pkg/internal/api/upgrade_window.go
+++ b/pkg/internal/api/upgrade_window.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// UpgradeWindow mirrors the OpenAPI public UpgradeWindowV1 shape: a weekly
+// recurring window during which the data plane is allowed to perform service
+// upgrades.
+type UpgradeWindow struct {
+	Weekday      int `json:"weekday"`
+	StartHourUtc int `json:"startHourUtc"`
+	Duration     int `json:"duration"`
+}
+
+// UpgradeWindowUpdate is the PUT request body. The server fixes `duration` so
+// it is intentionally omitted from the request — matching the OpenAPI
+// UpgradeWindowV1PutRequest shape.
+type UpgradeWindowUpdate struct {
+	Weekday      int `json:"weekday"`
+	StartHourUtc int `json:"startHourUtc"`
+}
+
+func (c *ClientImpl) GetUpgradeWindow(ctx context.Context, serviceId string) (*UpgradeWindow, error) {
+	req, err := http.NewRequest(http.MethodGet, c.getServicePath(serviceId, "/upgradeWindow"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := ResponseWithResult[UpgradeWindow]{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	return &response.Result, nil
+}
+
+func (c *ClientImpl) UpdateUpgradeWindow(ctx context.Context, serviceId string, u UpgradeWindowUpdate) (*UpgradeWindow, error) {
+	rb, err := json.Marshal(u)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, c.getServicePath(serviceId, "/upgradeWindow"), bytes.NewReader(rb))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := ResponseWithResult[UpgradeWindow]{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, err
+	}
+
+	return &response.Result, nil
+}
+
+func (c *ClientImpl) DeleteUpgradeWindow(ctx context.Context, serviceId string) error {
+	req, err := http.NewRequest(http.MethodDelete, c.getServicePath(serviceId, "/upgradeWindow"), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(ctx, req)
+	return err
+}

--- a/pkg/internal/api/upgrade_window.go
+++ b/pkg/internal/api/upgrade_window.go
@@ -7,6 +7,19 @@ import (
 	"net/http"
 )
 
+// UpgradeWindowAllowedStartHoursUtc is the server-side allowed set for
+// `startHourUtc` (`UPGRADE_WINDOW_ALLOWED_START_HOURS_UTC` in the OpenAPI
+// spec). Exposed so the provider's schema validator stays in sync with the
+// server — if the server ever expands the set, only this constant needs to
+// change.
+var UpgradeWindowAllowedStartHoursUtc = []int64{0, 6, 12, 18}
+
+// UpgradeWindowDurationHours is the server-fixed window duration in hours
+// (`UPGRADE_WINDOW_ALLOWED_DURATION_HOURS` in the OpenAPI spec). The provider
+// does not let users configure this — the resource exposes `duration` as a
+// `Computed` attribute and the server stays authoritative.
+const UpgradeWindowDurationHours = 6
+
 // UpgradeWindow mirrors the OpenAPI public UpgradeWindowV1 shape: a weekly
 // recurring window during which the data plane is allowed to perform service
 // upgrades.

--- a/pkg/internal/api/upgrade_window_test.go
+++ b/pkg/internal/api/upgrade_window_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func newUpgradeWindowTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(ClientConfig{
+		ApiURL:         server.URL,
+		OrganizationID: "org-1",
+		TokenKey:       "key",
+		TokenSecret:    "secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client, server
+}
+
+func TestGetUpgradeWindow(t *testing.T) {
+	expectedPath := "/organizations/org-1/services/svc-1/upgradeWindow"
+	want := UpgradeWindow{Weekday: 3, StartHourUtc: 12, Duration: 6}
+
+	client, _ := newUpgradeWindowTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q; want GET", r.Method)
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("path = %q; want %q", r.URL.Path, expectedPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ResponseWithResult[UpgradeWindow]{Result: want})
+	})
+
+	got, err := client.GetUpgradeWindow(context.Background(), "svc-1")
+	if err != nil {
+		t.Fatalf("GetUpgradeWindow: %v", err)
+	}
+	if diff := cmp.Diff(&want, got); diff != "" {
+		t.Errorf("GetUpgradeWindow mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetUpgradeWindow_NotFound(t *testing.T) {
+	client, _ := newUpgradeWindowTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+
+	_, err := client.GetUpgradeWindow(context.Background(), "svc-1")
+	if err == nil {
+		t.Fatalf("GetUpgradeWindow: expected error, got nil")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound(err) = false; want true (err = %v)", err)
+	}
+}
+
+func TestUpdateUpgradeWindow_OmitsDurationFromRequest(t *testing.T) {
+	update := UpgradeWindowUpdate{Weekday: 1, StartHourUtc: 6}
+	response := UpgradeWindow{Weekday: 1, StartHourUtc: 6, Duration: 6}
+
+	var capturedBody map[string]any
+	client, _ := newUpgradeWindowTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %q; want PUT", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(ResponseWithResult[UpgradeWindow]{Result: response})
+	})
+
+	got, err := client.UpdateUpgradeWindow(context.Background(), "svc-1", update)
+	if err != nil {
+		t.Fatalf("UpdateUpgradeWindow: %v", err)
+	}
+	if _, ok := capturedBody["duration"]; ok {
+		t.Errorf("request body should not contain duration: %v", capturedBody)
+	}
+	if w, ok := capturedBody["weekday"].(float64); !ok || int(w) != 1 {
+		t.Errorf("request weekday = %v; want 1", capturedBody["weekday"])
+	}
+	if h, ok := capturedBody["startHourUtc"].(float64); !ok || int(h) != 6 {
+		t.Errorf("request startHourUtc = %v; want 6", capturedBody["startHourUtc"])
+	}
+	if got.Duration != 6 {
+		t.Errorf("response Duration = %d; want 6", got.Duration)
+	}
+}
+
+func TestDeleteUpgradeWindow(t *testing.T) {
+	expectedPath := "/organizations/org-1/services/svc-1/upgradeWindow"
+	var sawDelete bool
+	client, _ := newUpgradeWindowTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %q; want DELETE", r.Method)
+		}
+		if r.URL.Path != expectedPath {
+			t.Errorf("path = %q; want %q", r.URL.Path, expectedPath)
+		}
+		sawDelete = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if err := client.DeleteUpgradeWindow(context.Background(), "svc-1"); err != nil {
+		t.Fatalf("DeleteUpgradeWindow: %v", err)
+	}
+	if !sawDelete {
+		t.Errorf("server did not see DELETE request")
+	}
+}

--- a/pkg/resource/descriptions/service_upgrade_window.md
+++ b/pkg/resource/descriptions/service_upgrade_window.md
@@ -23,7 +23,7 @@ The upgrade window can only be set on primary services. Secondary services inher
 terraform import clickhouse_service_upgrade_window.example <service_id>
 ```
 
-Imports against a service whose upgrade window has not been configured succeed (the framework runs Read after Import), but the subsequent Read returns `404` and removes the resource from state — leaving the next plan proposing a fresh create. Confirm the service ID is correct before importing.
+Import is refused with a clear diagnostic when the supplied service ID does not exist or points at a secondary service. Importing a primary service that does not yet have an upgrade window configured succeeds, but the subsequent Read returns `404` and removes the resource from state — leaving the next plan proposing a fresh create. Confirm the service ID is correct before importing.
 
 ## Example Usage
 

--- a/pkg/resource/descriptions/service_upgrade_window.md
+++ b/pkg/resource/descriptions/service_upgrade_window.md
@@ -1,0 +1,26 @@
+You can use the *clickhouse_service_upgrade_window* resource to pin the weekly upgrade window for a ClickHouse Cloud service.
+
+When configured, the data plane only attempts service upgrades during the declared window. The window is a single weekly recurrence: a `weekday` plus a `start_hour_utc`. The window currently lasts 6 hours from `start_hour_utc`; `duration` is returned by the API and exposed as a read-only attribute.
+
+~> **Note:** This resource is in beta. Scheduled upgrades must be enabled for your organization (`canUseScheduledUpgrades`). Reach out to ClickHouse support if the API returns `403 FORBIDDEN`. The upgrade window can only be set on primary services; secondary services inherit the primary service window.
+
+## Allowed values
+
+- `weekday`: `0` (Sunday) – `6` (Saturday)
+- `start_hour_utc`: one of `0`, `6`, `12`, `18`
+
+## Example Usage
+
+```hcl
+resource "clickhouse_service_upgrade_window" "example" {
+  service_id     = clickhouse_service.example.id
+  weekday        = 3 # Wednesday
+  start_hour_utc = 12
+}
+```
+
+## Import
+
+```sh
+terraform import clickhouse_service_upgrade_window.example <service_id>
+```

--- a/pkg/resource/descriptions/service_upgrade_window.md
+++ b/pkg/resource/descriptions/service_upgrade_window.md
@@ -2,12 +2,28 @@ You can use the *clickhouse_service_upgrade_window* resource to pin the weekly u
 
 When configured, the data plane only attempts service upgrades during the declared window. The window is a single weekly recurrence: a `weekday` plus a `start_hour_utc`. The window currently lasts 6 hours from `start_hour_utc`; `duration` is returned by the API and exposed as a read-only attribute.
 
-~> **Note:** This resource is in beta. Scheduled upgrades must be enabled for your organization (`canUseScheduledUpgrades`). Reach out to ClickHouse support if the API returns `403 FORBIDDEN`. The upgrade window can only be set on primary services; secondary services inherit the primary service window.
+~> **Note:** This resource is in beta. Setting or updating an upgrade window requires the `canUseScheduledUpgrades` entitlement — reach out to ClickHouse support if the API returns `403 FORBIDDEN`. Deleting an upgrade window is allowed even after the entitlement is lost, so existing windows can always be cleared.
+
+## Primary services only
+
+The upgrade window can only be set on primary services. Secondary services inherit the window from their primary. Applying this resource against a secondary service returns a `400` with the message `cannot set upgrade window on a secondary service`, surfaced by the provider as `Upgrade windows can only be set on primary services`.
 
 ## Allowed values
 
 - `weekday`: `0` (Sunday) – `6` (Saturday)
 - `start_hour_utc`: one of `0`, `6`, `12`, `18`
+
+## Best-effort overwrite protection
+
+`Create` performs a `GET` before issuing the `PUT` so that an existing window (e.g. one configured out-of-band) surfaces a "please import" diagnostic instead of being silently overwritten. The check is best-effort: a window created between this resource's `GET` and `PUT` (e.g. by another tool, or another Terraform apply) will still be overwritten by `PUT`.
+
+## Import
+
+```sh
+terraform import clickhouse_service_upgrade_window.example <service_id>
+```
+
+Imports against a service whose upgrade window has not been configured succeed (the framework runs Read after Import), but the subsequent Read returns `404` and removes the resource from state — leaving the next plan proposing a fresh create. Confirm the service ID is correct before importing.
 
 ## Example Usage
 
@@ -17,10 +33,4 @@ resource "clickhouse_service_upgrade_window" "example" {
   weekday        = 3 # Wednesday
   start_hour_utc = 12
 }
-```
-
-## Import
-
-```sh
-terraform import clickhouse_service_upgrade_window.example <service_id>
 ```

--- a/pkg/resource/models/service_upgrade_window_resource.go
+++ b/pkg/resource/models/service_upgrade_window_resource.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ServiceUpgradeWindowResourceModel is the Terraform state model for the
+// clickhouse_service_upgrade_window resource.
+type ServiceUpgradeWindowResourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	ServiceID    types.String `tfsdk:"service_id"`
+	Weekday      types.Int64  `tfsdk:"weekday"`
+	StartHourUtc types.Int64  `tfsdk:"start_hour_utc"`
+	Duration     types.Int64  `tfsdk:"duration"`
+}

--- a/pkg/resource/register_debug.go
+++ b/pkg/resource/register_debug.go
@@ -14,6 +14,7 @@ func GetResourceFactories() []func() upstreamresource.Resource {
 		NewServicePrivateEndpointsAttachmentResource,
 		NewServiceTransparentDataEncryptionKeyAssociationResource,
 		NewServiceScheduledScalingResource,
+		NewServiceUpgradeWindowResource,
 		NewClickPipeResource,
 		NewClickPipeReversePrivateEndpointResource,
 		NewClickPipeCdcInfrastructureResource,

--- a/pkg/resource/service_upgrade_window.go
+++ b/pkg/resource/service_upgrade_window.go
@@ -196,6 +196,31 @@ func (r *ServiceUpgradeWindowResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *ServiceUpgradeWindowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Validate the service exists and is a primary before writing state.
+	// GET /upgradeWindow on a secondary returns the inherited primary's window
+	// (so import would succeed at the upgrade-window layer), but every
+	// subsequent PUT/DELETE would 400 on "secondary service" — wedging the
+	// resource. Reject up front via GetService, which exposes isPrimary.
+	service, err := r.client.GetService(ctx, req.ID)
+	if err != nil {
+		if api.IsNotFound(err) {
+			resp.Diagnostics.AddError(
+				"Service not found",
+				fmt.Sprintf("Service %s does not exist or is not visible to the caller. Confirm the service ID is correct and the API key has access.", req.ID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Error verifying service for import", err.Error())
+		return
+	}
+	if service.IsPrimary != nil && !*service.IsPrimary {
+		resp.Diagnostics.AddError(
+			"Cannot import upgrade window on a secondary service",
+			fmt.Sprintf("Service %s is a secondary service. Upgrade windows can only be managed on the primary service; secondary services inherit the primary's window.", req.ID),
+		)
+		return
+	}
+
 	// `id` and `service_id` are equal — write both so Read finds the service.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), req.ID)...)

--- a/pkg/resource/service_upgrade_window.go
+++ b/pkg/resource/service_upgrade_window.go
@@ -1,0 +1,223 @@
+package resource
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/resource/models"
+)
+
+var (
+	_ resource.Resource                = &ServiceUpgradeWindowResource{}
+	_ resource.ResourceWithConfigure   = &ServiceUpgradeWindowResource{}
+	_ resource.ResourceWithImportState = &ServiceUpgradeWindowResource{}
+)
+
+//go:embed descriptions/service_upgrade_window.md
+var serviceUpgradeWindowResourceDescription string
+
+func NewServiceUpgradeWindowResource() resource.Resource {
+	return &ServiceUpgradeWindowResource{}
+}
+
+type ServiceUpgradeWindowResource struct {
+	client api.Client
+}
+
+func (r *ServiceUpgradeWindowResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_service_upgrade_window"
+}
+
+func (r *ServiceUpgradeWindowResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: serviceUpgradeWindowResourceDescription,
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Resource identifier. Equal to service_id (one window per service).",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"service_id": schema.StringAttribute{
+				Description: "ClickHouse Cloud service ID this upgrade window applies to.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"weekday": schema.Int64Attribute{
+				Description: "Day of the week the upgrade window starts. 0 = Sunday, 1 = Monday, …, 6 = Saturday.",
+				Required:    true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 6),
+				},
+			},
+			"start_hour_utc": schema.Int64Attribute{
+				Description: "UTC hour when the upgrade window starts. Must be one of 0, 6, 12, or 18.",
+				Required:    true,
+				Validators: []validator.Int64{
+					int64validator.OneOf(0, 6, 12, 18),
+				},
+			},
+			"duration": schema.Int64Attribute{
+				Description: "Length of the upgrade window in hours. Server-controlled; currently always 6.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *ServiceUpgradeWindowResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(api.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected api.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *ServiceUpgradeWindowResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan models.ServiceUpgradeWindowResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceID := plan.ServiceID.ValueString()
+
+	// Refuse to clobber an existing window. The user should import it.
+	existing, err := r.client.GetUpgradeWindow(ctx, serviceID)
+	if err != nil && !api.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error checking for existing upgrade window", err.Error())
+		return
+	}
+	if existing != nil {
+		resp.Diagnostics.AddError(
+			"Upgrade window already exists for this service",
+			fmt.Sprintf("Service %s already has an upgrade window. Import it into Terraform with: terraform import clickhouse_service_upgrade_window.<name> %s", serviceID, serviceID),
+		)
+		return
+	}
+
+	window, err := r.client.UpdateUpgradeWindow(ctx, serviceID, api.UpgradeWindowUpdate{
+		Weekday:      int(plan.Weekday.ValueInt64()),
+		StartHourUtc: int(plan.StartHourUtc.ValueInt64()),
+	})
+	if err != nil {
+		if api.IsNotFound(err) {
+			resp.Diagnostics.AddError(
+				"Service not found",
+				fmt.Sprintf("Service %s does not exist or has been deleted. Confirm clickhouse_service.<name>.id is correct.", serviceID),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Error creating upgrade window", err.Error())
+		return
+	}
+
+	plan.ID = plan.ServiceID
+	applyUpgradeWindowToState(window, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *ServiceUpgradeWindowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state models.ServiceUpgradeWindowResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	serviceID := state.ServiceID.ValueString()
+
+	window, err := r.client.GetUpgradeWindow(ctx, serviceID)
+	if err != nil {
+		if api.IsNotFound(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Error reading upgrade window", err.Error())
+		return
+	}
+
+	state.ID = state.ServiceID
+	applyUpgradeWindowToState(window, &state)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *ServiceUpgradeWindowResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan models.ServiceUpgradeWindowResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	window, err := r.client.UpdateUpgradeWindow(ctx, plan.ServiceID.ValueString(), api.UpgradeWindowUpdate{
+		Weekday:      int(plan.Weekday.ValueInt64()),
+		StartHourUtc: int(plan.StartHourUtc.ValueInt64()),
+	})
+	if err != nil {
+		if api.IsNotFound(err) {
+			resp.Diagnostics.AddError(
+				"Service not found",
+				fmt.Sprintf("Service %s no longer exists. Remove the resource from configuration or recreate the service.", plan.ServiceID.ValueString()),
+			)
+			return
+		}
+		resp.Diagnostics.AddError("Error updating upgrade window", err.Error())
+		return
+	}
+
+	plan.ID = plan.ServiceID
+	applyUpgradeWindowToState(window, &plan)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *ServiceUpgradeWindowResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state models.ServiceUpgradeWindowResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteUpgradeWindow(ctx, state.ServiceID.ValueString())
+	if err != nil && !api.IsNotFound(err) {
+		resp.Diagnostics.AddError("Error deleting upgrade window", err.Error())
+	}
+}
+
+func (r *ServiceUpgradeWindowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// `id` and `service_id` are equal — write both so Read finds the service.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), req.ID)...)
+}
+
+// applyUpgradeWindowToState maps an API UpgradeWindow response into the
+// Terraform state model.
+func applyUpgradeWindowToState(window *api.UpgradeWindow, state *models.ServiceUpgradeWindowResourceModel) {
+	state.Weekday = types.Int64Value(int64(window.Weekday))
+	state.StartHourUtc = types.Int64Value(int64(window.StartHourUtc))
+	state.Duration = types.Int64Value(int64(window.Duration))
+}

--- a/pkg/resource/service_upgrade_window.go
+++ b/pkg/resource/service_upgrade_window.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -69,7 +70,7 @@ func (r *ServiceUpgradeWindowResource) Schema(_ context.Context, _ resource.Sche
 				Description: "UTC hour when the upgrade window starts. Must be one of 0, 6, 12, or 18.",
 				Required:    true,
 				Validators: []validator.Int64{
-					int64validator.OneOf(0, 6, 12, 18),
+					int64validator.OneOf(api.UpgradeWindowAllowedStartHoursUtc...),
 				},
 			},
 			"duration": schema.Int64Attribute{
@@ -127,14 +128,7 @@ func (r *ServiceUpgradeWindowResource) Create(ctx context.Context, req resource.
 		StartHourUtc: int(plan.StartHourUtc.ValueInt64()),
 	})
 	if err != nil {
-		if api.IsNotFound(err) {
-			resp.Diagnostics.AddError(
-				"Service not found",
-				fmt.Sprintf("Service %s does not exist or has been deleted. Confirm clickhouse_service.<name>.id is correct.", serviceID),
-			)
-			return
-		}
-		resp.Diagnostics.AddError("Error creating upgrade window", err.Error())
+		addUpgradeWindowWriteErrorDiagnostic(&resp.Diagnostics, "creating", serviceID, err)
 		return
 	}
 
@@ -179,14 +173,7 @@ func (r *ServiceUpgradeWindowResource) Update(ctx context.Context, req resource.
 		StartHourUtc: int(plan.StartHourUtc.ValueInt64()),
 	})
 	if err != nil {
-		if api.IsNotFound(err) {
-			resp.Diagnostics.AddError(
-				"Service not found",
-				fmt.Sprintf("Service %s no longer exists. Remove the resource from configuration or recreate the service.", plan.ServiceID.ValueString()),
-			)
-			return
-		}
-		resp.Diagnostics.AddError("Error updating upgrade window", err.Error())
+		addUpgradeWindowWriteErrorDiagnostic(&resp.Diagnostics, "updating", plan.ServiceID.ValueString(), err)
 		return
 	}
 
@@ -212,6 +199,34 @@ func (r *ServiceUpgradeWindowResource) ImportState(ctx context.Context, req reso
 	// `id` and `service_id` are equal — write both so Read finds the service.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), req.ID)...)
+}
+
+// addUpgradeWindowWriteErrorDiagnostic specializes the diagnostic for the
+// documented client errors of `PUT /upgradeWindow` (404 service-missing,
+// 400 secondary-service, 403 entitlement). Anything else falls through to
+// the raw error string, which is the same shape every other resource uses.
+// `verb` is "creating" or "updating" so the operation reads naturally in
+// the diagnostic summary.
+func addUpgradeWindowWriteErrorDiagnostic(diags *diag.Diagnostics, verb, serviceID string, err error) {
+	switch {
+	case api.IsNotFound(err):
+		diags.AddError(
+			"Service not found",
+			fmt.Sprintf("Service %s does not exist or is not visible to the caller. Confirm clickhouse_service.<name>.id is correct and the API key has access.", serviceID),
+		)
+	case api.IsBadRequestWith(err, "secondary service"):
+		diags.AddError(
+			"Upgrade windows can only be set on primary services",
+			fmt.Sprintf("Service %s is a secondary service and inherits its upgrade window from the primary. Configure the upgrade window on the primary service instead.", serviceID),
+		)
+	case api.IsForbidden(err):
+		diags.AddError(
+			"Setting an upgrade window requires the scheduled upgrades entitlement",
+			"The organization does not have the `canUseScheduledUpgrades` feature enabled, or the API key lacks `control-plane:service:manage`. Contact ClickHouse support to enable the entitlement.",
+		)
+	default:
+		diags.AddError(fmt.Sprintf("Error %s upgrade window", verb), err.Error())
+	}
 }
 
 // applyUpgradeWindowToState maps an API UpgradeWindow response into the

--- a/pkg/resource/service_upgrade_window_test.go
+++ b/pkg/resource/service_upgrade_window_test.go
@@ -1,0 +1,256 @@
+package resource
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/resource/models"
+)
+
+func TestApplyUpgradeWindowToState_PopulatesAllFields(t *testing.T) {
+	window := &api.UpgradeWindow{Weekday: 3, StartHourUtc: 12, Duration: 6}
+
+	state := &models.ServiceUpgradeWindowResourceModel{
+		ServiceID: types.StringValue("svc-1"),
+	}
+
+	applyUpgradeWindowToState(window, state)
+
+	if state.Weekday.ValueInt64() != 3 {
+		t.Errorf("Weekday = %d; want 3", state.Weekday.ValueInt64())
+	}
+	if state.StartHourUtc.ValueInt64() != 12 {
+		t.Errorf("StartHourUtc = %d; want 12", state.StartHourUtc.ValueInt64())
+	}
+	if state.Duration.ValueInt64() != 6 {
+		t.Errorf("Duration = %d; want 6", state.Duration.ValueInt64())
+	}
+}
+
+// TestServiceUpgradeWindowResource_ImportState verifies that the custom
+// ImportState handler writes both `id` and `service_id` from the user-supplied
+// import ID.
+func TestServiceUpgradeWindowResource_ImportState(t *testing.T) {
+	ctx := context.Background()
+	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+	sch := schemaResp.Schema
+
+	req := resource.ImportStateRequest{ID: "uw-import-1"}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: sch,
+			Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	r.ImportState(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ImportState diags: %v", resp.Diagnostics)
+	}
+
+	var id, serviceID types.String
+	if d := resp.State.GetAttribute(ctx, path.Root("id"), &id); d.HasError() {
+		t.Fatalf("read id: %v", d)
+	}
+	if d := resp.State.GetAttribute(ctx, path.Root("service_id"), &serviceID); d.HasError() {
+		t.Fatalf("read service_id: %v", d)
+	}
+	if id.ValueString() != "uw-import-1" {
+		t.Errorf("id = %q; want uw-import-1", id.ValueString())
+	}
+	if serviceID.ValueString() != "uw-import-1" {
+		t.Errorf("service_id = %q; want uw-import-1", serviceID.ValueString())
+	}
+}
+
+// TestServiceUpgradeWindowSchema_ValidatorsRejectInvalidValues exercises the
+// attribute validators declared on the schema so the public-API contract
+// (weekday 0-6, start_hour_utc in {0,6,12,18}) is enforced before any API call.
+func TestServiceUpgradeWindowSchema_ValidatorsRejectInvalidValues(t *testing.T) {
+	ctx := context.Background()
+	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+
+	weekdayAttr, ok := schemaResp.Schema.Attributes["weekday"].(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("weekday attribute is not Int64Attribute")
+	}
+	startHourAttr, ok := schemaResp.Schema.Attributes["start_hour_utc"].(schema.Int64Attribute)
+	if !ok {
+		t.Fatalf("start_hour_utc attribute is not Int64Attribute")
+	}
+
+	cases := []struct {
+		name        string
+		validators  []validator.Int64
+		attrPath    path.Path
+		value       int64
+		wantInvalid bool
+	}{
+		{name: "weekday=-1", validators: weekdayAttr.Validators, attrPath: path.Root("weekday"), value: -1, wantInvalid: true},
+		{name: "weekday=0", validators: weekdayAttr.Validators, attrPath: path.Root("weekday"), value: 0, wantInvalid: false},
+		{name: "weekday=6", validators: weekdayAttr.Validators, attrPath: path.Root("weekday"), value: 6, wantInvalid: false},
+		{name: "weekday=7", validators: weekdayAttr.Validators, attrPath: path.Root("weekday"), value: 7, wantInvalid: true},
+
+		{name: "start_hour=0", validators: startHourAttr.Validators, attrPath: path.Root("start_hour_utc"), value: 0, wantInvalid: false},
+		{name: "start_hour=3", validators: startHourAttr.Validators, attrPath: path.Root("start_hour_utc"), value: 3, wantInvalid: true},
+		{name: "start_hour=6", validators: startHourAttr.Validators, attrPath: path.Root("start_hour_utc"), value: 6, wantInvalid: false},
+		{name: "start_hour=18", validators: startHourAttr.Validators, attrPath: path.Root("start_hour_utc"), value: 18, wantInvalid: false},
+		{name: "start_hour=24", validators: startHourAttr.Validators, attrPath: path.Root("start_hour_utc"), value: 24, wantInvalid: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if len(tc.validators) == 0 {
+				t.Fatalf("no validators on %s", tc.attrPath)
+			}
+
+			req := validator.Int64Request{
+				Path:        tc.attrPath,
+				ConfigValue: types.Int64Value(tc.value),
+			}
+			resp := &validator.Int64Response{}
+			for _, v := range tc.validators {
+				v.ValidateInt64(ctx, req, resp)
+			}
+			if resp.Diagnostics.HasError() != tc.wantInvalid {
+				t.Errorf("validation hasError=%v; want %v (diags=%v)", resp.Diagnostics.HasError(), tc.wantInvalid, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// TestServiceUpgradeWindowResource_Create_RefusesToClobber drives Create end to
+// end with a mocked API client to lock in the documented behavior: if a window
+// already exists for the service, Create must surface an "import it" diagnostic
+// and never issue a PUT. This is the only branch of the resource where the
+// provider intentionally deviates from PUT-as-upsert.
+func TestServiceUpgradeWindowResource_Create_RefusesToClobber(t *testing.T) {
+	ctx := context.Background()
+	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+	sch := schemaResp.Schema
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(&api.UpgradeWindow{Weekday: 0, StartHourUtc: 0, Duration: 6}, nil)
+	// UpdateUpgradeWindowMock is intentionally not set — minimock fails the test
+	// if Update is called, proving the clobber-guard short-circuits.
+
+	planRaw := tftypes.NewValue(sch.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, nil),
+		"service_id":     tftypes.NewValue(tftypes.String, "svc-1"),
+		"weekday":        tftypes.NewValue(tftypes.Number, big.NewFloat(3)),
+		"start_hour_utc": tftypes.NewValue(tftypes.Number, big.NewFloat(12)),
+		"duration":       tftypes.NewValue(tftypes.Number, nil),
+	})
+
+	req := resource.CreateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: planRaw},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{
+			Schema: sch,
+			Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("Create should have produced an error diagnostic; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "Upgrade window already exists for this service" {
+		t.Errorf("diagnostic summary = %q; want \"Upgrade window already exists for this service\"", got)
+	}
+}
+
+// TestServiceUpgradeWindowResource_Create_404OnGetProceedsWithPut covers the
+// happy path: GET returns 404 (no existing window), so Create issues a PUT and
+// writes the returned window into state.
+func TestServiceUpgradeWindowResource_Create_404OnGetProceedsWithPut(t *testing.T) {
+	ctx := context.Background()
+	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+	sch := schemaResp.Schema
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(nil, errors.New("status: 404, body: not found")).
+		UpdateUpgradeWindowMock.
+		Expect(ctx, "svc-1", api.UpgradeWindowUpdate{Weekday: 3, StartHourUtc: 12}).
+		Return(&api.UpgradeWindow{Weekday: 3, StartHourUtc: 12, Duration: 6}, nil)
+
+	planRaw := tftypes.NewValue(sch.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, nil),
+		"service_id":     tftypes.NewValue(tftypes.String, "svc-1"),
+		"weekday":        tftypes.NewValue(tftypes.Number, big.NewFloat(3)),
+		"start_hour_utc": tftypes.NewValue(tftypes.Number, big.NewFloat(12)),
+		"duration":       tftypes.NewValue(tftypes.Number, nil),
+	})
+
+	req := resource.CreateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: planRaw},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{
+			Schema: sch,
+			Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var got models.ServiceUpgradeWindowResourceModel
+	if diags := resp.State.Get(ctx, &got); diags.HasError() {
+		t.Fatalf("read state: %v", diags)
+	}
+	if got.ID.ValueString() != "svc-1" {
+		t.Errorf("state ID = %q; want svc-1", got.ID.ValueString())
+	}
+	if got.Weekday.ValueInt64() != 3 || got.StartHourUtc.ValueInt64() != 12 || got.Duration.ValueInt64() != 6 {
+		t.Errorf("state values = (weekday=%d, start=%d, duration=%d); want (3, 12, 6)",
+			got.Weekday.ValueInt64(), got.StartHourUtc.ValueInt64(), got.Duration.ValueInt64())
+	}
+}

--- a/pkg/resource/service_upgrade_window_test.go
+++ b/pkg/resource/service_upgrade_window_test.go
@@ -254,3 +254,323 @@ func TestServiceUpgradeWindowResource_Create_404OnGetProceedsWithPut(t *testing.
 			got.Weekday.ValueInt64(), got.StartHourUtc.ValueInt64(), got.Duration.ValueInt64())
 	}
 }
+
+// resourceWithSchema returns a configured resource and its schema. Used by
+// the lifecycle tests below to keep each test focused on its branch.
+func resourceWithSchema(t *testing.T) (*ServiceUpgradeWindowResource, schema.Schema) {
+	t.Helper()
+	ctx := context.Background()
+	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+	return r, schemaResp.Schema
+}
+
+// upgradeWindowPlanRaw builds a tftypes.Value matching the resource schema
+// for use as `req.Plan.Raw` in Create/Update tests.
+func upgradeWindowPlanRaw(ctx context.Context, sch schema.Schema, serviceID string, weekday, startHourUtc int64) tftypes.Value {
+	return tftypes.NewValue(sch.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, nil),
+		"service_id":     tftypes.NewValue(tftypes.String, serviceID),
+		"weekday":        tftypes.NewValue(tftypes.Number, big.NewFloat(float64(weekday))),
+		"start_hour_utc": tftypes.NewValue(tftypes.Number, big.NewFloat(float64(startHourUtc))),
+		"duration":       tftypes.NewValue(tftypes.Number, nil),
+	})
+}
+
+// upgradeWindowStateRaw builds a fully-populated tftypes.Value for use as
+// `req.State.Raw` in Read/Update/Delete tests.
+func upgradeWindowStateRaw(ctx context.Context, sch schema.Schema, serviceID string, weekday, startHourUtc, duration int64) tftypes.Value {
+	return tftypes.NewValue(sch.Type().TerraformType(ctx), map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, serviceID),
+		"service_id":     tftypes.NewValue(tftypes.String, serviceID),
+		"weekday":        tftypes.NewValue(tftypes.Number, big.NewFloat(float64(weekday))),
+		"start_hour_utc": tftypes.NewValue(tftypes.Number, big.NewFloat(float64(startHourUtc))),
+		"duration":       tftypes.NewValue(tftypes.Number, big.NewFloat(float64(duration))),
+	})
+}
+
+func TestServiceUpgradeWindowResource_Create_GetReturnsTransientError(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	// 500 from GET — clobber-guard must propagate, never silently fall through to PUT.
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(nil, errors.New("status: 500, body: internal server error"))
+
+	req := resource.CreateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: upgradeWindowPlanRaw(ctx, sch, "svc-1", 3, 12)},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: sch, Raw: tftypes.NewValue(sch.Type().TerraformType(ctx), nil)},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("Create should have produced an error on transient GET failure; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "Error checking for existing upgrade window" {
+		t.Errorf("diagnostic summary = %q; want \"Error checking for existing upgrade window\"", got)
+	}
+}
+
+func TestServiceUpgradeWindowResource_Create_UpdateReturns404(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(nil, errors.New("status: 404, body: not found")).
+		UpdateUpgradeWindowMock.
+		Expect(ctx, "svc-1", api.UpgradeWindowUpdate{Weekday: 3, StartHourUtc: 12}).
+		Return(nil, errors.New("status: 404, body: not found"))
+
+	req := resource.CreateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: upgradeWindowPlanRaw(ctx, sch, "svc-1", 3, 12)},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: sch, Raw: tftypes.NewValue(sch.Type().TerraformType(ctx), nil)},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("Create should error when PUT returns 404; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "Service not found" {
+		t.Errorf("diagnostic summary = %q; want \"Service not found\"", got)
+	}
+}
+
+// TestServiceUpgradeWindowResource_Create_SpecializedErrors covers the
+// documented 400-secondary and 403-entitlement branches from the OpenAPI
+// handler. Drives Create with mocks returning those exact errors and asserts
+// the specialized diagnostic surfaces (so customers don't paste raw
+// "status: 4xx" strings into support tickets).
+func TestServiceUpgradeWindowResource_Create_SpecializedErrors(t *testing.T) {
+	cases := []struct {
+		name        string
+		updateErr   error
+		wantSummary string
+	}{
+		{
+			name:        "400 secondary service",
+			updateErr:   errors.New("status: 400, body: cannot set upgrade window on a secondary service"),
+			wantSummary: "Upgrade windows can only be set on primary services",
+		},
+		{
+			name:        "403 entitlement",
+			updateErr:   errors.New("status: 403, body: organization lacks canUseScheduledUpgrades"),
+			wantSummary: "Setting an upgrade window requires the scheduled upgrades entitlement",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			r, sch := resourceWithSchema(t)
+
+			mc := minimock.NewController(t)
+			r.client = api.NewClientMock(mc).
+				GetUpgradeWindowMock.
+				Expect(ctx, "svc-1").
+				Return(nil, errors.New("status: 404, body: not found")).
+				UpdateUpgradeWindowMock.
+				Expect(ctx, "svc-1", api.UpgradeWindowUpdate{Weekday: 3, StartHourUtc: 12}).
+				Return(nil, tc.updateErr)
+
+			req := resource.CreateRequest{
+				Plan: tfsdk.Plan{Schema: sch, Raw: upgradeWindowPlanRaw(ctx, sch, "svc-1", 3, 12)},
+			}
+			resp := &resource.CreateResponse{
+				State: tfsdk.State{Schema: sch, Raw: tftypes.NewValue(sch.Type().TerraformType(ctx), nil)},
+			}
+
+			r.Create(ctx, req, resp)
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected error diagnostic for %s; got %v", tc.name, resp.Diagnostics)
+			}
+			if got := resp.Diagnostics[0].Summary(); got != tc.wantSummary {
+				t.Errorf("diagnostic summary = %q; want %q", got, tc.wantSummary)
+			}
+		})
+	}
+}
+
+func TestServiceUpgradeWindowResource_Read_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(&api.UpgradeWindow{Weekday: 5, StartHourUtc: 18, Duration: 6}, nil)
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 0, 0, 0)},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: sch, Raw: tftypes.NewValue(sch.Type().TerraformType(ctx), nil)},
+	}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+	var got models.ServiceUpgradeWindowResourceModel
+	if d := resp.State.Get(ctx, &got); d.HasError() {
+		t.Fatalf("read state: %v", d)
+	}
+	if got.Weekday.ValueInt64() != 5 || got.StartHourUtc.ValueInt64() != 18 || got.Duration.ValueInt64() != 6 {
+		t.Errorf("state = (weekday=%d, start=%d, duration=%d); want (5, 18, 6)",
+			got.Weekday.ValueInt64(), got.StartHourUtc.ValueInt64(), got.Duration.ValueInt64())
+	}
+}
+
+func TestServiceUpgradeWindowResource_Read_404RemovesResource(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(nil, errors.New("status: 404, body: not found"))
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 0, 0, 0)},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 0, 0, 0)},
+	}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read should not error on 404; got %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Errorf("Read should remove resource from state on 404; State.Raw.IsNull() = false")
+	}
+}
+
+func TestServiceUpgradeWindowResource_Update_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		UpdateUpgradeWindowMock.
+		Expect(ctx, "svc-1", api.UpgradeWindowUpdate{Weekday: 1, StartHourUtc: 6}).
+		Return(&api.UpgradeWindow{Weekday: 1, StartHourUtc: 6, Duration: 6}, nil)
+
+	req := resource.UpdateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: upgradeWindowPlanRaw(ctx, sch, "svc-1", 1, 6)},
+	}
+	resp := &resource.UpdateResponse{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics: %v", resp.Diagnostics)
+	}
+	var got models.ServiceUpgradeWindowResourceModel
+	if d := resp.State.Get(ctx, &got); d.HasError() {
+		t.Fatalf("read state: %v", d)
+	}
+	if got.Weekday.ValueInt64() != 1 || got.StartHourUtc.ValueInt64() != 6 {
+		t.Errorf("state = (weekday=%d, start=%d); want (1, 6)", got.Weekday.ValueInt64(), got.StartHourUtc.ValueInt64())
+	}
+}
+
+func TestServiceUpgradeWindowResource_Update_404(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		UpdateUpgradeWindowMock.
+		Expect(ctx, "svc-1", api.UpgradeWindowUpdate{Weekday: 1, StartHourUtc: 6}).
+		Return(nil, errors.New("status: 404, body: not found"))
+
+	req := resource.UpdateRequest{
+		Plan: tfsdk.Plan{Schema: sch, Raw: upgradeWindowPlanRaw(ctx, sch, "svc-1", 1, 6)},
+	}
+	resp := &resource.UpdateResponse{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+
+	r.Update(ctx, req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("Update should error on 404; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "Service not found" {
+		t.Errorf("diagnostic summary = %q; want \"Service not found\"", got)
+	}
+}
+
+func TestServiceUpgradeWindowResource_Delete_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		DeleteUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(nil)
+
+	req := resource.DeleteRequest{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+	resp := &resource.DeleteResponse{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+
+	r.Delete(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Delete returned diagnostics: %v", resp.Diagnostics)
+	}
+}
+
+// TestServiceUpgradeWindowResource_Delete_404IsSwallowed verifies that
+// destroying a resource whose window has already been cleared out-of-band
+// is a no-op rather than a Terraform-failing error.
+func TestServiceUpgradeWindowResource_Delete_404IsSwallowed(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		DeleteUpgradeWindowMock.
+		Expect(ctx, "svc-1").
+		Return(errors.New("status: 404, body: not found"))
+
+	req := resource.DeleteRequest{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+	resp := &resource.DeleteResponse{
+		State: tfsdk.State{Schema: sch, Raw: upgradeWindowStateRaw(ctx, sch, "svc-1", 3, 12, 6)},
+	}
+
+	r.Delete(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Errorf("Delete should swallow 404; got %v", resp.Diagnostics)
+	}
+}

--- a/pkg/resource/service_upgrade_window_test.go
+++ b/pkg/resource/service_upgrade_window_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/resource/models"
 )
 
+const serviceNotFoundSummary = "Service not found"
+
 func TestApplyUpgradeWindowToState_PopulatesAllFields(t *testing.T) {
 	window := &api.UpgradeWindow{Weekday: 3, StartHourUtc: 12, Duration: 6}
 
@@ -39,19 +41,19 @@ func TestApplyUpgradeWindowToState_PopulatesAllFields(t *testing.T) {
 	}
 }
 
-// TestServiceUpgradeWindowResource_ImportState verifies that the custom
-// ImportState handler writes both `id` and `service_id` from the user-supplied
-// import ID.
-func TestServiceUpgradeWindowResource_ImportState(t *testing.T) {
+// TestServiceUpgradeWindowResource_ImportState_Primary verifies the happy
+// path: GetService returns a primary service, ImportState writes both `id`
+// and `service_id` from the user-supplied import ID.
+func TestServiceUpgradeWindowResource_ImportState_Primary(t *testing.T) {
 	ctx := context.Background()
-	r := NewServiceUpgradeWindowResource().(*ServiceUpgradeWindowResource)
+	r, sch := resourceWithSchema(t)
 
-	schemaResp := &resource.SchemaResponse{}
-	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
-	if schemaResp.Diagnostics.HasError() {
-		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
-	}
-	sch := schemaResp.Schema
+	isPrimary := true
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetServiceMock.
+		Expect(ctx, "uw-import-1").
+		Return(&api.Service{Id: "uw-import-1", IsPrimary: &isPrimary}, nil)
 
 	req := resource.ImportStateRequest{ID: "uw-import-1"}
 	resp := &resource.ImportStateResponse{
@@ -78,6 +80,70 @@ func TestServiceUpgradeWindowResource_ImportState(t *testing.T) {
 	}
 	if serviceID.ValueString() != "uw-import-1" {
 		t.Errorf("service_id = %q; want uw-import-1", serviceID.ValueString())
+	}
+}
+
+// TestServiceUpgradeWindowResource_ImportState_Secondary verifies the guard
+// added after PR review: importing a secondary service ID is refused with a
+// clear diagnostic rather than wedging the resource (GET would succeed on a
+// secondary because it returns the inherited primary's window, but every
+// subsequent PUT/DELETE would 400).
+func TestServiceUpgradeWindowResource_ImportState_Secondary(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	isPrimary := false
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetServiceMock.
+		Expect(ctx, "secondary-1").
+		Return(&api.Service{Id: "secondary-1", IsPrimary: &isPrimary}, nil)
+
+	req := resource.ImportStateRequest{ID: "secondary-1"}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: sch,
+			Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	r.ImportState(ctx, req, resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("ImportState should refuse a secondary service; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "Cannot import upgrade window on a secondary service" {
+		t.Errorf("diagnostic summary = %q; want \"Cannot import upgrade window on a secondary service\"", got)
+	}
+}
+
+// TestServiceUpgradeWindowResource_ImportState_ServiceNotFound verifies that
+// importing a non-existent service ID fails fast with a clear diagnostic,
+// instead of the previous "succeed-then-disappear" flow where Read would 404
+// and silently remove the resource on next refresh.
+func TestServiceUpgradeWindowResource_ImportState_ServiceNotFound(t *testing.T) {
+	ctx := context.Background()
+	r, sch := resourceWithSchema(t)
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).
+		GetServiceMock.
+		Expect(ctx, "missing-svc").
+		Return(nil, errors.New("status: 404, body: not found"))
+
+	req := resource.ImportStateRequest{ID: "missing-svc"}
+	resp := &resource.ImportStateResponse{
+		State: tfsdk.State{
+			Schema: sch,
+			Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+		},
+	}
+
+	r.ImportState(ctx, req, resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("ImportState should error on 404; got %v", resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != serviceNotFoundSummary {
+		t.Errorf("diagnostic summary = %q; want %q", got, serviceNotFoundSummary)
 	}
 }
 
@@ -346,8 +412,8 @@ func TestServiceUpgradeWindowResource_Create_UpdateReturns404(t *testing.T) {
 	if !resp.Diagnostics.HasError() {
 		t.Fatalf("Create should error when PUT returns 404; got %v", resp.Diagnostics)
 	}
-	if got := resp.Diagnostics[0].Summary(); got != "Service not found" {
-		t.Errorf("diagnostic summary = %q; want \"Service not found\"", got)
+	if got := resp.Diagnostics[0].Summary(); got != serviceNotFoundSummary {
+		t.Errorf("diagnostic summary = %q; want %q", got, serviceNotFoundSummary)
 	}
 }
 
@@ -519,8 +585,8 @@ func TestServiceUpgradeWindowResource_Update_404(t *testing.T) {
 	if !resp.Diagnostics.HasError() {
 		t.Fatalf("Update should error on 404; got %v", resp.Diagnostics)
 	}
-	if got := resp.Diagnostics[0].Summary(); got != "Service not found" {
-		t.Errorf("diagnostic summary = %q; want \"Service not found\"", got)
+	if got := resp.Diagnostics[0].Summary(); got != serviceNotFoundSummary {
+		t.Errorf("diagnostic summary = %q; want %q", got, serviceNotFoundSummary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a new `clickhouse_service_upgrade_window` Terraform resource that wraps the OpenAPI service upgrade window endpoints (`GET`/`PUT`/`DELETE /v1/organizations/:orgId/services/:instanceId/upgradeWindow`).
- One record per service (`id == service_id`, `RequiresReplace` on `service_id`). Schema enforces the public API contract: `weekday` 0–6, `start_hour_utc` ∈ {0, 6, 12, 18}, `duration` is `Computed`/server-controlled.
- Modeled directly on `clickhouse_service_scheduled_scaling` (PR #536) — same alpha-build registration, same "refuse to clobber" Create probe, same import behavior.

## Why alpha-only
The corresponding OpenAPI endpoint depends on the `canUseScheduledUpgrades` organization entitlement for PUT (DELETE is intentionally not gated so a window can be cleared after entitlement loss). Keeping the registration under `//go:build alpha` matches how `scheduled_scaling` is rolling out.

## Test plan
- [x] `go build ./...` and `go build -tags alpha ./...` both compile
- [x] `go test ./...` and `go test -tags alpha ./...` both pass
- [x] `make fmt` clean (gofmt + golangci-lint)
- [x] Unit tests for API client (`GET`, `UPDATE`, `DELETE`, plus 404 case)
- [x] Unit tests for state mapping, `ImportState`, schema validators
- [x] Mock-driven tests for `Create`'s clobber-guard and 404-then-PUT happy path
- [ ] Manual acceptance smoke against a dev control plane org with `canUseScheduledUpgrades` (out of scope here; can be done after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)