### PR TITLE
Prevent CDC ClickPipe scaling leaks

### DIFF
--- a/pkg/resource/clickpipe_bug_fixes_test.go
+++ b/pkg/resource/clickpipe_bug_fixes_test.go
@@ -773,3 +773,60 @@ func TestClickPipeResource_ModifyPlan_RejectsTableDefinitionForCDC_Issue571(t *t
 			"a Postgres CDC pipe without table_definition must not be rejected; got: %v", diags.Errors())
 	})
 }
+
+func TestClickPipeResource_ConfigValidators_RejectCDCScaling(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+
+	runValidateConfig := func(t *testing.T, configModel models.ClickPipeResourceModel) diag.Diagnostics {
+		t.Helper()
+		planVal := tfsdk.Plan{Schema: sch}
+		if d := planVal.Set(ctx, &configModel); d.HasError() {
+			t.Fatalf("encoding config failed: %v", d.Errors())
+		}
+		configVal := tfsdk.Config{Schema: sch, Raw: planVal.Raw}
+
+		var diags diag.Diagnostics
+		for _, validator := range r.ConfigValidators(ctx) {
+			resp := &resource.ValidateConfigResponse{}
+			validator.ValidateResource(ctx, resource.ValidateConfigRequest{Config: configVal}, resp)
+			diags.Append(resp.Diagnostics...)
+		}
+		return diags
+	}
+	detailContains := func(diags diag.Diagnostics, substr string) bool {
+		for _, d := range diags.Errors() {
+			if strings.Contains(d.Detail(), substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	postgresConfig := getPostgresInitialState()
+	postgresConfig.Scaling = types.ObjectValueMust(models.ClickPipeScalingModel{}.ObjectType().AttrTypes, map[string]attr.Value{
+		"replicas":               types.Int64Value(2),
+		"replica_cpu_millicores": types.Int64Null(),
+		"replica_memory_gb":      types.Float64Null(),
+	})
+	postgresConfig.FieldMappings = types.ListNull(models.ClickPipeFieldMappingModel{}.ObjectType())
+	postgresConfig.Settings = types.DynamicNull()
+	postgresConfig.Stopped = types.BoolNull()
+	postgresConfig.TriggerResync = types.BoolNull()
+
+	diags := runValidateConfig(t, postgresConfig)
+	assert.True(t, detailContains(diags, "scaling cannot be configured on clickhouse_clickpipe for Postgres, MySQL, or MongoDB CDC sources"),
+		"CDC scaling must be rejected before create; got: %v", diags.Errors())
+
+	postgresConfig.Scaling = types.ObjectNull(models.ClickPipeScalingModel{}.ObjectType().AttrTypes)
+	diags = runValidateConfig(t, postgresConfig)
+	assert.False(t, detailContains(diags, "scaling cannot be configured on clickhouse_clickpipe"),
+		"Postgres CDC without clickpipe scaling must remain valid; got: %v", diags.Errors())
+}

--- a/pkg/resource/clickpipe_config_validators.go
+++ b/pkg/resource/clickpipe_config_validators.go
@@ -82,8 +82,49 @@ func (v pubsubSeekValidator) ValidateResource(ctx context.Context, req resource.
 	}
 }
 
+// cdcClickPipeScalingValidator prevents a partial create where the ClickPipe
+// POST succeeds but the follow-up scaling PATCH is rejected by the API.
+type cdcClickPipeScalingValidator struct{}
+
+func (v cdcClickPipeScalingValidator) Description(_ context.Context) string {
+	return "Validates that ClickPipe scaling is not configured for CDC source types."
+}
+
+func (v cdcClickPipeScalingValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v cdcClickPipeScalingValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data models.ClickPipeResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Scaling.IsNull() || data.Scaling.IsUnknown() || data.Source.IsNull() || data.Source.IsUnknown() {
+		return
+	}
+
+	sourceModel := models.ClickPipeSourceModel{}
+	resp.Diagnostics.Append(data.Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if sourceModel.Postgres.IsNull() && sourceModel.MySQL.IsNull() && sourceModel.MongoDB.IsNull() {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		path.Root("scaling"),
+		"Invalid CDC ClickPipe scaling configuration",
+		"scaling cannot be configured on clickhouse_clickpipe for Postgres, MySQL, or MongoDB CDC sources. Configure CDC infrastructure sizing with clickhouse_clickpipe_cdc_infrastructure instead.",
+	)
+}
+
 func (c *ClickPipeResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		pubsubSeekValidator{},
+		cdcClickPipeScalingValidator{},
 	}
 }


### PR DESCRIPTION
Adds config-time validation that rejects `scaling` on Postgres, MySQL, and MongoDB CDC ClickPipes.

The root cause is that ClickPipe create is a POST followed by a scaling PATCH, so a rejected PATCH can leave the created pipe outside Terraform state.

The validation points users to `clickhouse_clickpipe_cdc_infrastructure` for CDC sizing and includes coverage for rejecting Postgres CDC scaling while allowing Postgres CDC without the scaling block.
