### PR TITLE
ci(golangci-lint): use latest v2 version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,36 @@
+version: 2
+
 linters:
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - gosec
     - unconvert
     - dupl
     - goconst
-    - goimports
     - copyloopvar
-    - gofumpt
+    - staticcheck
 
 linters-settings:
   dupl:
     # TODO: Lower back to default (150) once the ClickPipe resource Postgres/MySQL
     # CDC duplication has been refactored.
     threshold: 500
-  goimports:
-    # Put imports beginning with prefix after 3rd-party packages.
-    # It's a comma-separated list of prefixes.
-    autofix: true
-    local-prefixes: github.com/ClickHouse/terraform-provider-clickhouse
+
+formatters:
+  enable:
+    - goimports
+    - gofumpt
+  settings:
+    goimports:
+      # Put imports beginning with prefix after 3rd-party packages.
+      # It's a comma-separated list of prefixes.
+      local-prefixes: github.com/ClickHouse/terraform-provider-clickhouse
 
 run:
   timeout: 10m
-  skip-dirs:
-  skip-dirs-default: true
+
+issues:
+  exclude-dirs-use-default: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: 2
+version: "2"
 
 linters:
   enable:
@@ -11,26 +11,53 @@ linters:
     - dupl
     - goconst
     - copyloopvar
-    - staticcheck
-
-linters-settings:
-  dupl:
-    # TODO: Lower back to default (150) once the ClickPipe resource Postgres/MySQL
-    # CDC duplication has been refactored.
-    threshold: 500
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    # Former issues.exclude-dirs-use-default: true
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    # Test fixtures legitimately repeat literals and embed fake credentials.
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
+          - gosec
+          - dupl
+      # goconst flags Terraform schema attribute keys (idiomatic string literals)
+      # throughout the schema-definition packages. Keep goconst active only on the
+      # client/logic code (pkg/internal/...), where magic-string detection has value.
+      - path: (pkg/resource|pkg/datasource)
+        linters:
+          - goconst
+      # Postgres and MySQL ClickPipe sources are intentionally implemented as parallel
+      # code paths (distinct model/API types). The resulting duplication is accepted.
+      - path: pkg/resource/clickpipe\.go
+        linters:
+          - dupl
 
 formatters:
   enable:
     - goimports
     - gofumpt
+  exclusions:
+    # Former issues.exclude-dirs-use-default: true
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
   settings:
     goimports:
       # Put imports beginning with prefix after 3rd-party packages.
       # It's a comma-separated list of prefixes.
-      local-prefixes: github.com/ClickHouse/terraform-provider-clickhouse
+      local-prefixes:
+        - github.com/ClickHouse/terraform-provider-clickhouse
 
 run:
   timeout: 10m
-
-issues:
-  exclude-dirs-use-default: true

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,9 @@ GOLANGCILINT = $(shell go env GOPATH)/bin/golangci-lint
 ifneq ($(shell test -f $(GOLANGCILINT) && echo -n yes),yes)
 GOLANGCILINT = /tmp/golangci-lint
 endif
+ensure-golangci-lint: export GOTOOLCHAIN := go1.26.0
 ensure-golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8)
+	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 define go-get-tool

--- a/pkg/internal/api/postgres.go
+++ b/pkg/internal/api/postgres.go
@@ -290,7 +290,7 @@ func (c *ClientImpl) waitForPostgresStateTransitionAndReturnWithInterval(ctx con
 // password each time. Callers needing retry safety must persist the
 // first-returned password before retrying.
 func (c *ClientImpl) SetPostgresPassword(ctx context.Context, postgresId string, body PostgresPassword) (*PostgresPassword, error) {
-	rb, err := json.Marshal(body)
+	rb, err := json.Marshal(body) //nolint:gosec // Password is an intended request field, not a leak
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode PostgresPassword: %w", err)
 	}

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -63,7 +63,7 @@ const (
 )
 
 const (
-	clickPipeStateChangeMaxWaitSeconds = time.Second * 60 * 2
+	clickPipeStateChangeMaxWait = time.Second * 60 * 2
 
 	// ClickPipe destination table engine types
 	ClickPipeEngineMergeTree          = "MergeTree"
@@ -1983,14 +1983,15 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 				}
 
 				// Validate queue_url requires compatible authentication per storage type
-				if storageType == api.ClickPipeObjectStorageS3Type {
+				switch storageType {
+				case api.ClickPipeObjectStorageS3Type:
 					if authType != api.ClickPipeAuthenticationIAMUser && authType != api.ClickPipeAuthenticationIAMRole {
 						response.Diagnostics.AddError(
 							"Invalid Configuration",
 							"queue_url with S3 requires authentication type to be either IAM_USER or IAM_ROLE",
 						)
 					}
-				} else if storageType == api.ClickPipeObjectStorageGCSType {
+				case api.ClickPipeObjectStorageGCSType:
 					if authType != api.ClickPipeAuthenticationIAMUser && authType != api.ClickPipeAuthenticationServiceAccount {
 						response.Diagnostics.AddError(
 							"Invalid Configuration",
@@ -2663,7 +2664,7 @@ func (c *ClickPipeResource) Create(ctx context.Context, request resource.CreateR
 	// Determine expected state(s) based on configuration
 	stateCheckFunc := c.getStateCheckFunc(ctx, plan)
 
-	finalClickPipe, err := c.client.WaitForClickPipeState(ctx, serviceID, createdClickPipe.ID, stateCheckFunc, clickPipeStateChangeMaxWaitSeconds)
+	finalClickPipe, err := c.client.WaitForClickPipeState(ctx, serviceID, createdClickPipe.ID, stateCheckFunc, clickPipeStateChangeMaxWait)
 	if err != nil {
 		// Only warn if the final state is not acceptable
 		if finalClickPipe == nil || !stateCheckFunc(finalClickPipe.State) {
@@ -2953,14 +2954,15 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			IAMRole:        objectStorageModel.IAMRole.ValueStringPointer(),
 		}
 
-		if storageType == api.ClickPipeObjectStorageAzureBlobType {
+		switch storageType {
+		case api.ClickPipeObjectStorageAzureBlobType:
 			objectStorage.ConnectionString = objectStorageModel.ConnectionString.ValueStringPointer()
 			objectStorage.Path = objectStorageModel.Path.ValueStringPointer()
 			objectStorage.AzureContainerName = objectStorageModel.AzureContainerName.ValueStringPointer()
-		} else if storageType == api.ClickPipeObjectStorageGCSType {
+		case api.ClickPipeObjectStorageGCSType:
 			objectStorage.URL = objectStorageModel.URL.ValueString()
 			objectStorage.ServiceAccountKey = objectStorageModel.ServiceAccountKey.ValueStringPointer()
-		} else {
+		default:
 			objectStorage.URL = objectStorageModel.URL.ValueString()
 		}
 
@@ -3921,17 +3923,18 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 		}
 
 		// Set storage-type-specific fields
-		if clickPipe.Source.ObjectStorage.Type == api.ClickPipeObjectStorageAzureBlobType {
+		switch clickPipe.Source.ObjectStorage.Type {
+		case api.ClickPipeObjectStorageAzureBlobType:
 			// For Azure Blob Storage, preserve all fields from state as API doesn't return them
 			objectStorageModel.Authentication = stateObjectStorageModel.Authentication
 			objectStorageModel.ConnectionString = stateObjectStorageModel.ConnectionString
 			objectStorageModel.Path = stateObjectStorageModel.Path
 			objectStorageModel.AzureContainerName = stateObjectStorageModel.AzureContainerName
-		} else if clickPipe.Source.ObjectStorage.Type == api.ClickPipeObjectStorageGCSType {
+		case api.ClickPipeObjectStorageGCSType:
 			objectStorageModel.Authentication = types.StringPointerValue(clickPipe.Source.ObjectStorage.Authentication)
 			objectStorageModel.URL = types.StringValue(clickPipe.Source.ObjectStorage.URL)
 			objectStorageModel.ServiceAccountKey = stateObjectStorageModel.ServiceAccountKey // preserve sensitive field from state
-		} else {
+		default:
 			// For S3-compatible storage, use API response values
 			objectStorageModel.Authentication = types.StringPointerValue(clickPipe.Source.ObjectStorage.Authentication)
 			objectStorageModel.URL = types.StringValue(clickPipe.Source.ObjectStorage.URL)
@@ -5469,7 +5472,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 	// Determine expected state(s) based on configuration
 	stateCheckFunc := c.getStateCheckFunc(ctx, plan)
 
-	finalClickPipe, err := c.client.WaitForClickPipeState(ctx, state.ServiceID.ValueString(), state.ID.ValueString(), stateCheckFunc, clickPipeStateChangeMaxWaitSeconds)
+	finalClickPipe, err := c.client.WaitForClickPipeState(ctx, state.ServiceID.ValueString(), state.ID.ValueString(), stateCheckFunc, clickPipeStateChangeMaxWait)
 	if err != nil {
 		// Only warn if the final state is not acceptable
 		if finalClickPipe == nil || !stateCheckFunc(finalClickPipe.State) {


### PR DESCRIPTION
Update golangci to v2.

References:
- https://golangci-lint.run/docs/product/migration-guide/
- https://github.com/golangci/golangci-lint/issues/6272