### PR TITLE
fix(clickpipes): add validation for invalid usage of table definition with CDC ClickPipes

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -112,7 +112,7 @@ Optional:
 - `managed_table` (Boolean) Whether the table is managed by ClickHouse Cloud. If `false`, the table must exist in the database. Default is `true`. **Not applicable to database/CDC pipes** (Postgres, MySQL, BigQuery, MongoDB): for those sources destination tables are always managed per-table via `table_mappings`, so this field is ignored and not sent to the API.
 - `roles` (List of String) ClickPipe will create a ClickHouse user with these roles. Add your custom roles here if required.
 - `table` (String) The name of the ClickHouse table. Required for all sources except Postgres CDC (where tables are created from table_mappings).
-- `table_definition` (Attributes) Definition of the destination table. Required for ClickPipes managed tables. (see [below for nested schema](#nestedatt--destination--table_definition))
+- `table_definition` (Attributes) Definition of the destination table. Required for ClickPipes managed tables. **Not supported for database/CDC pipes** (Postgres, MySQL, BigQuery, MongoDB): for those sources destination tables are defined per-table via `table_mappings` (each mapping's `target_table`, `table_engine`, `sorting_keys`, etc.), so configuring this is rejected at plan time. (see [below for nested schema](#nestedatt--destination--table_definition))
 
 <a id="nestedatt--destination--columns"></a>
 ### Nested Schema for `destination.columns`

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -1720,7 +1720,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						},
 					},
 					"table_definition": schema.SingleNestedAttribute{
-						MarkdownDescription: "Definition of the destination table. Required for ClickPipes managed tables.",
+						MarkdownDescription: "Definition of the destination table. Required for ClickPipes managed tables. **Not supported for database/CDC pipes** (Postgres, MySQL, BigQuery, MongoDB): for those sources destination tables are defined per-table via `table_mappings` (each mapping's `target_table`, `table_engine`, `sorting_keys`, etc.), so configuring this is rejected at plan time.",
 						Optional:            true,
 						Attributes: map[string]schema.Attribute{
 							"engine": schema.SingleNestedAttribute{
@@ -2160,14 +2160,28 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 
 			// Read config, not plan: config is null when omitted; the plan is already filled by the default.
 			configManagedTableSet := false
+			configTableDefinitionSet := false
 			if !config.Destination.IsNull() {
 				var configDestination models.ClickPipeDestinationModel
 				if diags := config.Destination.As(ctx, &configDestination, basetypes.ObjectAsOptions{}); !diags.HasError() {
 					configManagedTableSet = !configDestination.ManagedTable.IsNull()
+					configTableDefinitionSet = !configDestination.TableDefinition.IsNull()
 				}
 			}
 
 			if isDBPipe {
+				// (0) Reject table_definition: CDC pipes drop it on create and null it on read, so a configured value tripped "inconsistent result after apply" (issue #571).
+				if configTableDefinitionSet {
+					response.Diagnostics.AddAttributeError(
+						path.Root("destination").AtName("table_definition"),
+						"table_definition is not supported for database (CDC) pipes",
+						fmt.Sprintf("destination.table_definition cannot be used with '%s' sources. Destination tables for "+
+							"database/CDC pipes are defined per-table via the source's table_mappings (each mapping's "+
+							"target_table, table_engine, sorting_keys, etc.). Remove destination.table_definition.",
+							sourceType),
+					)
+				}
+
 				// (1) Warn on explicit set. Fires on create and update.
 				if configManagedTableSet {
 					response.Diagnostics.AddAttributeWarning(

--- a/pkg/resource/clickpipe_bug_fixes_test.go
+++ b/pkg/resource/clickpipe_bug_fixes_test.go
@@ -632,3 +632,94 @@ func TestClickPipeResource_ModifyPlan_ExcludedColumnsReorder_Issue558(t *testing
 			"a real target_table change on an existing mapping must still be rejected; got: %v", diags.Errors())
 	})
 }
+
+// Issue #571 — ModifyPlan must reject destination.table_definition on a CDC pipe (it caused "inconsistent result after apply"), and must not fire when it's omitted.
+
+// postgresPlanWithTableDefinition clones the Postgres fixture, optionally adding a minimal destination.table_definition (MergeTree).
+func postgresPlanWithTableDefinition(withTableDef bool) models.ClickPipeResourceModel {
+	plan := getPostgresInitialState()
+
+	plan.Scaling = types.ObjectNull(models.ClickPipeScalingModel{}.ObjectType().AttrTypes)
+	plan.FieldMappings = types.ListNull(models.ClickPipeFieldMappingModel{}.ObjectType())
+	plan.Settings = types.DynamicNull()
+	plan.Stopped = types.BoolValue(false)
+	plan.TriggerResync = types.BoolNull()
+
+	tableDef := types.ObjectNull(models.ClickPipeDestinationTableDefinitionModel{}.ObjectType().AttrTypes)
+	if withTableDef {
+		tableDef = models.ClickPipeDestinationTableDefinitionModel{
+			Engine: models.ClickPipeDestinationTableEngineModel{
+				Type:            types.StringValue("MergeTree"),
+				VersionColumnID: types.StringNull(),
+				ColumnIDs:       types.ListNull(types.StringType),
+			}.ObjectValue(),
+			SortingKey:  types.ListValueMust(types.StringType, []attr.Value{}),
+			PartitionBy: types.StringNull(),
+			PrimaryKey:  types.StringNull(),
+		}.ObjectValue()
+	}
+
+	plan.Destination = models.ClickPipeDestinationModel{
+		Database:        types.StringValue("default"),
+		Table:           types.StringNull(),
+		ManagedTable:    types.BoolNull(),
+		TableDefinition: tableDef,
+		Columns:         types.ListNull(models.ClickPipeDestinationColumnModel{}.ObjectType()),
+		Roles:           types.ListNull(types.StringType),
+	}.ObjectValue()
+
+	return plan
+}
+
+func TestClickPipeResource_ModifyPlan_RejectsTableDefinitionForCDC_Issue571(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+
+	// runCreate drives ModifyPlan for a create (null prior state) and returns the diagnostics.
+	runCreate := func(t *testing.T, planModel models.ClickPipeResourceModel) diag.Diagnostics {
+		t.Helper()
+		planVal := tfsdk.Plan{Schema: sch}
+		if d := planVal.Set(ctx, &planModel); d.HasError() {
+			t.Fatalf("encoding plan failed: %v", d.Errors())
+		}
+		req := resource.ModifyPlanRequest{
+			State:  tfsdk.State{Schema: sch}, // null Raw => create
+			Plan:   planVal,
+			Config: tfsdk.Config{Schema: sch, Raw: planVal.Raw},
+		}
+		resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Schema: sch, Raw: planVal.Raw}}
+		r.ModifyPlan(ctx, req, resp)
+		return resp.Diagnostics
+	}
+
+	detailContains := func(diags diag.Diagnostics, substr string) bool {
+		for _, d := range diags.Errors() {
+			if strings.Contains(d.Detail(), substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("table_definition on a CDC pipe is rejected at plan time", func(t *testing.T) {
+		diags := runCreate(t, postgresPlanWithTableDefinition(true))
+
+		assert.True(t, detailContains(diags, "destination.table_definition cannot be used"),
+			"#571: a table_definition on a Postgres CDC pipe must be rejected at plan time; got: %v", diags.Errors())
+	})
+
+	t.Run("omitting table_definition on a CDC pipe is allowed", func(t *testing.T) {
+		// Control: the guard must not over-fire when table_definition is absent.
+		diags := runCreate(t, postgresPlanWithTableDefinition(false))
+
+		assert.False(t, detailContains(diags, "destination.table_definition cannot be used"),
+			"a Postgres CDC pipe without table_definition must not be rejected; got: %v", diags.Errors())
+	})
+}


### PR DESCRIPTION
# Why
CDC ClickPipes plans with table definition blocks throw invalid state mismatch after applies due to table definitions not being applicable for CDC pipes
# What
This adds validation to prevent table_definition from being used with CDC pipes, along with updating documentation and adding a test to demonstrate.

#571