### PR TITLE
PubSub: Drop snapshot support

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -557,7 +557,7 @@ Required:
 - `authentication` (String) The authentication method for the Pub/Sub source. Currently only `SERVICE_ACCOUNT` is supported.
 - `format` (String) The message format of the Pub/Sub topic. (`JSONEachRow`, `Avro`, `Protobuf`)
 - `project_id` (String) The GCP project ID that owns the Pub/Sub topic.
-- `seek_type` (String) The starting position for consuming the subscription. (`latest`, `earliest`, `timestamp`, `snapshot`)
+- `seek_type` (String) The starting position for consuming the subscription. (`latest`, `earliest`, `timestamp`)
 - `service_account_key` (Attributes) GCP service account credentials. Required on create; provide a new value on update to rotate the key. (see [below for nested schema](#nestedatt--source--pubsub--service_account_key))
 - `topic` (String) The Pub/Sub topic name (not the fully-qualified path).
 
@@ -566,7 +566,6 @@ Optional:
 - `ack_deadline` (Number) Acknowledgement deadline in seconds (10–600).
 - `enable_ordering` (Boolean) Whether to enable ordered message delivery. Immutable — changing it requires destroy+create because ordered delivery is a property of the subscription at creation time.
 - `filter` (String) Optional Pub/Sub subscription filter expression (CEL). Max 256 characters. Immutable — changing it requires destroy+create because the underlying subscription filter cannot be edited in place.
-- `seek_snapshot` (String) The Pub/Sub snapshot identifier. Required when `seek_type = "snapshot"`; must be omitted otherwise.
 - `seek_timestamp` (String) RFC 3339 timestamp (e.g. `2026-04-10T12:00:00Z`). Required when `seek_type = "timestamp"`; must be omitted otherwise.
 
 <a id="nestedatt--source--pubsub--service_account_key"></a>

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -159,14 +159,12 @@ const (
 	ClickPipePubSubSeekTypeLatest    = "latest"
 	ClickPipePubSubSeekTypeEarliest  = "earliest"
 	ClickPipePubSubSeekTypeTimestamp = "timestamp"
-	ClickPipePubSubSeekTypeSnapshot  = "snapshot"
 )
 
 var ClickPipePubSubSeekTypes = []string{
 	ClickPipePubSubSeekTypeLatest,
 	ClickPipePubSubSeekTypeEarliest,
 	ClickPipePubSubSeekTypeTimestamp,
-	ClickPipePubSubSeekTypeSnapshot,
 }
 
 var ClickPipePubSubAuthenticationMethods = []string{

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -158,7 +158,6 @@ type ClickPipePubSubSource struct {
 
 	SeekType      string  `json:"seekType"`
 	SeekTimestamp *string `json:"seekTimestamp,omitempty"`
-	SeekSnapshot  *string `json:"seekSnapshot,omitempty"`
 
 	Filter         *string `json:"filter,omitempty"`
 	EnableOrdering *bool   `json:"enableOrdering,omitempty"`

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -716,16 +716,6 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									stringplanmodifier.RequiresReplace(),
 								},
 							},
-							"seek_snapshot": schema.StringAttribute{
-								MarkdownDescription: fmt.Sprintf(
-									"The Pub/Sub snapshot identifier. Required when `seek_type = \"%s\"`; must be omitted otherwise.",
-									api.ClickPipePubSubSeekTypeSnapshot,
-								),
-								Optional: true,
-								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.RequiresReplace(),
-								},
-							},
 							"filter": schema.StringAttribute{
 								MarkdownDescription: "Optional Pub/Sub subscription filter expression (CEL). Max 256 characters. Immutable — changing it requires destroy+create because the underlying subscription filter cannot be edited in place.",
 								Optional:            true,
@@ -2806,7 +2796,6 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			Authentication: pubsubModel.Authentication.ValueString(),
 			SeekType:       pubsubModel.SeekType.ValueString(),
 			SeekTimestamp:  pubsubModel.SeekTimestamp.ValueStringPointer(),
-			SeekSnapshot:   pubsubModel.SeekSnapshot.ValueStringPointer(),
 			Filter:         pubsubModel.Filter.ValueStringPointer(),
 			EnableOrdering: pubsubModel.EnableOrdering.ValueBoolPointer(),
 			AckDeadline:    pubsubModel.AckDeadline.ValueInt64Pointer(),
@@ -3723,7 +3712,6 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			Authentication: types.StringValue(clickPipe.Source.PubSub.Authentication),
 			SeekType:       types.StringValue(clickPipe.Source.PubSub.SeekType),
 			SeekTimestamp:  types.StringPointerValue(clickPipe.Source.PubSub.SeekTimestamp),
-			SeekSnapshot:   types.StringPointerValue(clickPipe.Source.PubSub.SeekSnapshot),
 			Filter:         types.StringPointerValue(clickPipe.Source.PubSub.Filter),
 		}
 

--- a/pkg/resource/clickpipe_config_validators.go
+++ b/pkg/resource/clickpipe_config_validators.go
@@ -13,12 +13,12 @@ import (
 )
 
 // pubsubSeekValidator enforces the cross-field rules between
-// source.pubsub.seek_type, seek_timestamp, and seek_snapshot. The server
-// rejects mismatches with a 400; this surfaces the same error at plan time.
+// source.pubsub.seek_type and seek_timestamp. The server rejects mismatches
+// with a 400; this surfaces the same error at plan time.
 type pubsubSeekValidator struct{}
 
 func (v pubsubSeekValidator) Description(_ context.Context) string {
-	return "Validates that source.pubsub.seek_timestamp and seek_snapshot match the chosen seek_type."
+	return "Validates that source.pubsub.seek_timestamp matches the chosen seek_type."
 }
 
 func (v pubsubSeekValidator) MarkdownDescription(ctx context.Context) string {
@@ -59,10 +59,8 @@ func (v pubsubSeekValidator) ValidateResource(ctx context.Context, req resource.
 
 	seekType := pubsubModel.SeekType.ValueString()
 	tsSet := !pubsubModel.SeekTimestamp.IsNull() && !pubsubModel.SeekTimestamp.IsUnknown()
-	snapSet := !pubsubModel.SeekSnapshot.IsNull() && !pubsubModel.SeekSnapshot.IsUnknown()
 
 	timestampPath := path.Root("source").AtName("pubsub").AtName("seek_timestamp")
-	snapshotPath := path.Root("source").AtName("pubsub").AtName("seek_snapshot")
 
 	switch seekType {
 	case api.ClickPipePubSubSeekTypeLatest, api.ClickPipePubSubSeekTypeEarliest:
@@ -73,41 +71,12 @@ func (v pubsubSeekValidator) ValidateResource(ctx context.Context, req resource.
 				fmt.Sprintf("seek_timestamp must not be set when seek_type is %q.", seekType),
 			)
 		}
-		if snapSet {
-			resp.Diagnostics.AddAttributeError(
-				snapshotPath,
-				"Invalid Pub/Sub seek configuration",
-				fmt.Sprintf("seek_snapshot must not be set when seek_type is %q.", seekType),
-			)
-		}
 	case api.ClickPipePubSubSeekTypeTimestamp:
 		if !tsSet {
 			resp.Diagnostics.AddAttributeError(
 				timestampPath,
 				"Invalid Pub/Sub seek configuration",
 				fmt.Sprintf("seek_timestamp is required when seek_type is %q.", seekType),
-			)
-		}
-		if snapSet {
-			resp.Diagnostics.AddAttributeError(
-				snapshotPath,
-				"Invalid Pub/Sub seek configuration",
-				fmt.Sprintf("seek_snapshot must not be set when seek_type is %q.", seekType),
-			)
-		}
-	case api.ClickPipePubSubSeekTypeSnapshot:
-		if !snapSet {
-			resp.Diagnostics.AddAttributeError(
-				snapshotPath,
-				"Invalid Pub/Sub seek configuration",
-				fmt.Sprintf("seek_snapshot is required when seek_type is %q.", seekType),
-			)
-		}
-		if tsSet {
-			resp.Diagnostics.AddAttributeError(
-				timestampPath,
-				"Invalid Pub/Sub seek configuration",
-				fmt.Sprintf("seek_timestamp must not be set when seek_type is %q.", seekType),
 			)
 		}
 	}

--- a/pkg/resource/clickpipe_pubsub_test.go
+++ b/pkg/resource/clickpipe_pubsub_test.go
@@ -18,7 +18,7 @@ import (
 // as-is so tests can exercise null vs. set behavior.
 func buildPubSubPlan(
 	format, projectID, topic, seekType string,
-	seekTimestamp, seekSnapshot, filter types.String,
+	seekTimestamp, filter types.String,
 	enableOrdering types.Bool,
 	ackDeadline types.Int64,
 	serviceAccountFile types.String,
@@ -33,7 +33,6 @@ func buildPubSubPlan(
 		"authentication":      types.StringValue(api.ClickPipeAuthenticationServiceAccount),
 		"seek_type":           types.StringValue(seekType),
 		"seek_timestamp":      seekTimestamp,
-		"seek_snapshot":       seekSnapshot,
 		"filter":              filter,
 		"enable_ordering":     enableOrdering,
 		"ack_deadline":        ackDeadline,
@@ -68,7 +67,6 @@ func TestExtractSourceFromPlan_PubSub_LatestCreate(t *testing.T) {
 		api.ClickPipePubSubSeekTypeLatest,
 		types.StringNull(),
 		types.StringNull(),
-		types.StringNull(),
 		types.BoolNull(),
 		types.Int64Null(),
 		types.StringValue("base64-encoded-key"),
@@ -86,7 +84,6 @@ func TestExtractSourceFromPlan_PubSub_LatestCreate(t *testing.T) {
 	assert.Equal(t, api.ClickPipeAuthenticationServiceAccount, source.PubSub.Authentication)
 	assert.Equal(t, api.ClickPipePubSubSeekTypeLatest, source.PubSub.SeekType)
 	assert.Nil(t, source.PubSub.SeekTimestamp)
-	assert.Nil(t, source.PubSub.SeekSnapshot)
 	assert.Nil(t, source.PubSub.Filter)
 	assert.Nil(t, source.PubSub.EnableOrdering)
 	assert.Nil(t, source.PubSub.AckDeadline)
@@ -104,7 +101,6 @@ func TestExtractSourceFromPlan_PubSub_TimestampWithOptionalFields(t *testing.T) 
 		"events",
 		api.ClickPipePubSubSeekTypeTimestamp,
 		types.StringValue("2026-04-10T12:00:00Z"),
-		types.StringNull(),
 		types.StringValue(`attributes.env = "prod"`),
 		types.BoolValue(true),
 		types.Int64Value(120),
@@ -136,7 +132,6 @@ func TestExtractSourceFromPlan_PubSub_UpdateIncludesAllFields(t *testing.T) {
 		"my-gcp-project",
 		"events",
 		api.ClickPipePubSubSeekTypeLatest,
-		types.StringNull(),
 		types.StringNull(),
 		types.StringValue("attributes.env = \"prod\""),
 		types.BoolValue(false),

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -263,7 +263,6 @@ type ClickPipePubSubSourceModel struct {
 	Authentication    types.String `tfsdk:"authentication"`
 	SeekType          types.String `tfsdk:"seek_type"`
 	SeekTimestamp     types.String `tfsdk:"seek_timestamp"`
-	SeekSnapshot      types.String `tfsdk:"seek_snapshot"`
 	Filter            types.String `tfsdk:"filter"`
 	EnableOrdering    types.Bool   `tfsdk:"enable_ordering"`
 	AckDeadline       types.Int64  `tfsdk:"ack_deadline"`
@@ -279,7 +278,6 @@ func (m ClickPipePubSubSourceModel) ObjectType() types.ObjectType {
 			"authentication":      types.StringType,
 			"seek_type":           types.StringType,
 			"seek_timestamp":      types.StringType,
-			"seek_snapshot":       types.StringType,
 			"filter":              types.StringType,
 			"enable_ordering":     types.BoolType,
 			"ack_deadline":        types.Int64Type,
@@ -296,7 +294,6 @@ func (m ClickPipePubSubSourceModel) ObjectValue() types.Object {
 		"authentication":      m.Authentication,
 		"seek_type":           m.SeekType,
 		"seek_timestamp":      m.SeekTimestamp,
-		"seek_snapshot":       m.SeekSnapshot,
 		"filter":              m.Filter,
 		"enable_ordering":     m.EnableOrdering,
 		"ack_deadline":        m.AckDeadline,


### PR DESCRIPTION
Drop support in ClickPipes PubSub provider for snapshot sampling since it has been removed.