### PR TITLE
Add ClickPipes object storage load options

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -476,6 +476,8 @@ Optional:
 - `path` (String) Path to the file(s) within the Azure container. Used for Azure Blob Storage sources. You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations. Example: `data/logs/*.json`
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
+- `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when queueUrl is provided.
+- `start_after` (String) Start continuous ingestion after this object key. Cannot be provided when skipInitialLoad is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -476,8 +476,8 @@ Optional:
 - `path` (String) Path to the file(s) within the Azure container. Used for Azure Blob Storage sources. You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations. Example: `data/logs/*.json`
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
-- `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when queueUrl is provided.
-- `start_after` (String) Start continuous ingestion after this object key. Cannot be provided when skipInitialLoad is true.
+- `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.
+- `start_after` (String) Start continuous ingestion after this object key. Cannot be provided when `skip_initial_load` is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/pkg/internal/api/clickpipe_models.go
+++ b/pkg/internal/api/clickpipe_models.go
@@ -120,8 +120,10 @@ type ClickPipeObjectStorageSource struct {
 	Delimiter   *string `json:"delimiter,omitempty"`
 	Compression *string `json:"compression,omitempty"`
 
-	IsContinuous bool    `json:"isContinuous"`
-	QueueURL     *string `json:"queueUrl,omitempty"`
+	IsContinuous    bool    `json:"isContinuous"`
+	QueueURL        *string `json:"queueUrl,omitempty"`
+	SkipInitialLoad *bool   `json:"skipInitialLoad,omitempty"`
+	StartAfter      *string `json:"startAfter,omitempty"`
 
 	Authentication *string                   `json:"authentication,omitempty"`
 	AccessKey      *ClickPipeSourceAccessKey `json:"accessKey,omitempty"`

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -539,14 +539,14 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"skip_initial_load": schema.BoolAttribute{
-								MarkdownDescription: "If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when queueUrl is provided.",
+								MarkdownDescription: "If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.Bool{
 									boolplanmodifier.RequiresReplace(),
 								},
 							},
 							"start_after": schema.StringAttribute{
-								MarkdownDescription: "Start continuous ingestion after this object key. Cannot be provided when skipInitialLoad is true.",
+								MarkdownDescription: "Start continuous ingestion after this object key. Cannot be provided when `skip_initial_load` is true.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -538,6 +538,20 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									stringplanmodifier.RequiresReplace(),
 								},
 							},
+							"skip_initial_load": schema.BoolAttribute{
+								MarkdownDescription: "If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when queueUrl is provided.",
+								Optional:            true,
+								PlanModifiers: []planmodifier.Bool{
+									boolplanmodifier.RequiresReplace(),
+								},
+							},
+							"start_after": schema.StringAttribute{
+								MarkdownDescription: "Start continuous ingestion after this object key. Cannot be provided when skipInitialLoad is true.",
+								Optional:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
 							"authentication": schema.StringAttribute{
 								MarkdownDescription: "CONNECTION_STRING is for Azure Blob Storage. IAM_ROLE and IAM_USER are for AWS S3. IAM_USER and SERVICE_ACCOUNT are for GCS. If not provided, no authentication is used",
 								Optional:            true,
@@ -2010,6 +2024,22 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 				}
 			}
 
+			if !objectStorageModel.SkipInitialLoad.IsNull() && !objectStorageModel.SkipInitialLoad.IsUnknown() && objectStorageModel.SkipInitialLoad.ValueBool() {
+				if objectStorageModel.QueueURL.IsNull() || objectStorageModel.QueueURL.IsUnknown() || objectStorageModel.QueueURL.ValueString() == "" {
+					response.Diagnostics.AddError(
+						"Invalid Configuration",
+						"queue_url is required when skip_initial_load is true",
+					)
+				}
+
+				if !objectStorageModel.StartAfter.IsNull() && !objectStorageModel.StartAfter.IsUnknown() && objectStorageModel.StartAfter.ValueString() != "" {
+					response.Diagnostics.AddError(
+						"Invalid Configuration",
+						"start_after cannot be provided when skip_initial_load is true",
+					)
+				}
+			}
+
 			// Validate IAM_ROLE is not used with GCS
 			if storageType == api.ClickPipeObjectStorageGCSType && authType == api.ClickPipeAuthenticationIAMRole {
 				response.Diagnostics.AddError(
@@ -3018,15 +3048,20 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 		}
 
 		objectStorage := &api.ClickPipeObjectStorageSource{
-			Type:           objectStorageModel.Type.ValueString(),
-			Format:         objectStorageModel.Format.ValueString(),
-			Delimiter:      objectStorageModel.Delimiter.ValueStringPointer(),
-			Compression:    objectStorageModel.Compression.ValueStringPointer(),
-			IsContinuous:   objectStorageModel.IsContinuous.ValueBool(),
-			QueueURL:       objectStorageModel.QueueURL.ValueStringPointer(),
-			Authentication: objectStorageModel.Authentication.ValueStringPointer(),
-			AccessKey:      accessKey,
-			IAMRole:        objectStorageModel.IAMRole.ValueStringPointer(),
+			Type:            objectStorageModel.Type.ValueString(),
+			Format:          objectStorageModel.Format.ValueString(),
+			Delimiter:       objectStorageModel.Delimiter.ValueStringPointer(),
+			Compression:     objectStorageModel.Compression.ValueStringPointer(),
+			IsContinuous:    objectStorageModel.IsContinuous.ValueBool(),
+			QueueURL:        objectStorageModel.QueueURL.ValueStringPointer(),
+			SkipInitialLoad: objectStorageModel.SkipInitialLoad.ValueBoolPointer(),
+			Authentication:  objectStorageModel.Authentication.ValueStringPointer(),
+			AccessKey:       accessKey,
+			IAMRole:         objectStorageModel.IAMRole.ValueStringPointer(),
+		}
+
+		if objectStorage.SkipInitialLoad == nil || !*objectStorage.SkipInitialLoad {
+			objectStorage.StartAfter = objectStorageModel.StartAfter.ValueStringPointer()
 		}
 
 		switch storageType {
@@ -4002,7 +4037,13 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			Compression:  types.StringPointerValue(clickPipe.Source.ObjectStorage.Compression),
 			IsContinuous: types.BoolValue(clickPipe.Source.ObjectStorage.IsContinuous),
 			QueueURL:     types.StringPointerValue(clickPipe.Source.ObjectStorage.QueueURL),
+			StartAfter:   types.StringPointerValue(clickPipe.Source.ObjectStorage.StartAfter),
 			IAMRole:      types.StringPointerValue(clickPipe.Source.ObjectStorage.IAMRole),
+		}
+		if clickPipe.Source.ObjectStorage.SkipInitialLoad != nil {
+			objectStorageModel.SkipInitialLoad = types.BoolPointerValue(clickPipe.Source.ObjectStorage.SkipInitialLoad)
+		} else {
+			objectStorageModel.SkipInitialLoad = stateObjectStorageModel.SkipInitialLoad
 		}
 
 		// Set storage-type-specific fields

--- a/pkg/resource/clickpipe_test.go
+++ b/pkg/resource/clickpipe_test.go
@@ -2,11 +2,14 @@ package resource
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gojuno/minimock/v3"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
@@ -624,10 +627,39 @@ func buildObjectStoragePlan(skipInitialLoad types.Bool, startAfter types.String)
 	}
 
 	return models.ClickPipeResourceModel{
-		ID:        types.StringValue("test-pipe-id"),
-		ServiceID: types.StringValue("service-123"),
-		Name:      types.StringValue("test-object-storage-pipe"),
-		Source:    sourceModel.ObjectValue(),
+		ID:            types.StringValue("test-pipe-id"),
+		ServiceID:     types.StringValue("service-123"),
+		Name:          types.StringValue("test-object-storage-pipe"),
+		Scaling:       types.ObjectNull(models.ClickPipeScalingModel{}.ObjectType().AttrTypes),
+		State:         types.StringValue("Running"),
+		Stopped:       types.BoolValue(false),
+		Source:        sourceModel.ObjectValue(),
+		Destination:   buildObjectStorageDestination().ObjectValue(),
+		FieldMappings: types.ListNull(models.ClickPipeFieldMappingModel{}.ObjectType()),
+		Settings:      types.DynamicNull(),
+		TriggerResync: types.BoolNull(),
+	}
+}
+
+func buildObjectStorageDestination() models.ClickPipeDestinationModel {
+	return models.ClickPipeDestinationModel{
+		Database:        types.StringValue("default"),
+		Table:           types.StringValue("data"),
+		ManagedTable:    types.BoolValue(true),
+		TableDefinition: types.ObjectNull(models.ClickPipeDestinationTableDefinitionModel{}.ObjectType().AttrTypes),
+		Columns: types.ListValueMust(
+			models.ClickPipeDestinationColumnModel{}.ObjectType(),
+			[]attr.Value{
+				types.ObjectValueMust(
+					models.ClickPipeDestinationColumnModel{}.ObjectType().AttrTypes,
+					map[string]attr.Value{
+						"name": types.StringValue("id"),
+						"type": types.StringValue("Int32"),
+					},
+				),
+			},
+		),
+		Roles: types.ListNull(types.StringType),
 	}
 }
 
@@ -672,6 +704,70 @@ func TestExtractSourceFromPlan_ObjectStorageInitialLoadOptions(t *testing.T) {
 		assert.NotNil(t, source.ObjectStorage)
 		assert.Nil(t, source.ObjectStorage.SkipInitialLoad)
 		assert.Nil(t, source.ObjectStorage.StartAfter)
+	})
+}
+
+func TestClickPipeResource_ModifyPlan_ObjectStorageInitialLoadValidation(t *testing.T) {
+	ctx := context.Background()
+	resourceUnderTest := &ClickPipeResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	resourceUnderTest.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+
+	run := func(t *testing.T, planModel models.ClickPipeResourceModel) diag.Diagnostics {
+		t.Helper()
+
+		planVal := tfsdk.Plan{Schema: sch}
+		if d := planVal.Set(ctx, &planModel); d.HasError() {
+			t.Fatalf("encoding plan failed: %v", d.Errors())
+		}
+
+		req := resource.ModifyPlanRequest{
+			Plan:   planVal,
+			Config: tfsdk.Config{Schema: sch, Raw: planVal.Raw},
+		}
+		resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Schema: sch, Raw: planVal.Raw}}
+		resourceUnderTest.ModifyPlan(ctx, req, resp)
+		return resp.Diagnostics
+	}
+
+	detailContains := func(diags diag.Diagnostics, substr string) bool {
+		for _, d := range diags.Errors() {
+			if strings.Contains(d.Detail(), substr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("skip_initial_load requires queue_url", func(t *testing.T) {
+		plan := buildObjectStoragePlan(types.BoolValue(true), types.StringNull())
+		var sourceModel models.ClickPipeSourceModel
+		diags := plan.Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{})
+		assert.False(t, diags.HasError(), "expected no source decode errors, got: %v", diags.Errors())
+
+		var objectStorageModel models.ClickPipeObjectStorageSourceModel
+		diags = sourceModel.ObjectStorage.As(ctx, &objectStorageModel, basetypes.ObjectAsOptions{})
+		assert.False(t, diags.HasError(), "expected no object storage decode errors, got: %v", diags.Errors())
+		objectStorageModel.QueueURL = types.StringNull()
+		sourceModel.ObjectStorage = objectStorageModel.ObjectValue()
+		plan.Source = sourceModel.ObjectValue()
+
+		diags = run(t, plan)
+
+		assert.True(t, detailContains(diags, "queue_url is required when skip_initial_load is true"), "expected queue_url validation diagnostic, got: %v", diags.Errors())
+	})
+
+	t.Run("skip_initial_load cannot be combined with start_after", func(t *testing.T) {
+		plan := buildObjectStoragePlan(types.BoolValue(true), types.StringValue("events/2026-06-01/"))
+
+		diags := run(t, plan)
+
+		assert.True(t, detailContains(diags, "start_after cannot be provided when skip_initial_load is true"), "expected start_after validation diagnostic, got: %v", diags.Errors())
 	})
 }
 

--- a/pkg/resource/clickpipe_test.go
+++ b/pkg/resource/clickpipe_test.go
@@ -592,6 +592,89 @@ func TestExtractSourceFromPlan_KafkaMutualTLS(t *testing.T) {
 	})
 }
 
+func buildObjectStoragePlan(skipInitialLoad types.Bool, startAfter types.String) models.ClickPipeResourceModel {
+	objectStorageAttrs := map[string]attr.Value{
+		"type":                 types.StringValue(api.ClickPipeObjectStorageS3Type),
+		"format":               types.StringValue("JSONEachRow"),
+		"url":                  types.StringValue("https://test-bucket.s3.us-east-1.amazonaws.com/data/*.json"),
+		"delimiter":            types.StringNull(),
+		"compression":          types.StringNull(),
+		"is_continuous":        types.BoolValue(true),
+		"queue_url":            types.StringValue("https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"),
+		"skip_initial_load":    skipInitialLoad,
+		"start_after":          startAfter,
+		"authentication":       types.StringValue(api.ClickPipeAuthenticationIAMUser),
+		"access_key":           types.ObjectNull(models.ClickPipeSourceAccessKeyModel{}.ObjectType().AttrTypes),
+		"iam_role":             types.StringNull(),
+		"service_account_key":  types.StringNull(),
+		"connection_string":    types.StringNull(),
+		"path":                 types.StringNull(),
+		"azure_container_name": types.StringNull(),
+	}
+
+	sourceModel := models.ClickPipeSourceModel{
+		Kafka:         types.ObjectNull(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes),
+		ObjectStorage: types.ObjectValueMust(models.ClickPipeObjectStorageSourceModel{}.ObjectType().AttrTypes, objectStorageAttrs),
+		Kinesis:       types.ObjectNull(models.ClickPipeKinesisSourceModel{}.ObjectType().AttrTypes),
+		PubSub:        types.ObjectNull(models.ClickPipePubSubSourceModel{}.ObjectType().AttrTypes),
+		Postgres:      types.ObjectNull(models.ClickPipePostgresSourceModel{}.ObjectType().AttrTypes),
+		MySQL:         types.ObjectNull(models.ClickPipeMySQLSourceModel{}.ObjectType().AttrTypes),
+		BigQuery:      types.ObjectNull(models.ClickPipeBigQuerySourceModel{}.ObjectType().AttrTypes),
+		MongoDB:       types.ObjectNull(models.ClickPipeMongoDBSourceModel{}.ObjectType().AttrTypes),
+	}
+
+	return models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("service-123"),
+		Name:      types.StringValue("test-object-storage-pipe"),
+		Source:    sourceModel.ObjectValue(),
+	}
+}
+
+func TestExtractSourceFromPlan_ObjectStorageInitialLoadOptions(t *testing.T) {
+	ctx := context.Background()
+	resource := &ClickPipeResource{}
+
+	t.Run("sets skip_initial_load and omits start_after when true", func(t *testing.T) {
+		plan := buildObjectStoragePlan(types.BoolValue(true), types.StringValue("events/2026-06-01/"))
+		diagnostics := diag.Diagnostics{}
+		source := resource.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+		assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+		assert.NotNil(t, source)
+		assert.NotNil(t, source.ObjectStorage)
+		assert.NotNil(t, source.ObjectStorage.SkipInitialLoad)
+		assert.True(t, *source.ObjectStorage.SkipInitialLoad)
+		assert.Nil(t, source.ObjectStorage.StartAfter)
+	})
+
+	t.Run("sets start_after when skip_initial_load is false", func(t *testing.T) {
+		plan := buildObjectStoragePlan(types.BoolValue(false), types.StringValue("events/2026-06-01/"))
+		diagnostics := diag.Diagnostics{}
+		source := resource.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+		assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+		assert.NotNil(t, source)
+		assert.NotNil(t, source.ObjectStorage)
+		assert.NotNil(t, source.ObjectStorage.SkipInitialLoad)
+		assert.False(t, *source.ObjectStorage.SkipInitialLoad)
+		assert.NotNil(t, source.ObjectStorage.StartAfter)
+		assert.Equal(t, "events/2026-06-01/", *source.ObjectStorage.StartAfter)
+	})
+
+	t.Run("omits skip_initial_load when unset", func(t *testing.T) {
+		plan := buildObjectStoragePlan(types.BoolNull(), types.StringNull())
+		diagnostics := diag.Diagnostics{}
+		source := resource.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+		assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+		assert.NotNil(t, source)
+		assert.NotNil(t, source.ObjectStorage)
+		assert.Nil(t, source.ObjectStorage.SkipInitialLoad)
+		assert.Nil(t, source.ObjectStorage.StartAfter)
+	})
+}
+
 // buildPostgresCredentialsPlan returns plan/config models for Postgres; password_wo is stripped from plan, password_wo_version is preserved (it's not write-only).
 func buildPostgresCredentialsPlan(password, passwordWO types.String, passwordWOVersion types.Int64) (plan, config models.ClickPipeResourceModel) {
 	build := func(pw, pwWO types.String) models.ClickPipeResourceModel {

--- a/pkg/resource/models/clickpipe_resource.go
+++ b/pkg/resource/models/clickpipe_resource.go
@@ -451,16 +451,18 @@ func (m ClickPipePostgresSourceModel) ObjectValue() types.Object {
 }
 
 type ClickPipeObjectStorageSourceModel struct {
-	Type           types.String `tfsdk:"type"`
-	Format         types.String `tfsdk:"format"`
-	URL            types.String `tfsdk:"url"`
-	Delimiter      types.String `tfsdk:"delimiter"`
-	Compression    types.String `tfsdk:"compression"`
-	IsContinuous   types.Bool   `tfsdk:"is_continuous"`
-	QueueURL       types.String `tfsdk:"queue_url"`
-	Authentication types.String `tfsdk:"authentication"`
-	AccessKey      types.Object `tfsdk:"access_key"`
-	IAMRole        types.String `tfsdk:"iam_role"`
+	Type            types.String `tfsdk:"type"`
+	Format          types.String `tfsdk:"format"`
+	URL             types.String `tfsdk:"url"`
+	Delimiter       types.String `tfsdk:"delimiter"`
+	Compression     types.String `tfsdk:"compression"`
+	IsContinuous    types.Bool   `tfsdk:"is_continuous"`
+	QueueURL        types.String `tfsdk:"queue_url"`
+	SkipInitialLoad types.Bool   `tfsdk:"skip_initial_load"`
+	StartAfter      types.String `tfsdk:"start_after"`
+	Authentication  types.String `tfsdk:"authentication"`
+	AccessKey       types.Object `tfsdk:"access_key"`
+	IAMRole         types.String `tfsdk:"iam_role"`
 
 	// GCS specific fields
 	ServiceAccountKey types.String `tfsdk:"service_account_key"`
@@ -481,6 +483,8 @@ func (m ClickPipeObjectStorageSourceModel) ObjectType() types.ObjectType {
 			"compression":          types.StringType,
 			"is_continuous":        types.BoolType,
 			"queue_url":            types.StringType,
+			"skip_initial_load":    types.BoolType,
+			"start_after":          types.StringType,
 			"authentication":       types.StringType,
 			"access_key":           ClickPipeSourceAccessKeyModel{}.ObjectType(),
 			"iam_role":             types.StringType,
@@ -501,6 +505,8 @@ func (m ClickPipeObjectStorageSourceModel) ObjectValue() types.Object {
 		"compression":          m.Compression,
 		"is_continuous":        m.IsContinuous,
 		"queue_url":            m.QueueURL,
+		"skip_initial_load":    m.SkipInitialLoad,
+		"start_after":          m.StartAfter,
 		"authentication":       m.Authentication,
 		"access_key":           m.AccessKey,
 		"iam_role":             m.IAMRole,


### PR DESCRIPTION
## Summary

Adds Terraform support for ClickPipes object storage `skip_initial_load` and `start_after`, matching the OpenAPI fields. The resource now validates that `skip_initial_load` requires `queue_url` and cannot be combined with `start_after`, maps both fields into API requests, and preserves explicit false values during state sync. Generated ClickPipe docs and focused unit coverage were updated.

## Validation

Added tests.