### PR TITLE
feat(resource): add stop attribute to clickhouse_service

### DIFF
--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -6,6 +6,8 @@ description: |-
   You can use the clickhouse_service resource to deploy ClickHouse cloud instances on supported cloud providers.
   Known limitations:
   If you create a service with warehouse_id set and then remove warehouse_id attribute completely, the provider won't detect the change. If you want to make a secondary service become primary, remove the warehouse_id and taint it before applying.If you create a service with readonly flag set to true and then remove readonly flag completely, the provider won't detect the change. If you want to make a secondary service read write, explicitly set the readonly flag to false.
+  Stopping a service:
+  Setting stop = true stops the service: its compute is fully shut down so compute billing stops (storage is still billed). Unlike auto-idle (see idle_scaling), a stopped service does NOT auto-resume on query; set stop = false to start it again.Secondary (replica) services in a warehouse can be stopped independently — stopping one only shuts down that service's compute; the primary and sibling services keep running.The primary (first) service of a warehouse cannot be stopped while any secondary services still exist: ClickHouse Cloud requires the first service to stay up. Remove the secondary services before stopping the primary.
 ---
 
 # clickhouse_service (Resource)
@@ -16,6 +18,12 @@ Known limitations:
 
 - If you create a service with `warehouse_id` set and then remove `warehouse_id` attribute completely, the provider won't detect the change. If you want to make a secondary service become primary, remove the `warehouse_id` and taint it before applying.
 - If you create a service with `readonly` flag set to true and then remove `readonly` flag completely, the provider won't detect the change. If you want to make a secondary service read write, explicitly set the `readonly` flag to false.
+
+Stopping a service:
+
+- Setting `stop = true` stops the service: its compute is fully shut down so compute billing stops (storage is still billed). Unlike auto-idle (see `idle_scaling`), a stopped service does NOT auto-resume on query; set `stop = false` to start it again.
+- Secondary (replica) services in a warehouse can be stopped independently — stopping one only shuts down that service's compute; the primary and sibling services keep running.
+- The primary (first) service of a warehouse cannot be stopped while any secondary services still exist: ClickHouse Cloud requires the first service to stay up. Remove the secondary services before stopping the primary.
 
 ## Example Usage
 
@@ -82,6 +90,7 @@ resource "clickhouse_service" "service" {
 - `query_api_endpoints` (Attributes) Configuration of the query API endpoints feature. (see [below for nested schema](#nestedatt--query_api_endpoints))
 - `readonly` (Boolean) Indicates if this service should be read only. Only allowed for secondary services, those which share data with another service (i.e. when `warehouse_id` field is set).
 - `release_channel` (String) Release channel to use for this service. Can be 'default', 'fast' or 'slow'.
+- `stop` (Boolean) When set to true the service is stopped; when false it is started. A stopped service has its compute fully shut down (compute billing stops; storage is still billed) and will NOT auto-resume on query — unlike auto-idle (see idle_scaling). For a warehouse, secondary (replica) services can be stopped independently; the primary (first) service cannot be stopped while any secondary services still exist (ClickHouse Cloud requires the first service to stay up), so stopping it will fail until the secondary services are removed.
 - `tags` (Map of String) Tags associated with the service as key-value pairs.
 - `tier` (String) Tier of the service: 'development', 'production'. Required for organizations using the Legacy ClickHouse Cloud Tiers, must be omitted for organizations using the new ClickHouse Cloud Tiers.
 - `transparent_data_encryption` (Attributes) Configuration of the Transparent Data Encryption (TDE) feature. Requires an organization with the Enterprise plan. (see [below for nested schema](#nestedatt--transparent_data_encryption))

--- a/pkg/internal/api/client_mock.go
+++ b/pkg/internal/api/client_mock.go
@@ -26,6 +26,13 @@ type ClientMock struct {
 	beforeChangeClickPipeStateCounter uint64
 	ChangeClickPipeStateMock          mClientMockChangeClickPipeState
 
+	funcChangeServiceState          func(ctx context.Context, serviceId string, command string) (sp1 *Service, err error)
+	funcChangeServiceStateOrigin    string
+	inspectFuncChangeServiceState   func(ctx context.Context, serviceId string, command string)
+	afterChangeServiceStateCounter  uint64
+	beforeChangeServiceStateCounter uint64
+	ChangeServiceStateMock          mClientMockChangeServiceState
+
 	funcCreateClickPipe          func(ctx context.Context, serviceId string, clickPipe ClickPipe) (cp1 *ClickPipe, err error)
 	funcCreateClickPipeOrigin    string
 	inspectFuncCreateClickPipe   func(ctx context.Context, serviceId string, clickPipe ClickPipe)
@@ -292,6 +299,13 @@ type ClientMock struct {
 	beforeListRolesCounter uint64
 	ListRolesMock          mClientMockListRoles
 
+	funcListServices          func(ctx context.Context) (sa1 []Service, err error)
+	funcListServicesOrigin    string
+	inspectFuncListServices   func(ctx context.Context)
+	afterListServicesCounter  uint64
+	beforeListServicesCounter uint64
+	ListServicesMock          mClientMockListServices
+
 	funcReplacePostgresConfig          func(ctx context.Context, postgresId string, body PostgresConfig) (pp1 *PostgresConfigUpdateResponse, err error)
 	funcReplacePostgresConfigOrigin    string
 	inspectFuncReplacePostgresConfig   func(ctx context.Context, postgresId string, body PostgresConfig)
@@ -472,6 +486,9 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 	m.ChangeClickPipeStateMock = mClientMockChangeClickPipeState{mock: m}
 	m.ChangeClickPipeStateMock.callArgs = []*ClientMockChangeClickPipeStateParams{}
 
+	m.ChangeServiceStateMock = mClientMockChangeServiceState{mock: m}
+	m.ChangeServiceStateMock.callArgs = []*ClientMockChangeServiceStateParams{}
+
 	m.CreateClickPipeMock = mClientMockCreateClickPipe{mock: m}
 	m.CreateClickPipeMock.callArgs = []*ClientMockCreateClickPipeParams{}
 
@@ -585,6 +602,9 @@ func NewClientMock(t minimock.Tester) *ClientMock {
 
 	m.ListRolesMock = mClientMockListRoles{mock: m}
 	m.ListRolesMock.callArgs = []*ClientMockListRolesParams{}
+
+	m.ListServicesMock = mClientMockListServices{mock: m}
+	m.ListServicesMock.callArgs = []*ClientMockListServicesParams{}
 
 	m.ReplacePostgresConfigMock = mClientMockReplacePostgresConfig{mock: m}
 	m.ReplacePostgresConfigMock.callArgs = []*ClientMockReplacePostgresConfigParams{}
@@ -1065,6 +1085,380 @@ func (m *ClientMock) MinimockChangeClickPipeStateInspect() {
 	if !m.ChangeClickPipeStateMock.invocationsDone() && afterChangeClickPipeStateCounter > 0 {
 		m.t.Errorf("Expected %d calls to ClientMock.ChangeClickPipeState at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.ChangeClickPipeStateMock.expectedInvocations), m.ChangeClickPipeStateMock.expectedInvocationsOrigin, afterChangeClickPipeStateCounter)
+	}
+}
+
+type mClientMockChangeServiceState struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockChangeServiceStateExpectation
+	expectations       []*ClientMockChangeServiceStateExpectation
+
+	callArgs []*ClientMockChangeServiceStateParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ClientMockChangeServiceStateExpectation specifies expectation struct of the Client.ChangeServiceState
+type ClientMockChangeServiceStateExpectation struct {
+	mock               *ClientMock
+	params             *ClientMockChangeServiceStateParams
+	paramPtrs          *ClientMockChangeServiceStateParamPtrs
+	expectationOrigins ClientMockChangeServiceStateExpectationOrigins
+	results            *ClientMockChangeServiceStateResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ClientMockChangeServiceStateParams contains parameters of the Client.ChangeServiceState
+type ClientMockChangeServiceStateParams struct {
+	ctx       context.Context
+	serviceId string
+	command   string
+}
+
+// ClientMockChangeServiceStateParamPtrs contains pointers to parameters of the Client.ChangeServiceState
+type ClientMockChangeServiceStateParamPtrs struct {
+	ctx       *context.Context
+	serviceId *string
+	command   *string
+}
+
+// ClientMockChangeServiceStateResults contains results of the Client.ChangeServiceState
+type ClientMockChangeServiceStateResults struct {
+	sp1 *Service
+	err error
+}
+
+// ClientMockChangeServiceStateOrigins contains origins of expectations of the Client.ChangeServiceState
+type ClientMockChangeServiceStateExpectationOrigins struct {
+	origin          string
+	originCtx       string
+	originServiceId string
+	originCommand   string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmChangeServiceState *mClientMockChangeServiceState) Optional() *mClientMockChangeServiceState {
+	mmChangeServiceState.optional = true
+	return mmChangeServiceState
+}
+
+// Expect sets up expected params for Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) Expect(ctx context.Context, serviceId string, command string) *mClientMockChangeServiceState {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	if mmChangeServiceState.defaultExpectation == nil {
+		mmChangeServiceState.defaultExpectation = &ClientMockChangeServiceStateExpectation{}
+	}
+
+	if mmChangeServiceState.defaultExpectation.paramPtrs != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by ExpectParams functions")
+	}
+
+	mmChangeServiceState.defaultExpectation.params = &ClientMockChangeServiceStateParams{ctx, serviceId, command}
+	mmChangeServiceState.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmChangeServiceState.expectations {
+		if minimock.Equal(e.params, mmChangeServiceState.defaultExpectation.params) {
+			mmChangeServiceState.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmChangeServiceState.defaultExpectation.params)
+		}
+	}
+
+	return mmChangeServiceState
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) ExpectCtxParam1(ctx context.Context) *mClientMockChangeServiceState {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	if mmChangeServiceState.defaultExpectation == nil {
+		mmChangeServiceState.defaultExpectation = &ClientMockChangeServiceStateExpectation{}
+	}
+
+	if mmChangeServiceState.defaultExpectation.params != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Expect")
+	}
+
+	if mmChangeServiceState.defaultExpectation.paramPtrs == nil {
+		mmChangeServiceState.defaultExpectation.paramPtrs = &ClientMockChangeServiceStateParamPtrs{}
+	}
+	mmChangeServiceState.defaultExpectation.paramPtrs.ctx = &ctx
+	mmChangeServiceState.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmChangeServiceState
+}
+
+// ExpectServiceIdParam2 sets up expected param serviceId for Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) ExpectServiceIdParam2(serviceId string) *mClientMockChangeServiceState {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	if mmChangeServiceState.defaultExpectation == nil {
+		mmChangeServiceState.defaultExpectation = &ClientMockChangeServiceStateExpectation{}
+	}
+
+	if mmChangeServiceState.defaultExpectation.params != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Expect")
+	}
+
+	if mmChangeServiceState.defaultExpectation.paramPtrs == nil {
+		mmChangeServiceState.defaultExpectation.paramPtrs = &ClientMockChangeServiceStateParamPtrs{}
+	}
+	mmChangeServiceState.defaultExpectation.paramPtrs.serviceId = &serviceId
+	mmChangeServiceState.defaultExpectation.expectationOrigins.originServiceId = minimock.CallerInfo(1)
+
+	return mmChangeServiceState
+}
+
+// ExpectCommandParam3 sets up expected param command for Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) ExpectCommandParam3(command string) *mClientMockChangeServiceState {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	if mmChangeServiceState.defaultExpectation == nil {
+		mmChangeServiceState.defaultExpectation = &ClientMockChangeServiceStateExpectation{}
+	}
+
+	if mmChangeServiceState.defaultExpectation.params != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Expect")
+	}
+
+	if mmChangeServiceState.defaultExpectation.paramPtrs == nil {
+		mmChangeServiceState.defaultExpectation.paramPtrs = &ClientMockChangeServiceStateParamPtrs{}
+	}
+	mmChangeServiceState.defaultExpectation.paramPtrs.command = &command
+	mmChangeServiceState.defaultExpectation.expectationOrigins.originCommand = minimock.CallerInfo(1)
+
+	return mmChangeServiceState
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) Inspect(f func(ctx context.Context, serviceId string, command string)) *mClientMockChangeServiceState {
+	if mmChangeServiceState.mock.inspectFuncChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("Inspect function is already set for ClientMock.ChangeServiceState")
+	}
+
+	mmChangeServiceState.mock.inspectFuncChangeServiceState = f
+
+	return mmChangeServiceState
+}
+
+// Return sets up results that will be returned by Client.ChangeServiceState
+func (mmChangeServiceState *mClientMockChangeServiceState) Return(sp1 *Service, err error) *ClientMock {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	if mmChangeServiceState.defaultExpectation == nil {
+		mmChangeServiceState.defaultExpectation = &ClientMockChangeServiceStateExpectation{mock: mmChangeServiceState.mock}
+	}
+	mmChangeServiceState.defaultExpectation.results = &ClientMockChangeServiceStateResults{sp1, err}
+	mmChangeServiceState.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmChangeServiceState.mock
+}
+
+// Set uses given function f to mock the Client.ChangeServiceState method
+func (mmChangeServiceState *mClientMockChangeServiceState) Set(f func(ctx context.Context, serviceId string, command string) (sp1 *Service, err error)) *ClientMock {
+	if mmChangeServiceState.defaultExpectation != nil {
+		mmChangeServiceState.mock.t.Fatalf("Default expectation is already set for the Client.ChangeServiceState method")
+	}
+
+	if len(mmChangeServiceState.expectations) > 0 {
+		mmChangeServiceState.mock.t.Fatalf("Some expectations are already set for the Client.ChangeServiceState method")
+	}
+
+	mmChangeServiceState.mock.funcChangeServiceState = f
+	mmChangeServiceState.mock.funcChangeServiceStateOrigin = minimock.CallerInfo(1)
+	return mmChangeServiceState.mock
+}
+
+// When sets expectation for the Client.ChangeServiceState which will trigger the result defined by the following
+// Then helper
+func (mmChangeServiceState *mClientMockChangeServiceState) When(ctx context.Context, serviceId string, command string) *ClientMockChangeServiceStateExpectation {
+	if mmChangeServiceState.mock.funcChangeServiceState != nil {
+		mmChangeServiceState.mock.t.Fatalf("ClientMock.ChangeServiceState mock is already set by Set")
+	}
+
+	expectation := &ClientMockChangeServiceStateExpectation{
+		mock:               mmChangeServiceState.mock,
+		params:             &ClientMockChangeServiceStateParams{ctx, serviceId, command},
+		expectationOrigins: ClientMockChangeServiceStateExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmChangeServiceState.expectations = append(mmChangeServiceState.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.ChangeServiceState return parameters for the expectation previously defined by the When method
+func (e *ClientMockChangeServiceStateExpectation) Then(sp1 *Service, err error) *ClientMock {
+	e.results = &ClientMockChangeServiceStateResults{sp1, err}
+	return e.mock
+}
+
+// Times sets number of times Client.ChangeServiceState should be invoked
+func (mmChangeServiceState *mClientMockChangeServiceState) Times(n uint64) *mClientMockChangeServiceState {
+	if n == 0 {
+		mmChangeServiceState.mock.t.Fatalf("Times of ClientMock.ChangeServiceState mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmChangeServiceState.expectedInvocations, n)
+	mmChangeServiceState.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmChangeServiceState
+}
+
+func (mmChangeServiceState *mClientMockChangeServiceState) invocationsDone() bool {
+	if len(mmChangeServiceState.expectations) == 0 && mmChangeServiceState.defaultExpectation == nil && mmChangeServiceState.mock.funcChangeServiceState == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmChangeServiceState.mock.afterChangeServiceStateCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmChangeServiceState.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// ChangeServiceState implements Client
+func (mmChangeServiceState *ClientMock) ChangeServiceState(ctx context.Context, serviceId string, command string) (sp1 *Service, err error) {
+	mm_atomic.AddUint64(&mmChangeServiceState.beforeChangeServiceStateCounter, 1)
+	defer mm_atomic.AddUint64(&mmChangeServiceState.afterChangeServiceStateCounter, 1)
+
+	mmChangeServiceState.t.Helper()
+
+	if mmChangeServiceState.inspectFuncChangeServiceState != nil {
+		mmChangeServiceState.inspectFuncChangeServiceState(ctx, serviceId, command)
+	}
+
+	mm_params := ClientMockChangeServiceStateParams{ctx, serviceId, command}
+
+	// Record call args
+	mmChangeServiceState.ChangeServiceStateMock.mutex.Lock()
+	mmChangeServiceState.ChangeServiceStateMock.callArgs = append(mmChangeServiceState.ChangeServiceStateMock.callArgs, &mm_params)
+	mmChangeServiceState.ChangeServiceStateMock.mutex.Unlock()
+
+	for _, e := range mmChangeServiceState.ChangeServiceStateMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sp1, e.results.err
+		}
+	}
+
+	if mmChangeServiceState.ChangeServiceStateMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.Counter, 1)
+		mm_want := mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.params
+		mm_want_ptrs := mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockChangeServiceStateParams{ctx, serviceId, command}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmChangeServiceState.t.Errorf("ClientMock.ChangeServiceState got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.serviceId != nil && !minimock.Equal(*mm_want_ptrs.serviceId, mm_got.serviceId) {
+				mmChangeServiceState.t.Errorf("ClientMock.ChangeServiceState got unexpected parameter serviceId, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.expectationOrigins.originServiceId, *mm_want_ptrs.serviceId, mm_got.serviceId, minimock.Diff(*mm_want_ptrs.serviceId, mm_got.serviceId))
+			}
+
+			if mm_want_ptrs.command != nil && !minimock.Equal(*mm_want_ptrs.command, mm_got.command) {
+				mmChangeServiceState.t.Errorf("ClientMock.ChangeServiceState got unexpected parameter command, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.expectationOrigins.originCommand, *mm_want_ptrs.command, mm_got.command, minimock.Diff(*mm_want_ptrs.command, mm_got.command))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmChangeServiceState.t.Errorf("ClientMock.ChangeServiceState got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmChangeServiceState.ChangeServiceStateMock.defaultExpectation.results
+		if mm_results == nil {
+			mmChangeServiceState.t.Fatal("No results are set for the ClientMock.ChangeServiceState")
+		}
+		return (*mm_results).sp1, (*mm_results).err
+	}
+	if mmChangeServiceState.funcChangeServiceState != nil {
+		return mmChangeServiceState.funcChangeServiceState(ctx, serviceId, command)
+	}
+	mmChangeServiceState.t.Fatalf("Unexpected call to ClientMock.ChangeServiceState. %v %v %v", ctx, serviceId, command)
+	return
+}
+
+// ChangeServiceStateAfterCounter returns a count of finished ClientMock.ChangeServiceState invocations
+func (mmChangeServiceState *ClientMock) ChangeServiceStateAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmChangeServiceState.afterChangeServiceStateCounter)
+}
+
+// ChangeServiceStateBeforeCounter returns a count of ClientMock.ChangeServiceState invocations
+func (mmChangeServiceState *ClientMock) ChangeServiceStateBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmChangeServiceState.beforeChangeServiceStateCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.ChangeServiceState.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmChangeServiceState *mClientMockChangeServiceState) Calls() []*ClientMockChangeServiceStateParams {
+	mmChangeServiceState.mutex.RLock()
+
+	argCopy := make([]*ClientMockChangeServiceStateParams, len(mmChangeServiceState.callArgs))
+	copy(argCopy, mmChangeServiceState.callArgs)
+
+	mmChangeServiceState.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockChangeServiceStateDone returns true if the count of the ChangeServiceState invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockChangeServiceStateDone() bool {
+	if m.ChangeServiceStateMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.ChangeServiceStateMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.ChangeServiceStateMock.invocationsDone()
+}
+
+// MinimockChangeServiceStateInspect logs each unmet expectation
+func (m *ClientMock) MinimockChangeServiceStateInspect() {
+	for _, e := range m.ChangeServiceStateMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.ChangeServiceState at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterChangeServiceStateCounter := mm_atomic.LoadUint64(&m.afterChangeServiceStateCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.ChangeServiceStateMock.defaultExpectation != nil && afterChangeServiceStateCounter < 1 {
+		if m.ChangeServiceStateMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ClientMock.ChangeServiceState at\n%s", m.ChangeServiceStateMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ClientMock.ChangeServiceState at\n%s with params: %#v", m.ChangeServiceStateMock.defaultExpectation.expectationOrigins.origin, *m.ChangeServiceStateMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcChangeServiceState != nil && afterChangeServiceStateCounter < 1 {
+		m.t.Errorf("Expected call to ClientMock.ChangeServiceState at\n%s", m.funcChangeServiceStateOrigin)
+	}
+
+	if !m.ChangeServiceStateMock.invocationsDone() && afterChangeServiceStateCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.ChangeServiceState at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.ChangeServiceStateMock.expectedInvocations), m.ChangeServiceStateMock.expectedInvocationsOrigin, afterChangeServiceStateCounter)
 	}
 }
 
@@ -14251,6 +14645,318 @@ func (m *ClientMock) MinimockListRolesInspect() {
 	}
 }
 
+type mClientMockListServices struct {
+	optional           bool
+	mock               *ClientMock
+	defaultExpectation *ClientMockListServicesExpectation
+	expectations       []*ClientMockListServicesExpectation
+
+	callArgs []*ClientMockListServicesParams
+	mutex    sync.RWMutex
+
+	expectedInvocations       uint64
+	expectedInvocationsOrigin string
+}
+
+// ClientMockListServicesExpectation specifies expectation struct of the Client.ListServices
+type ClientMockListServicesExpectation struct {
+	mock               *ClientMock
+	params             *ClientMockListServicesParams
+	paramPtrs          *ClientMockListServicesParamPtrs
+	expectationOrigins ClientMockListServicesExpectationOrigins
+	results            *ClientMockListServicesResults
+	returnOrigin       string
+	Counter            uint64
+}
+
+// ClientMockListServicesParams contains parameters of the Client.ListServices
+type ClientMockListServicesParams struct {
+	ctx context.Context
+}
+
+// ClientMockListServicesParamPtrs contains pointers to parameters of the Client.ListServices
+type ClientMockListServicesParamPtrs struct {
+	ctx *context.Context
+}
+
+// ClientMockListServicesResults contains results of the Client.ListServices
+type ClientMockListServicesResults struct {
+	sa1 []Service
+	err error
+}
+
+// ClientMockListServicesOrigins contains origins of expectations of the Client.ListServices
+type ClientMockListServicesExpectationOrigins struct {
+	origin    string
+	originCtx string
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmListServices *mClientMockListServices) Optional() *mClientMockListServices {
+	mmListServices.optional = true
+	return mmListServices
+}
+
+// Expect sets up expected params for Client.ListServices
+func (mmListServices *mClientMockListServices) Expect(ctx context.Context) *mClientMockListServices {
+	if mmListServices.mock.funcListServices != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by Set")
+	}
+
+	if mmListServices.defaultExpectation == nil {
+		mmListServices.defaultExpectation = &ClientMockListServicesExpectation{}
+	}
+
+	if mmListServices.defaultExpectation.paramPtrs != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by ExpectParams functions")
+	}
+
+	mmListServices.defaultExpectation.params = &ClientMockListServicesParams{ctx}
+	mmListServices.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
+	for _, e := range mmListServices.expectations {
+		if minimock.Equal(e.params, mmListServices.defaultExpectation.params) {
+			mmListServices.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmListServices.defaultExpectation.params)
+		}
+	}
+
+	return mmListServices
+}
+
+// ExpectCtxParam1 sets up expected param ctx for Client.ListServices
+func (mmListServices *mClientMockListServices) ExpectCtxParam1(ctx context.Context) *mClientMockListServices {
+	if mmListServices.mock.funcListServices != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by Set")
+	}
+
+	if mmListServices.defaultExpectation == nil {
+		mmListServices.defaultExpectation = &ClientMockListServicesExpectation{}
+	}
+
+	if mmListServices.defaultExpectation.params != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by Expect")
+	}
+
+	if mmListServices.defaultExpectation.paramPtrs == nil {
+		mmListServices.defaultExpectation.paramPtrs = &ClientMockListServicesParamPtrs{}
+	}
+	mmListServices.defaultExpectation.paramPtrs.ctx = &ctx
+	mmListServices.defaultExpectation.expectationOrigins.originCtx = minimock.CallerInfo(1)
+
+	return mmListServices
+}
+
+// Inspect accepts an inspector function that has same arguments as the Client.ListServices
+func (mmListServices *mClientMockListServices) Inspect(f func(ctx context.Context)) *mClientMockListServices {
+	if mmListServices.mock.inspectFuncListServices != nil {
+		mmListServices.mock.t.Fatalf("Inspect function is already set for ClientMock.ListServices")
+	}
+
+	mmListServices.mock.inspectFuncListServices = f
+
+	return mmListServices
+}
+
+// Return sets up results that will be returned by Client.ListServices
+func (mmListServices *mClientMockListServices) Return(sa1 []Service, err error) *ClientMock {
+	if mmListServices.mock.funcListServices != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by Set")
+	}
+
+	if mmListServices.defaultExpectation == nil {
+		mmListServices.defaultExpectation = &ClientMockListServicesExpectation{mock: mmListServices.mock}
+	}
+	mmListServices.defaultExpectation.results = &ClientMockListServicesResults{sa1, err}
+	mmListServices.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
+	return mmListServices.mock
+}
+
+// Set uses given function f to mock the Client.ListServices method
+func (mmListServices *mClientMockListServices) Set(f func(ctx context.Context) (sa1 []Service, err error)) *ClientMock {
+	if mmListServices.defaultExpectation != nil {
+		mmListServices.mock.t.Fatalf("Default expectation is already set for the Client.ListServices method")
+	}
+
+	if len(mmListServices.expectations) > 0 {
+		mmListServices.mock.t.Fatalf("Some expectations are already set for the Client.ListServices method")
+	}
+
+	mmListServices.mock.funcListServices = f
+	mmListServices.mock.funcListServicesOrigin = minimock.CallerInfo(1)
+	return mmListServices.mock
+}
+
+// When sets expectation for the Client.ListServices which will trigger the result defined by the following
+// Then helper
+func (mmListServices *mClientMockListServices) When(ctx context.Context) *ClientMockListServicesExpectation {
+	if mmListServices.mock.funcListServices != nil {
+		mmListServices.mock.t.Fatalf("ClientMock.ListServices mock is already set by Set")
+	}
+
+	expectation := &ClientMockListServicesExpectation{
+		mock:               mmListServices.mock,
+		params:             &ClientMockListServicesParams{ctx},
+		expectationOrigins: ClientMockListServicesExpectationOrigins{origin: minimock.CallerInfo(1)},
+	}
+	mmListServices.expectations = append(mmListServices.expectations, expectation)
+	return expectation
+}
+
+// Then sets up Client.ListServices return parameters for the expectation previously defined by the When method
+func (e *ClientMockListServicesExpectation) Then(sa1 []Service, err error) *ClientMock {
+	e.results = &ClientMockListServicesResults{sa1, err}
+	return e.mock
+}
+
+// Times sets number of times Client.ListServices should be invoked
+func (mmListServices *mClientMockListServices) Times(n uint64) *mClientMockListServices {
+	if n == 0 {
+		mmListServices.mock.t.Fatalf("Times of ClientMock.ListServices mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmListServices.expectedInvocations, n)
+	mmListServices.expectedInvocationsOrigin = minimock.CallerInfo(1)
+	return mmListServices
+}
+
+func (mmListServices *mClientMockListServices) invocationsDone() bool {
+	if len(mmListServices.expectations) == 0 && mmListServices.defaultExpectation == nil && mmListServices.mock.funcListServices == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmListServices.mock.afterListServicesCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmListServices.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// ListServices implements Client
+func (mmListServices *ClientMock) ListServices(ctx context.Context) (sa1 []Service, err error) {
+	mm_atomic.AddUint64(&mmListServices.beforeListServicesCounter, 1)
+	defer mm_atomic.AddUint64(&mmListServices.afterListServicesCounter, 1)
+
+	mmListServices.t.Helper()
+
+	if mmListServices.inspectFuncListServices != nil {
+		mmListServices.inspectFuncListServices(ctx)
+	}
+
+	mm_params := ClientMockListServicesParams{ctx}
+
+	// Record call args
+	mmListServices.ListServicesMock.mutex.Lock()
+	mmListServices.ListServicesMock.callArgs = append(mmListServices.ListServicesMock.callArgs, &mm_params)
+	mmListServices.ListServicesMock.mutex.Unlock()
+
+	for _, e := range mmListServices.ListServicesMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.sa1, e.results.err
+		}
+	}
+
+	if mmListServices.ListServicesMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmListServices.ListServicesMock.defaultExpectation.Counter, 1)
+		mm_want := mmListServices.ListServicesMock.defaultExpectation.params
+		mm_want_ptrs := mmListServices.ListServicesMock.defaultExpectation.paramPtrs
+
+		mm_got := ClientMockListServicesParams{ctx}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmListServices.t.Errorf("ClientMock.ListServices got unexpected parameter ctx, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmListServices.ListServicesMock.defaultExpectation.expectationOrigins.originCtx, *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmListServices.t.Errorf("ClientMock.ListServices got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmListServices.ListServicesMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmListServices.ListServicesMock.defaultExpectation.results
+		if mm_results == nil {
+			mmListServices.t.Fatal("No results are set for the ClientMock.ListServices")
+		}
+		return (*mm_results).sa1, (*mm_results).err
+	}
+	if mmListServices.funcListServices != nil {
+		return mmListServices.funcListServices(ctx)
+	}
+	mmListServices.t.Fatalf("Unexpected call to ClientMock.ListServices. %v", ctx)
+	return
+}
+
+// ListServicesAfterCounter returns a count of finished ClientMock.ListServices invocations
+func (mmListServices *ClientMock) ListServicesAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListServices.afterListServicesCounter)
+}
+
+// ListServicesBeforeCounter returns a count of ClientMock.ListServices invocations
+func (mmListServices *ClientMock) ListServicesBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmListServices.beforeListServicesCounter)
+}
+
+// Calls returns a list of arguments used in each call to ClientMock.ListServices.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmListServices *mClientMockListServices) Calls() []*ClientMockListServicesParams {
+	mmListServices.mutex.RLock()
+
+	argCopy := make([]*ClientMockListServicesParams, len(mmListServices.callArgs))
+	copy(argCopy, mmListServices.callArgs)
+
+	mmListServices.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockListServicesDone returns true if the count of the ListServices invocations corresponds
+// the number of defined expectations
+func (m *ClientMock) MinimockListServicesDone() bool {
+	if m.ListServicesMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.ListServicesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.ListServicesMock.invocationsDone()
+}
+
+// MinimockListServicesInspect logs each unmet expectation
+func (m *ClientMock) MinimockListServicesInspect() {
+	for _, e := range m.ListServicesMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to ClientMock.ListServices at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+		}
+	}
+
+	afterListServicesCounter := mm_atomic.LoadUint64(&m.afterListServicesCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.ListServicesMock.defaultExpectation != nil && afterListServicesCounter < 1 {
+		if m.ListServicesMock.defaultExpectation.params == nil {
+			m.t.Errorf("Expected call to ClientMock.ListServices at\n%s", m.ListServicesMock.defaultExpectation.returnOrigin)
+		} else {
+			m.t.Errorf("Expected call to ClientMock.ListServices at\n%s with params: %#v", m.ListServicesMock.defaultExpectation.expectationOrigins.origin, *m.ListServicesMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcListServices != nil && afterListServicesCounter < 1 {
+		m.t.Errorf("Expected call to ClientMock.ListServices at\n%s", m.funcListServicesOrigin)
+	}
+
+	if !m.ListServicesMock.invocationsDone() && afterListServicesCounter > 0 {
+		m.t.Errorf("Expected %d calls to ClientMock.ListServices at\n%s but found %d calls",
+			mm_atomic.LoadUint64(&m.ListServicesMock.expectedInvocations), m.ListServicesMock.expectedInvocationsOrigin, afterListServicesCounter)
+	}
+}
+
 type mClientMockReplacePostgresConfig struct {
 	optional           bool
 	mock               *ClientMock
@@ -23539,6 +24245,8 @@ func (m *ClientMock) MinimockFinish() {
 		if !m.minimockDone() {
 			m.MinimockChangeClickPipeStateInspect()
 
+			m.MinimockChangeServiceStateInspect()
+
 			m.MinimockCreateClickPipeInspect()
 
 			m.MinimockCreatePostgresInspect()
@@ -23615,6 +24323,8 @@ func (m *ClientMock) MinimockFinish() {
 
 			m.MinimockListRolesInspect()
 
+			m.MinimockListServicesInspect()
+
 			m.MinimockReplacePostgresConfigInspect()
 
 			m.MinimockRestorePostgresInspect()
@@ -23686,6 +24396,7 @@ func (m *ClientMock) minimockDone() bool {
 	done := true
 	return done &&
 		m.MinimockChangeClickPipeStateDone() &&
+		m.MinimockChangeServiceStateDone() &&
 		m.MinimockCreateClickPipeDone() &&
 		m.MinimockCreatePostgresDone() &&
 		m.MinimockCreatePostgresReadReplicaDone() &&
@@ -23724,6 +24435,7 @@ func (m *ClientMock) minimockDone() bool {
 		m.MinimockListPostgresDone() &&
 		m.MinimockListReversePrivateEndpointsDone() &&
 		m.MinimockListRolesDone() &&
+		m.MinimockListServicesDone() &&
 		m.MinimockReplacePostgresConfigDone() &&
 		m.MinimockRestorePostgresDone() &&
 		m.MinimockRotateTDEKeyDone() &&

--- a/pkg/internal/api/constants.go
+++ b/pkg/internal/api/constants.go
@@ -9,9 +9,18 @@ const (
 	ReleaseChannelFast    = "fast"
 	ReleaseChannelSlow    = "slow"
 
-	StateProvisioning = "provisioning"
-	StateStopped      = "stopped"
-	StateStopping     = "stopping"
+	StateProvisioning     = "provisioning"
+	StateStopped          = "stopped"
+	StateStopping         = "stopping"
+	StateRunning          = "running"
+	StateStarting         = "starting"
+	StateIdle             = "idle"
+	StateAwaking          = "awaking"
+	StateDegraded         = "degraded"
+	StatePartiallyRunning = "partially_running"
+
+	ServiceStateCommandStart = "start"
+	ServiceStateCommandStop  = "stop"
 
 	ResponseHeaderRateLimitReset = "X-RateLimit-Reset"
 

--- a/pkg/internal/api/interface.go
+++ b/pkg/internal/api/interface.go
@@ -9,10 +9,12 @@ type Client interface {
 	GetApiKeyID(ctx context.Context, name *string) (*ApiKey, error)
 
 	GetService(ctx context.Context, serviceId string) (*Service, error)
+	ListServices(ctx context.Context) ([]Service, error)
 	GetOrgPrivateEndpointConfig(ctx context.Context, cloudProvider string, region string) (*OrgPrivateEndpointConfig, error)
 	CreateService(ctx context.Context, s Service) (*Service, string, error)
 	WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error
 	UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error)
+	ChangeServiceState(ctx context.Context, serviceId string, command string) (*Service, error)
 	UpdateReplicaScaling(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (*Service, error)
 	GetScheduledScaling(ctx context.Context, serviceId string) (*AutoScalingSchedule, error)
 	UpdateScheduledScaling(ctx context.Context, serviceId string, s AutoScalingScheduleUpdate) (*AutoScalingSchedule, error)

--- a/pkg/internal/api/service.go
+++ b/pkg/internal/api/service.go
@@ -70,6 +70,22 @@ func (c *ClientImpl) GetService(ctx context.Context, serviceId string) (*Service
 	return &service, nil
 }
 
+func (c *ClientImpl) ListServices(ctx context.Context) ([]Service, error) {
+	req, err := http.NewRequest(http.MethodGet, c.getServicePath("", ""), nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	servicesResponse := ResponseWithResult[[]Service]{}
+	if err := json.Unmarshal(body, &servicesResponse); err != nil {
+		return nil, err
+	}
+	return servicesResponse.Result, nil
+}
+
 func (c *ClientImpl) CreateService(ctx context.Context, s Service) (*Service, string, error) {
 	// Needed until we have alignment between service creation and replicaScaling calls.
 	s.FixMemoryBounds()
@@ -155,6 +171,31 @@ func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s Serv
 	return &serviceResponse.Result, nil
 }
 
+func (c *ClientImpl) ChangeServiceState(ctx context.Context, serviceId string, command string) (*Service, error) {
+	rb, err := json.Marshal(ServiceStateUpdate{Command: command})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, c.getServicePath(serviceId, "/state"), strings.NewReader(string(rb)))
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := c.doRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceResponse := ResponseWithResult[Service]{}
+	err = json.Unmarshal(body, &serviceResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &serviceResponse.Result, nil
+}
+
 func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Service, error) {
 	service, err := c.GetService(ctx, serviceId)
 	if IsNotFound(err) {
@@ -166,7 +207,7 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 
 	if service.State != StateStopped && service.State != StateStopping {
 		rb, _ := json.Marshal(ServiceStateUpdate{
-			Command: "stop",
+			Command: ServiceStateCommandStop,
 		})
 		req, err := http.NewRequest(http.MethodPatch, c.getServicePath(serviceId, "/state"), strings.NewReader(string(rb)))
 		if err != nil {

--- a/pkg/resource/descriptions/service.md
+++ b/pkg/resource/descriptions/service.md
@@ -4,3 +4,9 @@ Known limitations:
 
 - If you create a service with `warehouse_id` set and then remove `warehouse_id` attribute completely, the provider won't detect the change. If you want to make a secondary service become primary, remove the `warehouse_id` and taint it before applying.
 - If you create a service with `readonly` flag set to true and then remove `readonly` flag completely, the provider won't detect the change. If you want to make a secondary service read write, explicitly set the `readonly` flag to false.
+
+Stopping a service:
+
+- Setting `stop = true` stops the service: its compute is fully shut down so compute billing stops (storage is still billed). Unlike auto-idle (see `idle_scaling`), a stopped service does NOT auto-resume on query; set `stop = false` to start it again.
+- Secondary (replica) services in a warehouse can be stopped independently — stopping one only shuts down that service's compute; the primary and sibling services keep running.
+- The primary (first) service of a warehouse cannot be stopped while any secondary services still exist: ClickHouse Cloud requires the first service to stay up. Remove the secondary services before stopping the primary.

--- a/pkg/resource/models/service_resource.go
+++ b/pkg/resource/models/service_resource.go
@@ -227,6 +227,7 @@ type ServiceResourceModel struct {
 	MaxReplicaMemoryGb              types.Int64  `tfsdk:"max_replica_memory_gb"`
 	NumReplicas                     types.Int64  `tfsdk:"num_replicas"`
 	IdleTimeoutMinutes              types.Int64  `tfsdk:"idle_timeout_minutes"`
+	Stop                            types.Bool   `tfsdk:"stop"`
 	IAMRole                         types.String `tfsdk:"iam_role"`
 	PrivateEndpointConfig           types.Object `tfsdk:"private_endpoint_config"`
 	EncryptionKey                   types.String `tfsdk:"encryption_key"`
@@ -262,6 +263,7 @@ func (m *ServiceResourceModel) Equals(b ServiceResourceModel) bool {
 		!m.MaxTotalMemoryGb.Equal(b.MaxTotalMemoryGb) ||
 		!m.NumReplicas.Equal(b.NumReplicas) ||
 		!m.IdleTimeoutMinutes.Equal(b.IdleTimeoutMinutes) ||
+		!m.Stop.Equal(b.Stop) ||
 		!m.IAMRole.Equal(b.IAMRole) ||
 		!m.PrivateEndpointConfig.Equal(b.PrivateEndpointConfig) ||
 		!m.EncryptionKey.Equal(b.EncryptionKey) ||

--- a/pkg/resource/service.go
+++ b/pkg/resource/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
 	internalplanmodifier "github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/planmodifier"
@@ -220,6 +221,16 @@ func (r *ServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "When set to true the service is allowed to scale down to zero when idle.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"stop": schema.BoolAttribute{
+				Description: "When set to true the service is stopped; when false it is started. " +
+					"A stopped service has its compute fully shut down (compute billing stops; storage is still billed) and will NOT auto-resume on query — unlike auto-idle (see idle_scaling). " +
+					"For a warehouse, secondary (replica) services can be stopped independently; the primary (first) service cannot be stopped while any secondary services still exist (ClickHouse Cloud requires the first service to stay up), so stopping it will fail until the secondary services are removed.",
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.UseStateForUnknown(),
 				},
@@ -679,6 +690,29 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 
 		if !state.IdleScaling.ValueBool() && plan.IdleScaling.ValueBool() {
 			plan.IdleTimeoutMinutes = config.IdleTimeoutMinutes
+		}
+
+		// A warehouse's primary service cannot be stopped while it still has secondary
+		// (replica) services attached: ClickHouse Cloud requires the first service in a
+		// warehouse to stay up. Catch this at plan time instead of failing mid-apply.
+		if r.client != nil &&
+			!plan.Stop.IsUnknown() && plan.Stop.ValueBool() && !state.Stop.ValueBool() &&
+			state.IsPrimary.ValueBool() &&
+			!state.DataWarehouseID.IsNull() && state.DataWarehouseID.ValueString() != "" {
+			services, err := r.client.ListServices(ctx)
+			if err != nil {
+				// Best-effort: if we can't list services, don't block the plan; the API
+				// will still enforce the rule at apply time.
+				tflog.Warn(ctx, "could not list services to validate stopping a warehouse primary", map[string]any{"error": err.Error()})
+			} else if anySecondaryInWarehouse(services, state.DataWarehouseID.ValueString(), state.ID.ValueString()) {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("stop"),
+					"Cannot stop warehouse primary service",
+					"This service is the primary of a warehouse that still has secondary (replica) services. "+
+						"ClickHouse Cloud requires the first service in a warehouse to stay running, so it cannot be stopped while secondary services exist. "+
+						"Remove (delete) the secondary services first, or keep this service running (set stop = false).",
+				)
+			}
 		}
 	}
 
@@ -1264,6 +1298,19 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		}
 	}
 
+	// Stop the service if requested, after all other create operations.
+	if !plan.Stop.IsUnknown() && plan.Stop.ValueBool() {
+		_, err := r.client.ChangeServiceState(ctx, s.Id, api.ServiceStateCommandStop)
+		if err != nil {
+			resp.Diagnostics.AddError("Error stopping ClickHouse Service", "Could not stop service after creation, unexpected error: "+err.Error())
+			return
+		}
+		if err := r.client.WaitForServiceState(ctx, s.Id, func(st string) bool { return st == api.StateStopped }, 30*60); err != nil {
+			resp.Diagnostics.AddError("Error waiting for ClickHouse Service to stop", err.Error())
+			return
+		}
+	}
+
 	// Map response body to schema and populate Computed attribute values
 	plan.ID = types.StringValue(s.Id)
 	err = r.syncServiceState(ctx, &plan, true)
@@ -1328,6 +1375,21 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	// Generate API request body from plan
 	serviceId := state.ID.ValueString()
+
+	// Start the service early, before any other update operations, so that
+	// subsequent changes can be applied to a running service.
+	if !plan.Stop.IsUnknown() && !plan.Stop.Equal(state.Stop) && !plan.Stop.ValueBool() {
+		_, err := r.client.ChangeServiceState(ctx, serviceId, api.ServiceStateCommandStart)
+		if err != nil {
+			resp.Diagnostics.AddError("Error starting ClickHouse Service", "Could not start service, unexpected error: "+err.Error())
+			return
+		}
+		if err := r.client.WaitForServiceState(ctx, serviceId, isServiceStarted, 30*60); err != nil {
+			resp.Diagnostics.AddError("Error waiting for ClickHouse Service to start", err.Error())
+			return
+		}
+	}
+
 	service := api.ServiceUpdate{
 		Name:         "",
 		IpAccessList: nil,
@@ -1682,6 +1744,20 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 				)
 				return
 			}
+		}
+	}
+
+	// Stop the service last, after all other update operations have been
+	// applied, since a stopped service cannot accept further changes.
+	if !plan.Stop.IsUnknown() && !plan.Stop.Equal(state.Stop) && plan.Stop.ValueBool() {
+		_, err := r.client.ChangeServiceState(ctx, serviceId, api.ServiceStateCommandStop)
+		if err != nil {
+			resp.Diagnostics.AddError("Error stopping ClickHouse Service", "Could not stop service, unexpected error: "+err.Error())
+			return
+		}
+		if err := r.client.WaitForServiceState(ctx, serviceId, func(s string) bool { return s == api.StateStopped }, 30*60); err != nil {
+			resp.Diagnostics.AddError("Error waiting for ClickHouse Service to stop", err.Error())
+			return
 		}
 	}
 
@@ -2089,6 +2165,8 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *models.Se
 		state.IdleTimeoutMinutes = types.Int64Null()
 	}
 
+	state.Stop = types.BoolValue(isServiceStopped(service.State))
+
 	if service.Tier == api.TierProduction || service.Tier == api.TierPPv2 {
 		if service.MinReplicaMemoryGb != nil {
 			state.MinReplicaMemoryGb = types.Int64Value(int64(*service.MinReplicaMemoryGb))
@@ -2253,6 +2331,38 @@ func (r *ServiceResource) syncServiceState(ctx context.Context, state *models.Se
 	}
 
 	return nil
+}
+
+func isServiceStopped(state string) bool {
+	return state == api.StateStopped || state == api.StateStopping
+}
+
+// isServiceStarted reports whether the service has settled into a running-like terminal state after a start.
+func isServiceStarted(state string) bool {
+	switch state {
+	case api.StateRunning, api.StateIdle, api.StateDegraded, api.StatePartiallyRunning:
+		return true
+	default:
+		return false
+	}
+}
+
+// anySecondaryInWarehouse reports whether services contains a secondary service
+// (a service in the same warehouse that is not the primary), excluding selfID.
+func anySecondaryInWarehouse(services []api.Service, warehouseID, selfID string) bool {
+	if warehouseID == "" {
+		return false
+	}
+	for i := range services {
+		svc := services[i]
+		if svc.Id == selfID {
+			continue
+		}
+		if svc.DataWarehouseId != nil && *svc.DataWarehouseId == warehouseID && (svc.IsPrimary == nil || !*svc.IsPrimary) {
+			return true
+		}
+	}
+	return false
 }
 
 func servicePasswordUpdateFromPlainPassword(password string) api.ServicePasswordUpdate {

--- a/pkg/resource/service_test.go
+++ b/pkg/resource/service_test.go
@@ -510,6 +510,58 @@ func TestServiceResource_syncServiceState(t *testing.T) {
 			updateTimestamp: false,
 			wantErr:         false,
 		},
+		{
+			name:  "Maps stopped state to stop=true",
+			state: state,
+			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
+				src.State = api.StateStopped
+			}).GetPtr(),
+			responseErr: nil,
+			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
+				src.Stop = types.BoolValue(true)
+			}).Get(),
+			updateTimestamp: false,
+			wantErr:         false,
+		},
+		{
+			name:  "Maps stopping state to stop=true",
+			state: state,
+			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
+				src.State = api.StateStopping
+			}).GetPtr(),
+			responseErr: nil,
+			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
+				src.Stop = types.BoolValue(true)
+			}).Get(),
+			updateTimestamp: false,
+			wantErr:         false,
+		},
+		{
+			name:  "Maps running state to stop=false",
+			state: state,
+			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
+				src.State = api.StateRunning
+			}).GetPtr(),
+			responseErr: nil,
+			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
+				src.Stop = types.BoolValue(false)
+			}).Get(),
+			updateTimestamp: false,
+			wantErr:         false,
+		},
+		{
+			name:  "Maps idle state to stop=false",
+			state: state,
+			response: test.NewUpdater(getBaseResponse(state.ID.ValueString())).Update(func(src *api.Service) {
+				src.State = api.StateIdle
+			}).GetPtr(),
+			responseErr: nil,
+			desiredState: test.NewUpdater(state).Update(func(src *models.ServiceResourceModel) {
+				src.Stop = types.BoolValue(false)
+			}).Get(),
+			updateTimestamp: false,
+			wantErr:         false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -591,6 +643,7 @@ func getInitialState() models.ServiceResourceModel {
 		MaxTotalMemoryGb:                types.Int64{},
 		NumReplicas:                     types.Int64{},
 		IdleTimeoutMinutes:              types.Int64{},
+		Stop:                            types.BoolValue(false),
 		IAMRole:                         types.StringValue(""),
 		PrivateEndpointConfig:           privateEndpointConfig,
 		EncryptionKey:                   types.StringNull(),
@@ -747,4 +800,75 @@ func tagsEqual(a, b []api.Tag) bool {
 	}
 
 	return true
+}
+
+func TestAnySecondaryInWarehouse(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name        string
+		services    []api.Service
+		warehouseID string
+		selfID      string
+		want        bool
+	}{
+		{
+			name: "Secondary present in same warehouse returns true",
+			services: []api.Service{
+				{Id: "primary", IsPrimary: boolPtr(true), DataWarehouseId: strPtr("wh-1")},
+				{Id: "secondary", IsPrimary: boolPtr(false), DataWarehouseId: strPtr("wh-1")},
+			},
+			warehouseID: "wh-1",
+			selfID:      "primary",
+			want:        true,
+		},
+		{
+			name: "Only the primary itself in the list returns false",
+			services: []api.Service{
+				{Id: "primary", IsPrimary: boolPtr(true), DataWarehouseId: strPtr("wh-1")},
+			},
+			warehouseID: "wh-1",
+			selfID:      "primary",
+			want:        false,
+		},
+		{
+			name: "Another primary in a different warehouse returns false",
+			services: []api.Service{
+				{Id: "primary", IsPrimary: boolPtr(true), DataWarehouseId: strPtr("wh-1")},
+				{Id: "other-primary", IsPrimary: boolPtr(true), DataWarehouseId: strPtr("wh-2")},
+			},
+			warehouseID: "wh-1",
+			selfID:      "primary",
+			want:        false,
+		},
+		{
+			name: "Empty warehouseID returns false",
+			services: []api.Service{
+				{Id: "secondary", IsPrimary: boolPtr(false), DataWarehouseId: strPtr("wh-1")},
+			},
+			warehouseID: "",
+			selfID:      "primary",
+			want:        false,
+		},
+		{
+			name: "Service with nil IsPrimary in same warehouse is treated as secondary",
+			services: []api.Service{
+				{Id: "primary", IsPrimary: boolPtr(true), DataWarehouseId: strPtr("wh-1")},
+				{Id: "unknown", IsPrimary: nil, DataWarehouseId: strPtr("wh-1")},
+			},
+			warehouseID: "wh-1",
+			selfID:      "primary",
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := anySecondaryInWarehouse(tt.services, tt.warehouseID, tt.selfID)
+			if got != tt.want {
+				t.Errorf("'%s' anySecondaryInWarehouse = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds a `stop` boolean to the `clickhouse_service` resource to stop (pause) or start a service via the ClickHouse Cloud `/state` API. The name matches ClickHouse's own vocabulary (the UI **Stop/Start** button, the `stop`/`start` API command, and the `stopped` service state).

```hcl
resource "clickhouse_service" "example" {
  # ...
  stop = true   # stop (pause) the service; false starts it
}
```

## Behavior

- **Update** starts the service *before* applying other changes and stops it *after* them, so changes are applied to a running service.
- **Create** stops the service after provisioning when `stop = true`.
- **Read** maps the API state to `stop`: `stopped`/`stopping` → `true`. Note `idle` (auto-idle) is **not** treated as stopped — an idled service is still "started" and auto-resumes on query, whereas a stopped service does not.

## Warehouse semantics + plan-time validation

In a warehouse, secondary ("replica") services can be stopped independently. ClickHouse Cloud does **not** allow stopping the primary (first) service while it still has secondary services. To avoid a confusing mid-apply API error, the provider validates this at **plan time** and returns a clear, actionable diagnostic when you try to stop a primary that still has secondaries.

## API changes

- New `ChangeServiceState(serviceId, command)` client method (the `/state` endpoint).
- New `ListServices()` client method, used by the plan-time validation to detect sibling secondary services.
- `DeleteService` now uses the shared stop-command constant.
- Mock regenerated.

## Testing

- Unit tests for the service-state → `stop` mapping and for the warehouse secondary-detection helper.
- `go build`, `go vet`, `go test ./pkg/...`, `gofmt`, `golangci-lint` (v2.12.2), and `make docs-alpha` all clean.
- Locally verified end-to-end against a local provider build: stopping a warehouse primary that has a secondary is blocked at plan time, while stopping a secondary or a standalone primary works.

## Follow-up

- Add `stop` usage to the `examples/full/warehouse` example for e2e coverage (not included here).