### PR TITLE
feat(clickpipes): add ClickPipeAvroFormat to object_storage formats list

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -460,7 +460,7 @@ Optional:
 
 Required:
 
-- `format` (String) The format of the S3 objects. (`JSONEachRow`, `CSV`, `CSVWithNames`, `Parquet`)
+- `format` (String) The format of the S3 objects. (`JSONEachRow`, `CSV`, `CSVWithNames`, `Parquet`, `Avro`)
 
 Optional:
 

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -180,6 +180,7 @@ var ClickPipeObjectStorageFormats = []string{
 	ClickPipeCSVFormat,
 	ClickPipeCSVWithNamesFormat,
 	ClickPipeParquetFormat,
+	ClickPipeAvroFormat
 }
 
 const (

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -180,7 +180,7 @@ var ClickPipeObjectStorageFormats = []string{
 	ClickPipeCSVFormat,
 	ClickPipeCSVWithNamesFormat,
 	ClickPipeParquetFormat,
-	ClickPipeAvroFormat
+	ClickPipeAvroFormat,
 }
 
 const (


### PR DESCRIPTION
This PR simply adds the `ClickPipeAvroFormat` to the `ClickPipeObjectStorageFormats` collection.

After creating a Clickpipe for s3 manually some month ago I now want to manage everything in code. I imported the clickpipe, which eilded this config:
```tf
    source         = {
        object_storage = {
            authentication = "IAM_USER"
            format         = "Avro"
            is_continuous  = true
            type           = "s3"
            url            = "s3://<user_object_storage_path>/*/*/*/*.avro"
        }
    }
```

However when I run `terraform plan`, I get the following error:

<img width="995" height="171" alt="Screenshot 2026-06-05 at 13 05 53" src="https://github.com/user-attachments/assets/3dde1c4a-a063-47d9-a444-c5cd509dfb74" />

