### PR TITLE
fix(postgres): retry replica create until parent has a backup

### DIFF
--- a/pkg/internal/api/postgres.go
+++ b/pkg/internal/api/postgres.go
@@ -24,9 +24,11 @@ var (
 // Retry budgets. Overridable per-call via the *WithBudget / *WithInterval
 // helpers so unit tests can run in milliseconds.
 var (
-	postgresDeleteRetryInterval        = 10 * time.Second
-	postgresDeleteRetryAttempts uint64 = 90 // 90 × 10s = 15 minutes
-	postgresStatePollInterval          = 5 * time.Second
+	postgresDeleteRetryInterval            = 10 * time.Second
+	postgresDeleteRetryAttempts     uint64 = 90 // 90 × 10s = 15 minutes
+	postgresReplicaNotReadyInterval        = 20 * time.Second
+	postgresReplicaNotReadyAttempts uint64 = 90 // 90 × 20s = 30 minutes
+	postgresStatePollInterval              = 5 * time.Second
 	// Predicate must hold this long before WaitForPostgresMatch succeeds —
 	// rejects transient matches during multi-step transitions. 15s = 3 polls.
 	postgresStateSettleDuration = 15 * time.Second
@@ -387,24 +389,62 @@ func (c *ClientImpl) RestorePostgres(ctx context.Context, sourceId string, body 
 }
 
 // CreatePostgresReadReplica creates a read replica of the source primary.
+// A fresh primary rejects replicas with a 400 until its first base backup
+// completes (an unpredictable window observed from 0s to several minutes);
+// that specific error retries for ~30 min, everything else fails immediately.
 func (c *ClientImpl) CreatePostgresReadReplica(ctx context.Context, sourceId string, body PostgresReadReplicaRequest) (*Postgres, error) {
+	return c.createPostgresReadReplicaWithInterval(ctx, sourceId, body, postgresReplicaNotReadyInterval, postgresReplicaNotReadyAttempts)
+}
+
+// createPostgresReadReplicaWithInterval is the test seam for CreatePostgresReadReplica.
+func (c *ClientImpl) createPostgresReadReplicaWithInterval(ctx context.Context, sourceId string, body PostgresReadReplicaRequest, interval time.Duration, maxRetries uint64) (*Postgres, error) {
 	rb, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode PostgresReadReplicaRequest: %w", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, c.getPostgresPath(sourceId, "/readReplica"), bytes.NewReader(rb))
-	if err != nil {
+	var pg *Postgres
+	createOnce := func() error {
+		req, err := http.NewRequest(http.MethodPost, c.getPostgresPath(sourceId, "/readReplica"), bytes.NewReader(rb))
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		respBody, err := c.doRequest(ctx, req)
+		if err != nil {
+			if errIndicatesReplicaNotReady(err) {
+				return err
+			}
+			return backoff.Permanent(err)
+		}
+		resp := ResponseWithResult[Postgres]{}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return backoff.Permanent(fmt.Errorf("failed to unmarshal Postgres: %w", err))
+		}
+		pg = &resp.Result
+		return nil
+	}
+	if interval <= 0 {
+		interval = postgresReplicaNotReadyInterval
+	}
+	b := backoff.WithContext(backoff.NewConstantBackOff(interval), ctx)
+	if err := backoff.Retry(createOnce, backoff.WithMaxRetries(b, maxRetries)); err != nil {
 		return nil, err
 	}
-	respBody, err := c.doRequest(ctx, req)
-	if err != nil {
-		return nil, err
+	return pg, nil
+}
+
+// errIndicatesReplicaNotReady matches the 400 a primary returns while its
+// first base backup is pending: "Parent server is not ready for read
+// replicas. There are no backups, yet." Message-substring match because the
+// public API exposes no structured error code for this condition.
+func errIndicatesReplicaNotReady(err error) bool {
+	if err == nil {
+		return false
 	}
-	resp := ResponseWithResult[Postgres]{}
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal Postgres: %w", err)
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "status: 400") {
+		return false
 	}
-	return &resp.Result, nil
+	return strings.Contains(strings.ToLower(msg), "not ready for read replicas")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/internal/api/postgres_test.go
+++ b/pkg/internal/api/postgres_test.go
@@ -782,6 +782,64 @@ func TestCreatePostgresReadReplica_HappyPath(t *testing.T) {
 	}
 }
 
+func TestCreatePostgresReadReplica_RetriesWhileParentNotReady(t *testing.T) {
+	var calls atomic.Int32
+	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n <= 2 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"BAD_REQUEST: Parent server is not ready for read replicas. There are no backups, yet.","status":400}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-replica", IsPrimary: false}})
+	})
+	got, err := client.createPostgresReadReplicaWithInterval(context.Background(), "primary-id", PostgresReadReplicaRequest{Name: "replica"}, 1*time.Millisecond, 5)
+	if err != nil {
+		t.Fatalf("CreatePostgresReadReplica should retry while the parent is not ready; got %v", err)
+	}
+	if got.Id != "pg-replica" {
+		t.Errorf("replica id = %q; want pg-replica", got.Id)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("expected 3 calls (2x not-ready 400 + 1x 200); got %d", calls.Load())
+	}
+}
+
+func TestCreatePostgresReadReplica_FailsFastOnOtherBadRequest(t *testing.T) {
+	var calls atomic.Int32
+	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"BAD_REQUEST: invalid size","status":400}`))
+	})
+	_, err := client.createPostgresReadReplicaWithInterval(context.Background(), "primary-id", PostgresReadReplicaRequest{Name: "replica"}, 1*time.Millisecond, 5)
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected fail-fast (1 call); got %d calls", calls.Load())
+	}
+}
+
+func TestCreatePostgresReadReplica_FailsFastOnConflict(t *testing.T) {
+	var calls atomic.Int32
+	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"CONFLICT: Conflict","status":409}`))
+	})
+	_, err := client.createPostgresReadReplicaWithInterval(context.Background(), "primary-id", PostgresReadReplicaRequest{Name: "replica"}, 1*time.Millisecond, 5)
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected fail-fast (1 call); got %d calls", calls.Load())
+	}
+}
+
 // ----- CA certificates (raw response) ------------------------------------
 
 func TestGetPostgresCaCertificates_ReturnsRawPEM(t *testing.T) {


### PR DESCRIPTION
Creating a read replica right after its primary finishes provisioning intermittently fails with `400: Parent server is not ready for read replicas. There are no backups, yet.` — the parent can't take replicas until its first base backup completes. Measured live: the window is usually 0s but sometimes outlasts CI's apply retries, which is what made `e2e (postgres, aws)` flaky (and leaked the primaries that eventually bricked the test org — see #597).

This treats that specific 400 as retryable in `CreatePostgresReadReplica` (20s interval, ~30 min budget, context-aware), mirroring the existing `DeletePostgres` retry pattern. Any other error still fails immediately. Matching is by status + message substring since the API exposes no structured error code for this condition.

Test plan: unit tests cover retry-then-success, fail-fast on other 400s, and fail-fast on 409; `go test ./pkg/...` passes; `go build -tags alpha` clean.