### PR TITLE
feat(clickpipe): add exactly_once to Kafka source

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -231,6 +231,7 @@ Optional:
 - `ca_certificate` (String) PEM encoded CA certificates to validate the broker's certificate.
 - `consumer_group` (String) Consumer group of the Kafka source. If not provided `clickpipes-<ID>` will be used.
 - `credentials` (Attributes) The credentials for the Kafka source. (see [below for nested schema](#nestedatt--source--kafka--credentials))
+- `exactly_once` (Boolean) Enable exactly-once delivery. Guarantees every Kafka record is inserted exactly once across restarts and rebalances.
 - `iam_role` (String) The IAM role for the Kafka source. Use with `IAM_ROLE` authentication. It can be used with AWS ClickHouse service only. Read more at https://clickhouse.com/docs/en/integrations/clickpipes/kafka#iam
 - `offset` (Attributes) The Kafka offset. (see [below for nested schema](#nestedatt--source--kafka--offset))
 - `reverse_private_endpoint_ids` (List of String) The list of reverse private endpoint IDs for the Kafka source. (comma separated)

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -108,6 +108,8 @@ type ClickPipeKafkaSource struct {
 	CACertificate  *string                          `json:"caCertificate,omitempty"`
 
 	ReversePrivateEndpointIDs []string `json:"reversePrivateEndpointIds,omitempty"`
+
+	ExactlyOnce *bool `json:"exactlyOnce,omitempty"`
 }
 
 type ClickPipeObjectStorageSource struct {

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -438,6 +438,13 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									listplanmodifier.RequiresReplace(),
 								},
 							},
+							"exactly_once": schema.BoolAttribute{
+								MarkdownDescription: "Enable exactly-once delivery. Guarantees every Kafka record is inserted exactly once across restarts and rebalances.",
+								Optional:            true,
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.RequiresReplace(),
+								},
+							},
 						},
 					},
 					"object_storage": schema.SingleNestedAttribute{
@@ -2833,6 +2840,7 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 		if !isUpdate {
 			source.Kafka.Type = kafkaModel.Type.ValueString()
 			source.Kafka.Format = kafkaModel.Format.ValueString()
+			source.Kafka.ExactlyOnce = kafkaModel.ExactlyOnce.ValueBoolPointer()
 		}
 
 		if kafkaModel.Authentication.ValueString() != api.ClickPipeAuthenticationIAMRole {
@@ -3946,6 +3954,12 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			kafkaModel.ReversePrivateEndpointIDs, _ = types.ListValue(types.StringType, reversePrivateEndpointIDs)
 		} else {
 			kafkaModel.ReversePrivateEndpointIDs = types.ListNull(types.StringType)
+		}
+
+		if clickPipe.Source.Kafka.ExactlyOnce != nil {
+			kafkaModel.ExactlyOnce = types.BoolValue(*clickPipe.Source.Kafka.ExactlyOnce)
+		} else {
+			kafkaModel.ExactlyOnce = types.BoolNull()
 		}
 
 		sourceModel.Kafka = kafkaModel.ObjectValue()

--- a/pkg/resource/clickpipe_kafka_exactly_once_test.go
+++ b/pkg/resource/clickpipe_kafka_exactly_once_test.go
@@ -1,0 +1,94 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/resource/models"
+)
+
+// buildKafkaExactlyOncePlan returns a minimal IAM_ROLE-authenticated Kafka plan
+// with the given exactly_once value, so tests can exercise null vs. set behavior.
+func buildKafkaExactlyOncePlan(exactlyOnce types.Bool) models.ClickPipeResourceModel {
+	kafkaAttrs := map[string]attr.Value{
+		"type":                         types.StringValue("msk"),
+		"format":                       types.StringValue(api.ClickPipeJSONEachRowFormat),
+		"brokers":                      types.StringValue("broker:9092"),
+		"topics":                       types.StringValue("test-topic"),
+		"consumer_group":               types.StringNull(),
+		"offset":                       types.ObjectNull(models.ClickPipeKafkaOffsetModel{}.ObjectType().AttrTypes),
+		"schema_registry":              types.ObjectNull(models.ClickPipeKafkaSchemaRegistryModel{}.ObjectType().AttrTypes),
+		"authentication":               types.StringValue(api.ClickPipeAuthenticationIAMRole),
+		"credentials":                  types.ObjectNull(models.ClickPipeKafkaSourceCredentialsModel{}.ObjectType().AttrTypes),
+		"iam_role":                     types.StringValue("arn:aws:iam::123456789012:role/MyRole"),
+		"ca_certificate":               types.StringNull(),
+		"reverse_private_endpoint_ids": types.ListNull(types.StringType),
+		"exactly_once":                 exactlyOnce,
+	}
+	sourceModel := models.ClickPipeSourceModel{
+		Kafka:         types.ObjectValueMust(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes, kafkaAttrs),
+		ObjectStorage: types.ObjectNull(models.ClickPipeObjectStorageSourceModel{}.ObjectType().AttrTypes),
+		Kinesis:       types.ObjectNull(models.ClickPipeKinesisSourceModel{}.ObjectType().AttrTypes),
+		PubSub:        types.ObjectNull(models.ClickPipePubSubSourceModel{}.ObjectType().AttrTypes),
+		Postgres:      types.ObjectNull(models.ClickPipePostgresSourceModel{}.ObjectType().AttrTypes),
+		MySQL:         types.ObjectNull(models.ClickPipeMySQLSourceModel{}.ObjectType().AttrTypes),
+		BigQuery:      types.ObjectNull(models.ClickPipeBigQuerySourceModel{}.ObjectType().AttrTypes),
+		MongoDB:       types.ObjectNull(models.ClickPipeMongoDBSourceModel{}.ObjectType().AttrTypes),
+	}
+	return models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("service-123"),
+		Name:      types.StringValue("test-kafka-eos"),
+		Source:    sourceModel.ObjectValue(),
+	}
+}
+
+func TestExtractSourceFromPlan_Kafka_ExactlyOnceEnabled(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildKafkaExactlyOncePlan(types.BoolValue(true))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.Kafka)
+	assert.NotNil(t, source.Kafka.ExactlyOnce)
+	assert.True(t, *source.Kafka.ExactlyOnce)
+}
+
+func TestExtractSourceFromPlan_Kafka_ExactlyOnceNull(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildKafkaExactlyOncePlan(types.BoolNull())
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.Kafka)
+	assert.Nil(t, source.Kafka.ExactlyOnce)
+}
+
+// exactly_once is create-only: it must not be included in an update (PATCH) payload.
+func TestExtractSourceFromPlan_Kafka_ExactlyOnceOmittedOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildKafkaExactlyOncePlan(types.BoolValue(true))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, true)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.Kafka)
+	assert.Nil(t, source.Kafka.ExactlyOnce)
+}

--- a/pkg/resource/clickpipe_test.go
+++ b/pkg/resource/clickpipe_test.go
@@ -519,6 +519,7 @@ func buildKafkaMutualTLSPlan(certificate, privateKey types.String) models.ClickP
 		"iam_role":                     types.StringNull(),
 		"ca_certificate":               types.StringNull(),
 		"reverse_private_endpoint_ids": types.ListNull(types.StringType),
+		"exactly_once":                 types.BoolNull(),
 	}
 
 	sourceModel := models.ClickPipeSourceModel{
@@ -720,6 +721,7 @@ func buildKafkaCredentialsPlan(password, passwordWO types.String, passwordWOVers
 			"iam_role":                     types.StringNull(),
 			"ca_certificate":               types.StringNull(),
 			"reverse_private_endpoint_ids": types.ListNull(types.StringType),
+			"exactly_once":                 types.BoolNull(),
 		}
 		sourceModel := models.ClickPipeSourceModel{
 			Kafka:         types.ObjectValueMust(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes, kafkaAttrs),
@@ -817,6 +819,7 @@ func buildKafkaSchemaRegistryCredentialsPlan(password, passwordWO types.String, 
 			"iam_role":                     types.StringNull(),
 			"ca_certificate":               types.StringNull(),
 			"reverse_private_endpoint_ids": types.ListNull(types.StringType),
+			"exactly_once":                 types.BoolNull(),
 		}
 		sourceModel := models.ClickPipeSourceModel{
 			Kafka:         types.ObjectValueMust(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes, kafkaAttrs),

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -186,6 +186,8 @@ type ClickPipeKafkaSourceModel struct {
 	CACertificate  types.String `tfsdk:"ca_certificate"`
 
 	ReversePrivateEndpointIDs types.List `tfsdk:"reverse_private_endpoint_ids"`
+
+	ExactlyOnce types.Bool `tfsdk:"exactly_once"`
 }
 
 func (m ClickPipeKafkaSourceModel) ObjectType() types.ObjectType {
@@ -203,6 +205,7 @@ func (m ClickPipeKafkaSourceModel) ObjectType() types.ObjectType {
 			"iam_role":                     types.StringType,
 			"ca_certificate":               types.StringType,
 			"reverse_private_endpoint_ids": types.ListType{ElemType: types.StringType},
+			"exactly_once":                 types.BoolType,
 		},
 	}
 }
@@ -221,6 +224,7 @@ func (m ClickPipeKafkaSourceModel) ObjectValue() types.Object {
 		"iam_role":                     m.IAMRole,
 		"ca_certificate":               m.CACertificate,
 		"reverse_private_endpoint_ids": m.ReversePrivateEndpointIDs,
+		"exactly_once":                 m.ExactlyOnce,
 	})
 }
 


### PR DESCRIPTION
- Adds an `exactly_once` boolean to the `clickhouse_clickpipe` Kafka source

Resolves https://linear.app/clickhouse/issue/CLP-998/implement-terraform-for-kafka-exactly-once