### PR TITLE
fix(release): make cleanup + release gates rerun-safe

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -335,6 +335,7 @@ jobs:
   cleanup:
     runs-on: k8s-small
     needs: [ "e2e", "import", "upgrade", "token" ]
+    if: always() && needs.token.result == 'success'
     continue-on-error: true
     steps:
       - name: Checkout
@@ -362,7 +363,7 @@ jobs:
   # Bump the provider version in the examples directory
   bump-examples:
     needs: [ "validate", "e2e", "import", "upgrade" ]
-    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
+    if: ${{ always() && needs.validate.result == 'success' && needs.e2e.result == 'success' && needs.import.result == 'success' && needs.upgrade.result == 'success' }}
     runs-on: k8s-small
     permissions:
       contents: write
@@ -462,7 +463,7 @@ jobs:
       contents: write
       pull-requests: write
     needs: [ "e2e", "import", "upgrade", "bump-examples" ]
-    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
+    if: ${{ always() && needs.e2e.result == 'success' && needs.import.result == 'success' && needs.upgrade.result == 'success' && needs.bump-examples.result == 'success' }}
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -495,7 +496,7 @@ jobs:
       contents: write
     runs-on: k8s-medium
     needs: [ "validate", "tag", "e2e", "import", "upgrade" ]
-    if: ${{ needs.e2e.result != 'failure' && needs.import.result != 'failure' && needs.upgrade.result != 'failure' }}
+    if: ${{ always() && needs.validate.result == 'success' && needs.tag.result == 'success' && needs.e2e.result == 'success' && needs.import.result == 'success' && needs.upgrade.result == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Three related fixes to the release workflow so that re-running failed jobs after a transient test failure can actually produce a release.

### 1. `cleanup` had no `if:` clause
`needs: [e2e, import, upgrade, token]` without `if: always()` means a failed e2e/upgrade makes `cleanup` skip — the orphaned test ClickHouse services then collide with the next attempt as `DUPLICATE_INSTANCE_NAME` (409). This is exactly what happened on run #232 attempt 2.

### 2. Release gates used `!= 'failure'`
`bump-examples`, `tag`, and `goreleaser` gated on `needs.<job>.result != 'failure'`, which lets `skipped`/`cancelled` through. `tag` also didn't check `bump-examples.result` in its `if:`, and `goreleaser` didn't check `tag.result`. Tightened to explicit `== 'success'` for every direct upstream.

### 3. Re-run-failed-jobs needed `always()` to re-evaluate gates
The three release-gating jobs now use `if: always() && needs.X.result == 'success' && …` so they're considered on every attempt and re-evaluate their `needs` cleanly when previously-failed matrix combos are re-run.

## Test plan

- [ ] Trigger Release workflow with a known-bad fixture, observe `cleanup` runs (not skipped) and tears down leaked services
- [ ] Fix the fixture, re-run failed jobs only, observe `bump-examples` → `tag` → `goreleaser` chain executes and a release is produced