### PR TITLE
fix(clickpipes): avoid panic when importing Kafka pipe with schema_registry

### DIFF
--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -3912,6 +3912,8 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 				if diags := stateKafkaModel.SchemaRegistry.As(ctx, &stateSchemaRegistryModel, basetypes.ObjectAsOptions{}); diags.HasError() {
 					return fmt.Errorf("error reading ClickPipe Kafka source schema registry: %v", diags)
 				}
+			} else {
+				stateSchemaRegistryModel.Credentials = types.ObjectNull(models.ClickPipeSourceCredentialsModel{}.ObjectType().AttrTypes)
 			}
 
 			schemaRegistryModel := models.ClickPipeKafkaSchemaRegistryModel{

--- a/pkg/resource/clickpipe_bug_fixes_test.go
+++ b/pkg/resource/clickpipe_bug_fixes_test.go
@@ -20,6 +20,56 @@ import (
 
 func int64Ptr(i int64) *int64 { return &i }
 
+func TestClickPipeResource_syncClickPipeState_KafkaSchemaRegistryImport(t *testing.T) {
+	ctx := context.Background()
+
+	state := models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("test-service-id"),
+		Source:    types.ObjectNull(models.ClickPipeSourceModel{}.ObjectType().AttrTypes),
+	}
+
+	mc := minimock.NewController(t)
+	apiClientMock := api.NewClientMock(mc).
+		GetClickPipeMock.
+		Expect(ctx, state.ServiceID.ValueString(), state.ID.ValueString()).
+		Return(&api.ClickPipe{
+			ID:    "test-pipe-id",
+			Name:  "test-pipe",
+			State: "Running",
+			Source: api.ClickPipeSource{
+				Kafka: &api.ClickPipeKafkaSource{
+					Type:           "confluent",
+					Format:         "Protobuf",
+					Brokers:        "broker:9092",
+					Topics:         "test-topic",
+					Authentication: "PLAIN",
+					SchemaRegistry: &api.ClickPipeKafkaSchemaRegistry{
+						URL:            "https://schema-registry.example/schemas/ids/1",
+						Authentication: "PLAIN",
+					},
+				},
+			},
+			Destination: api.ClickPipeDestination{Database: "default"},
+		}, nil)
+
+	r := &ClickPipeResource{client: apiClientMock}
+
+	err := r.syncClickPipeState(ctx, &state)
+	assert.NoError(t, err)
+
+	var sourceModel models.ClickPipeSourceModel
+	state.Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{})
+	var kafkaModel models.ClickPipeKafkaSourceModel
+	sourceModel.Kafka.As(ctx, &kafkaModel, basetypes.ObjectAsOptions{})
+	assert.False(t, kafkaModel.SchemaRegistry.IsNull(), "schema_registry should be populated after sync")
+	var srModel models.ClickPipeKafkaSchemaRegistryModel
+	kafkaModel.SchemaRegistry.As(ctx, &srModel, basetypes.ObjectAsOptions{})
+	assert.Equal(t, "https://schema-registry.example/schemas/ids/1", srModel.URL.ValueString())
+	assert.Equal(t, "PLAIN", srModel.Authentication.ValueString())
+	assert.True(t, srModel.Credentials.IsNull(), "credentials should be a typed null (not present in API response)")
+}
+
 // ============================================================================
 // Issue #528 — Postgres/MySQL credentials become "undefined" when
 // lifecycle.ignore_changes hides them during update.


### PR DESCRIPTION
## Summary

- `terraform import` on a Kafka ClickPipe whose source has `schema_registry` panics in `pkg/resource/clickpipe.go:syncClickPipeState` (`ObjectValueMust` rejects an empty `types.ObjectType[]` for the inner `credentials` field)
- Root cause: when state is null (no prior state, e.g. during import), the `else` branch was missing and `stateSchemaRegistryModel.Credentials` stayed as a zero-value `types.Object{}` with no `AttrTypes`. The kafka-source credentials branch right above already handles this defensively with a typed-null fallback
- Fix: mirror that typed-null `else` clause for the schema_registry credentials; adds regression test in `clickpipe_bug_fixes_test.go`

Customer report: provider `ClickHouse/clickhouse v3.17.1`, Terraform `v1.11.3`, panic trace through `ClickPipeKafkaSchemaRegistryModel.ObjectValue` (clickpipe_resource.go:71) → `syncClickPipeState` (clickpipe.go:3909) → `Read` (clickpipe.go:4988) — reproduced verbatim end-to-end against `v3.17.1` and verified the fix removes the panic.

## Test plan

- [x] `go test ./pkg/resource/...` — full pkg green
- [x] New `TestClickPipeResource_syncClickPipeState_KafkaSchemaRegistryImport` test panics on unfixed code, passes on fixed code
- [x] `golangci-lint run ./pkg/resource/... --new-from-rev=origin/main` — clean
- [x] E2E: `terraform plan` with an `import {}` block against a real Kafka+schema_registry ClickPipe in dev — pre-fix: same panic as customer; post-fix: plan completes