### PR TITLE
feat(resource): support in-place rename of clickhouse_postgres_service

### DIFF
--- a/docs/resources/postgres_service.md
+++ b/docs/resources/postgres_service.md
@@ -143,14 +143,12 @@ description: |-
   before users can adopt them; size is the most frequently changed
   attribute, so the trade-off goes the other way here. The
   cloud_provider, ha_type, and postgres_version attributes
-  remain client-side validated because they churn rarely.name can be changed in place. The server's PATCH body accepts
-  name, so a rename is applied via PATCH rather than
-  destroy-and-recreate. Renaming is disruptive: the server rotates the
-  service's hostname and CA certificates, so hostname and
-  connection_string change (the plan marks them as updating and emits
-  a warning) and existing clients must reconnect to the new host and
-  re-trust the new certificate. Renaming a live read replica is rejected
-  at plan time, mirroring size / ha_type / tags.The connection string and password are visible in plan output even
+  remain client-side validated because they churn rarely.Changing name rotates the service's hostname and CA certificates,
+  so hostname and connection_string change (the plan marks them as
+  updating and emits a warning) and existing clients must reconnect to
+  the new host and re-trust the new certificate. Renaming a live read
+  replica is rejected at plan time, mirroring size / ha_type /
+  tags.The connection string and password are visible in plan output even
   though both are marked Sensitive. The Terraform CLI renders
   Sensitive attributes as (sensitive value) in human-readable
   output but the underlying state file is plaintext — ensure your
@@ -346,14 +344,12 @@ UI, or CLI directly.
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes
   remain client-side validated because they churn rarely.
-- `name` can be changed in place. The server's PATCH body accepts
-  `name`, so a rename is applied via PATCH rather than
-  destroy-and-recreate. Renaming is disruptive: the server rotates the
-  service's hostname and CA certificates, so `hostname` and
-  `connection_string` change (the plan marks them as updating and emits
-  a warning) and existing clients must reconnect to the new host and
-  re-trust the new certificate. Renaming a live read replica is rejected
-  at plan time, mirroring `size` / `ha_type` / `tags`.
+- Changing `name` rotates the service's hostname and CA certificates,
+  so `hostname` and `connection_string` change (the plan marks them as
+  updating and emits a warning) and existing clients must reconnect to
+  the new host and re-trust the new certificate. Renaming a live read
+  replica is rejected at plan time, mirroring `size` / `ha_type` /
+  `tags`.
 - The connection string and password are visible in plan output even
   though both are marked `Sensitive`. The Terraform CLI renders
   `Sensitive` attributes as `(sensitive value)` in human-readable
@@ -367,7 +363,7 @@ UI, or CLI directly.
 
 ### Required
 
-- `name` (String) Human-readable name. Can be changed in place; the rename is applied via PATCH (no destroy-and-recreate). Note: renaming rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.
+- `name` (String) Human-readable name. Changing it rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.
 
 ### Optional
 

--- a/docs/resources/postgres_service.md
+++ b/docs/resources/postgres_service.md
@@ -143,9 +143,14 @@ description: |-
   before users can adopt them; size is the most frequently changed
   attribute, so the trade-off goes the other way here. The
   cloud_provider, ha_type, and postgres_version attributes
-  remain client-side validated because they churn rarely.name is immutable post-create. The server's PATCH body has no
-  name field, so changing it forces destroy-and-recreate via
-  RequiresReplace.The connection string and password are visible in plan output even
+  remain client-side validated because they churn rarely.name can be changed in place. The server's PATCH body accepts
+  name, so a rename is applied via PATCH rather than
+  destroy-and-recreate. Renaming is disruptive: the server rotates the
+  service's hostname and CA certificates, so hostname and
+  connection_string change (the plan marks them as updating and emits
+  a warning) and existing clients must reconnect to the new host and
+  re-trust the new certificate. Renaming a live read replica is rejected
+  at plan time, mirroring size / ha_type / tags.The connection string and password are visible in plan output even
   though both are marked Sensitive. The Terraform CLI renders
   Sensitive attributes as (sensitive value) in human-readable
   output but the underlying state file is plaintext — ensure your
@@ -341,9 +346,14 @@ UI, or CLI directly.
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes
   remain client-side validated because they churn rarely.
-- `name` is immutable post-create. The server's PATCH body has no
-  `name` field, so changing it forces destroy-and-recreate via
-  `RequiresReplace`.
+- `name` can be changed in place. The server's PATCH body accepts
+  `name`, so a rename is applied via PATCH rather than
+  destroy-and-recreate. Renaming is disruptive: the server rotates the
+  service's hostname and CA certificates, so `hostname` and
+  `connection_string` change (the plan marks them as updating and emits
+  a warning) and existing clients must reconnect to the new host and
+  re-trust the new certificate. Renaming a live read replica is rejected
+  at plan time, mirroring `size` / `ha_type` / `tags`.
 - The connection string and password are visible in plan output even
   though both are marked `Sensitive`. The Terraform CLI renders
   `Sensitive` attributes as `(sensitive value)` in human-readable
@@ -357,7 +367,7 @@ UI, or CLI directly.
 
 ### Required
 
-- `name` (String) Human-readable name. Immutable post-create; changes force destroy-and-recreate. Differs from clickhouse_service, which allows in-place rename.
+- `name` (String) Human-readable name. Can be changed in place; the rename is applied via PATCH (no destroy-and-recreate). Note: renaming rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.
 
 ### Optional
 

--- a/pkg/internal/api/postgres.go
+++ b/pkg/internal/api/postgres.go
@@ -100,9 +100,9 @@ func (c *ClientImpl) CreatePostgres(ctx context.Context, body PostgresCreate) (*
 	return &resp.Result, resp.Result.Password, nil
 }
 
-// UpdatePostgres PATCHes name / size / haType / tags. A name change renames
-// the service in place (the server also rotates its host name and CA certs).
-// Other fields would be rejected by the server; PostgresUpdate's shape enforces this.
+// UpdatePostgres PATCHes name / size / haType / tags. A name change also
+// rotates the service's host name and CA certs. Other fields would be rejected
+// by the server; PostgresUpdate's shape enforces this.
 func (c *ClientImpl) UpdatePostgres(ctx context.Context, postgresId string, body PostgresUpdate) (*Postgres, error) {
 	rb, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/internal/api/postgres.go
+++ b/pkg/internal/api/postgres.go
@@ -100,8 +100,9 @@ func (c *ClientImpl) CreatePostgres(ctx context.Context, body PostgresCreate) (*
 	return &resp.Result, resp.Result.Password, nil
 }
 
-// UpdatePostgres PATCHes size / haType / tags. Other fields would be rejected
-// by the server; PostgresUpdate's shape enforces this.
+// UpdatePostgres PATCHes name / size / haType / tags. A name change renames
+// the service in place (the server also rotates its host name and CA certs).
+// Other fields would be rejected by the server; PostgresUpdate's shape enforces this.
 func (c *ClientImpl) UpdatePostgres(ctx context.Context, postgresId string, body PostgresUpdate) (*Postgres, error) {
 	rb, err := json.Marshal(body)
 	if err != nil {

--- a/pkg/internal/api/postgres_models.go
+++ b/pkg/internal/api/postgres_models.go
@@ -103,8 +103,8 @@ type PostgresCreate struct {
 }
 
 // PostgresUpdate is the PATCH /postgres/{id} body. Server accepts
-// name / size / haType / tags. Setting name renames the service in place;
-// the server also rotates the host name and CA certificates as a side effect.
+// name / size / haType / tags. Setting name renames the service and rotates
+// its host name and CA certificates as a side effect.
 // Tags is *[]Tag so callers can distinguish:
 //
 //	nil       -> field omitted; server leaves existing tags alone

--- a/pkg/internal/api/postgres_models.go
+++ b/pkg/internal/api/postgres_models.go
@@ -102,14 +102,16 @@ type PostgresCreate struct {
 	PgBouncerConfig PgConfigMap `json:"pgBouncerConfig,omitempty"`
 }
 
-// PostgresUpdate is the PATCH /postgres/{id} body. Server accepts ONLY
-// size / haType / tags; `name` is intentionally absent (no field in the
-// server schema). Tags is *[]Tag so callers can distinguish:
+// PostgresUpdate is the PATCH /postgres/{id} body. Server accepts
+// name / size / haType / tags. Setting name renames the service in place;
+// the server also rotates the host name and CA certificates as a side effect.
+// Tags is *[]Tag so callers can distinguish:
 //
 //	nil       -> field omitted; server leaves existing tags alone
 //	&[]Tag{}  -> server clears all tags
 //	&[]Tag{…} -> server replaces with these
 type PostgresUpdate struct {
+	Name   string `json:"name,omitempty"`
 	Size   string `json:"size,omitempty"`
 	HaType string `json:"haType,omitempty"`
 	Tags   *[]Tag `json:"tags,omitempty"`

--- a/pkg/internal/api/postgres_test.go
+++ b/pkg/internal/api/postgres_test.go
@@ -238,6 +238,28 @@ func TestUpdatePostgres_PatchesOnlyChangedFields(t *testing.T) {
 	}
 }
 
+func TestUpdatePostgres_SendsNameWhenSet(t *testing.T) {
+	const newName = "renamed-pg"
+	var capturedBody map[string]any
+	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if err := json.Unmarshal(body, &capturedBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", Name: newName}})
+	})
+	_, err := client.UpdatePostgres(context.Background(), testPostgresID, PostgresUpdate{Name: newName})
+	if err != nil {
+		t.Fatalf("UpdatePostgres: %v", err)
+	}
+	if got := capturedBody["name"]; got != newName {
+		t.Errorf("name = %v; want %q", got, newName)
+	}
+}
+
 // ----- DeletePostgres ------------------------------------------------------
 
 func TestDeletePostgres_HappyPath(t *testing.T) {

--- a/pkg/resource/descriptions/postgres_service.md
+++ b/pkg/resource/descriptions/postgres_service.md
@@ -185,9 +185,14 @@ UI, or CLI directly.
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes
   remain client-side validated because they churn rarely.
-- `name` is immutable post-create. The server's PATCH body has no
-  `name` field, so changing it forces destroy-and-recreate via
-  `RequiresReplace`.
+- `name` can be changed in place. The server's PATCH body accepts
+  `name`, so a rename is applied via PATCH rather than
+  destroy-and-recreate. Renaming is disruptive: the server rotates the
+  service's hostname and CA certificates, so `hostname` and
+  `connection_string` change (the plan marks them as updating and emits
+  a warning) and existing clients must reconnect to the new host and
+  re-trust the new certificate. Renaming a live read replica is rejected
+  at plan time, mirroring `size` / `ha_type` / `tags`.
 - The connection string and password are visible in plan output even
   though both are marked `Sensitive`. The Terraform CLI renders
   `Sensitive` attributes as `(sensitive value)` in human-readable

--- a/pkg/resource/descriptions/postgres_service.md
+++ b/pkg/resource/descriptions/postgres_service.md
@@ -185,14 +185,12 @@ UI, or CLI directly.
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes
   remain client-side validated because they churn rarely.
-- `name` can be changed in place. The server's PATCH body accepts
-  `name`, so a rename is applied via PATCH rather than
-  destroy-and-recreate. Renaming is disruptive: the server rotates the
-  service's hostname and CA certificates, so `hostname` and
-  `connection_string` change (the plan marks them as updating and emits
-  a warning) and existing clients must reconnect to the new host and
-  re-trust the new certificate. Renaming a live read replica is rejected
-  at plan time, mirroring `size` / `ha_type` / `tags`.
+- Changing `name` rotates the service's hostname and CA certificates,
+  so `hostname` and `connection_string` change (the plan marks them as
+  updating and emits a warning) and existing clients must reconnect to
+  the new host and re-trust the new certificate. Renaming a live read
+  replica is rejected at plan time, mirroring `size` / `ha_type` /
+  `tags`.
 - The connection string and password are visible in plan output even
   though both are marked `Sensitive`. The Terraform CLI renders
   `Sensitive` attributes as `(sensitive value)` in human-readable

--- a/pkg/resource/postgres_service.go
+++ b/pkg/resource/postgres_service.go
@@ -243,7 +243,7 @@ func (r *PostgresServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"name": schema.StringAttribute{
-				Description: "Human-readable name. Can be changed in place; the rename is applied via PATCH (no destroy-and-recreate). Note: renaming rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.",
+				Description: "Human-readable name. Changing it rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(postgresInstanceNameMin, postgresInstanceNameMax),
@@ -920,7 +920,7 @@ func (r *PostgresServiceResource) ModifyPlan(ctx context.Context, req resource.M
 		resp.Diagnostics.AddAttributeWarning(
 			path.Root("name"),
 			"Renaming rotates the connection endpoint",
-			"Changing name renames the service in place, but the server also issues a new host name and CA certificates. Existing clients must reconnect to the new hostname and re-trust the new certificate; hostname and connection_string will change.",
+			"Renaming rotates the service's host name and CA certificates: hostname and connection_string change, and existing clients must reconnect to the new host and re-trust the new certificate.",
 		)
 	}
 

--- a/pkg/resource/postgres_service.go
+++ b/pkg/resource/postgres_service.go
@@ -223,6 +223,7 @@ func replicaUpdateForbidden(plan, state models.PostgresServiceResourceModel) dia
 			"`"+name+"` cannot be changed on a live read replica — the server rejects direct modifications. Change it on the parent (primary) instead. Removing read_replica_of turns this into a standalone primary, but destroys and recreates the instance (it is not an in-place detach).",
 		)
 	}
+	forbid("name", plan.Name, state.Name)
 	forbid("size", plan.Size, state.Size)
 	forbid("ha_type", plan.HaType, state.HaType)
 	forbid("tags", plan.Tags, state.Tags)
@@ -242,13 +243,10 @@ func (r *PostgresServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"name": schema.StringAttribute{
-				Description: "Human-readable name. Immutable post-create; changes force destroy-and-recreate. Differs from clickhouse_service, which allows in-place rename.",
+				Description: "Human-readable name. Can be changed in place; the rename is applied via PATCH (no destroy-and-recreate). Note: renaming rotates the server-assigned hostname and CA certificates, so connection_string and hostname change and existing clients must reconnect.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(postgresInstanceNameMin, postgresInstanceNameMax),
-				},
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"cloud_provider": schema.StringAttribute{
@@ -911,13 +909,28 @@ func (r *PostgresServiceResource) ModifyPlan(ctx context.Context, req resource.M
 		}
 	}
 
+	// A rename rotates the server-assigned host name and CA certificates. hostname
+	// (UseStateForUnknown) and connection_string (pinned below) would otherwise
+	// carry stale values, tripping an inconsistent-result error on the post-apply
+	// read. Mark hostname unknown so the plan shows it changing, and warn that
+	// existing clients must reconnect to the new host and re-trust the new cert.
+	rename := renamePlanned(plan, state)
+	if rename {
+		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("hostname"), types.StringUnknown())...)
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("name"),
+			"Renaming rotates the connection endpoint",
+			"Changing name renames the service in place, but the server also issues a new host name and CA certificates. Existing clients must reconnect to the new hostname and re-trust the new certificate; hostname and connection_string will change.",
+		)
+	}
+
 	// password and connection_string are Computed and hydrated from the server on
 	// every read, so state always holds a known value. The only question is plan
-	// stability: when a rotation is planned the new value isn't known yet (a
-	// an interpolated password), so mark them
-	// unknown; otherwise pin the prior state value (which equals the live one).
-	// `password` only needs setting when the user didn't configure a literal —
-	// a configured value is already the known plan value.
+	// stability: when a rotation is planned the new value isn't known yet (an
+	// interpolated password), and a rename re-issues the connection string, so
+	// mark them unknown; otherwise pin the prior state value (which equals the
+	// live one). `password` only needs setting when the user didn't configure a
+	// literal — a configured value is already the known plan value.
 	rotation := passwordRotationPlanned(config, state)
 	if config.Password.IsNull() {
 		pw := state.Password
@@ -927,7 +940,7 @@ func (r *PostgresServiceResource) ModifyPlan(ctx context.Context, req resource.M
 		resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("password"), pw)...)
 	}
 	connStr := state.ConnectionString
-	if rotation {
+	if rotation || rename {
 		connStr = types.StringUnknown()
 	}
 	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("connection_string"), connStr)...)
@@ -1163,6 +1176,13 @@ func buildPostgresUpdate(ctx context.Context, plan, state models.PostgresService
 	changed := false
 	transitionExpected := false
 
+	if !plan.Name.Equal(state.Name) {
+		update.Name = plan.Name.ValueString()
+		changed = true
+		// A rename is server-side eventually-consistent (it rotates the host name
+		// and CA certs), so wait until the new name is reflected before reading back.
+		transitionExpected = true
+	}
 	if !plan.Size.Equal(state.Size) {
 		update.Size = plan.Size.ValueString()
 		changed = true
@@ -1208,6 +1228,7 @@ func buildPostgresUpdate(ctx context.Context, plan, state models.PostgresService
 // PATCHed (size / ha_type / tags). This is field-aware so the wait doesn't
 // settle on a stale 'running' before Ubicloud commits the queued change.
 func buildPostgresMatchPredicate(body *api.PostgresUpdate) func(*api.Postgres) bool {
+	expectName := body.Name
 	expectSize := body.Size
 	expectHaType := body.HaType
 	var expectTags map[string]string
@@ -1220,6 +1241,9 @@ func buildPostgresMatchPredicate(body *api.PostgresUpdate) func(*api.Postgres) b
 	}
 	return func(pg *api.Postgres) bool {
 		if pg.State != api.PostgresStateRunning {
+			return false
+		}
+		if expectName != "" && pg.Name != expectName {
 			return false
 		}
 		if expectSize != "" && pg.Size != expectSize {
@@ -1507,4 +1531,15 @@ func passwordRotationPlanned(config, state models.PostgresServiceResourceModel) 
 		return true
 	}
 	return !config.Password.IsNull() && !config.Password.Equal(state.Password)
+}
+
+// renamePlanned reports whether the update plans an in-place rename: a known
+// plan name that differs from the live state. name is Required (always known in
+// a non-interpolated plan); an unknown (interpolated) name can't be proven a
+// change, so defer to apply.
+func renamePlanned(plan, state models.PostgresServiceResourceModel) bool {
+	if plan.Name.IsUnknown() {
+		return false
+	}
+	return !plan.Name.Equal(state.Name)
 }

--- a/pkg/resource/postgres_service_config_password_restore_test.go
+++ b/pkg/resource/postgres_service_config_password_restore_test.go
@@ -208,6 +208,24 @@ func TestPasswordRotationPlanned(t *testing.T) {
 	}
 }
 
+func TestRenamePlanned(t *testing.T) {
+	mdl := func(n types.String) models.PostgresServiceResourceModel {
+		return models.PostgresServiceResourceModel{Name: n}
+	}
+
+	if !renamePlanned(mdl(types.StringValue("new")), mdl(types.StringValue("old"))) {
+		t.Error("a known plan name differing from state is a planned rename")
+	}
+	if renamePlanned(mdl(types.StringValue("same")), mdl(types.StringValue("same"))) {
+		t.Error("identical names are not a rename")
+	}
+	// name is Required (not Computed): an unknown plan value is an interpolated
+	// config that can't be proven a change, so defer to apply.
+	if renamePlanned(mdl(types.StringUnknown()), mdl(types.StringValue("old"))) {
+		t.Error("an unknown (interpolated) name must not be treated as a rename at plan time")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // create-time attribute validation: required for a standard create; for a
 // replica/restore validated against the source (match/omit → ok, conflict →
@@ -434,6 +452,11 @@ func TestReplicaUpdateForbidden(t *testing.T) {
 	m := func(size, ha types.String, tags, pg types.Map) models.PostgresServiceResourceModel {
 		return models.PostgresServiceResourceModel{Size: size, HaType: ha, Tags: tags, PgConfig: pg}
 	}
+	withName := func(base models.PostgresServiceResourceModel, n types.String) models.PostgresServiceResourceModel {
+		base.Name = n
+		return base
+	}
+	nameOld, nameNew := types.StringValue("svc-old"), types.StringValue("svc-new")
 	cases := []struct {
 		name        string
 		plan, state models.PostgresServiceResourceModel
@@ -450,6 +473,10 @@ func TestReplicaUpdateForbidden(t *testing.T) {
 		// apply, don't false-positive at plan.
 		{"unknown size → deferred", m(types.StringUnknown(), none, tagsA, cfgA), m(large, none, tagsA, cfgA), 0},
 		{"unknown tags → deferred", m(large, none, types.MapUnknown(types.StringType), cfgA), m(large, none, tagsA, cfgA), 0},
+		// A live replica's name is server-derived; renaming it directly is rejected,
+		// so block it at plan time alongside size/ha_type/tags.
+		{"name changed", withName(m(large, none, tagsA, cfgA), nameNew), withName(m(large, none, tagsA, cfgA), nameOld), 1},
+		{"unknown name → deferred", withName(m(large, none, tagsA, cfgA), types.StringUnknown()), withName(m(large, none, tagsA, cfgA), nameOld), 0},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/resource/postgres_service_test.go
+++ b/pkg/resource/postgres_service_test.go
@@ -517,6 +517,25 @@ func TestBuildPostgresUpdate(t *testing.T) {
 			t.Errorf("size change inside combined diff must still surface TransitionExpected")
 		}
 	})
+
+	t.Run("name-only diff produces name body with TransitionExpected", func(t *testing.T) {
+		plan := baseModel("c6gd.large", "none", mapTags())
+		plan.Name = types.StringValue("renamed")
+		state := baseModel("c6gd.large", "none", mapTags())
+		state.Name = types.StringValue("original")
+		result, diags := buildPostgresUpdate(ctx, plan, state)
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if result.Body == nil || result.Body.Name != "renamed" {
+			t.Errorf("expected name=renamed in body, got %#v", result.Body)
+		}
+		// A rename is server-side eventually-consistent (the host name + certs
+		// rotate); the wait must hold until the new name is reflected.
+		if !result.TransitionExpected {
+			t.Errorf("name change must signal TransitionExpected=true")
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -594,6 +613,17 @@ func TestBuildPostgresMatchPredicate(t *testing.T) {
 		}
 		if predicate(&api.Postgres{State: api.PostgresStateRunning, Size: "r6gd.large", HaType: "async", Tags: []api.Tag{{Key: "team", Value: "billing"}}}) {
 			t.Error("must NOT match while size still pending")
+		}
+	})
+
+	t.Run("name-only PATCH: only name is gated", func(t *testing.T) {
+		body := &api.PostgresUpdate{Name: "renamed"}
+		predicate := buildPostgresMatchPredicate(body)
+		if !predicate(&api.Postgres{State: api.PostgresStateRunning, Name: "renamed"}) {
+			t.Error("should match once the server reflects the new name")
+		}
+		if predicate(&api.Postgres{State: api.PostgresStateRunning, Name: "original"}) {
+			t.Error("must NOT match while name is still the pre-rename value (queued-rename race case)")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `name` on `clickhouse_postgres_service` is now mutable **in place** via PATCH instead of forcing destroy-and-recreate. The control-plane `postgresServicePatch` OpenAPI gained a `name` field (control-plane #33493 + #33495); this wires it through the provider.
- Renaming is disruptive: the server rotates the service's host name and CA certificates. `ModifyPlan` now marks `hostname` and `connection_string` unknown on a rename and emits a plan-time warning that existing clients must reconnect to the new host and re-trust the new cert.
- The post-PATCH wait predicate (`buildPostgresMatchPredicate`) now gates on the new `name` — a rename is server-side eventually-consistent, so we hold until the server reflects it before reading back.
- Renaming a **live read replica** is rejected at plan time, consistent with `size` / `ha_type` / `tags`.
- `name` keeps its 1–50 length validator; only the `RequiresReplace` plan modifier is removed. `username` and `port` are unchanged by a rename, so they stay pinned.

## Test plan

- [x] `go test ./pkg/resource/ ./pkg/internal/api/` (stable + `-tags alpha`) — api client sends `name`; `buildPostgresUpdate`, `buildPostgresMatchPredicate`, `replicaUpdateForbidden`, and `renamePlanned` cover the new logic.
- [ ] e2e on dev (live-fire): `terraform apply` a `name` change → **no replacement** (stable `id`), `hostname` + `connection_string` change, converges to `running`, and the rotation warning is surfaced; confirm a rename on a live read replica is blocked at plan time.