### PR TITLE
feat(clickpipe): collapse provider-flavored CDC source types to base type

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -401,7 +401,7 @@ Optional:
 - `port` (Number) The port of the MySQL instance. Default is 3306.
 - `skip_cert_verification` (Boolean) Skip certificate verification for the MySQL connection.
 - `tls_host` (String) TLS/SSL host for secure connections. Used to verify the server certificate.
-- `type` (String) The type of MySQL-compatible source. (`mysql`, `rdsmysql`, `auroramysql`, `planetscalevitess`, `mariadb`, `rdsmariadb`). Default is `mysql`.
+- `type` (String) The type of MySQL-compatible source. (`mysql`, `mariadb`). Default is `mysql`. Provider-flavored values such as `rdsmysql` are deprecated; use the base `mysql` or `mariadb` type.
 
 <a id="nestedatt--source--mysql--credentials"></a>
 ### Nested Schema for `source.mysql.credentials`
@@ -509,7 +509,7 @@ Optional:
 - `iam_role` (String) IAM role ARN for IAM authentication. Required when authentication is set to `iam_role`.
 - `port` (Number) The port of the Postgres instance. Default is 5432.
 - `tls_host` (String) TLS/SSL host for secure connections. Used to verify the server certificate.
-- `type` (String) The type of the Postgres source. (`postgres`, `supabase`, `neon`, `alloydb`, `planetscale`, `rdspostgres`, `aurorapostgres`, `cloudsqlpostgres`, `azurepostgres`, `crunchybridge`, `tigerdata`). Default is `postgres`.
+- `type` (String) The type of the Postgres source. (`postgres`). Default is `postgres`. Provider-flavored values such as `rdspostgres` are deprecated; use the base `postgres` type.
 
 <a id="nestedatt--source--postgres--credentials"></a>
 ### Nested Schema for `source.postgres.credentials`

--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -126,6 +126,21 @@ var ClickPipePostgresSourceTypes = []string{
 	ClickPipePostgresTigerDataSourceType,
 }
 
+// ClickPipePostgresAcceptedSourceTypes lists the source types accepted as input. The
+// provider-flavored variants above are deprecated: users must collapse them to the base
+// `postgres` type. ClickPipePostgresSourceTypes is retained to normalize legacy state.
+var ClickPipePostgresAcceptedSourceTypes = []string{
+	ClickPipePostgresSourceType,
+}
+
+// CollapsePostgresSourceType maps any legacy provider-flavored Postgres type to its base type.
+func CollapsePostgresSourceType(sourceType string) string {
+	if slices.Contains(ClickPipePostgresSourceTypes, sourceType) {
+		return ClickPipePostgresSourceType
+	}
+	return sourceType
+}
+
 var ClickPipeObjectStorageAuthenticationMethods = []string{
 	ClickPipeAuthenticationIAMRole,
 	ClickPipeAuthenticationIAMUser,
@@ -306,6 +321,26 @@ var ClickPipeMySQLMariaDBSourceTypes = []string{
 
 func IsClickPipeMySQLMariaDBSourceType(sourceType string) bool {
 	return slices.Contains(ClickPipeMySQLMariaDBSourceTypes, sourceType)
+}
+
+// ClickPipeMySQLAcceptedSourceTypes lists the source types accepted as input. Provider
+// prefixes are collapsed to a base engine type, but the MariaDB engine stays distinct
+// from MySQL. ClickPipeMySQLSourceTypes is retained to normalize legacy state.
+var ClickPipeMySQLAcceptedSourceTypes = []string{
+	ClickPipeMySQLSourceTypeMySQL,
+	ClickPipeMySQLSourceTypeMariaDB,
+}
+
+// CollapseMySQLSourceType maps any legacy provider-flavored MySQL type to its base engine
+// type, preserving the MySQL/MariaDB distinction.
+func CollapseMySQLSourceType(sourceType string) string {
+	if IsClickPipeMySQLMariaDBSourceType(sourceType) {
+		return ClickPipeMySQLSourceTypeMariaDB
+	}
+	if slices.Contains(ClickPipeMySQLSourceTypes, sourceType) {
+		return ClickPipeMySQLSourceTypeMySQL
+	}
+	return sourceType
 }
 
 // MongoDB constants

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -3534,11 +3534,17 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 		}
 
 		mysqlSource := &api.ClickPipeMySQLSource{
-			Type:     mysqlModel.Type.ValueString(),
 			Host:     mysqlModel.Host.ValueString(),
 			Port:     int(mysqlModel.Port.ValueInt64()),
 			Settings: settings,
 			Mappings: tableMappings,
+		}
+
+		// type is immutable for an existing pipe, so only send it on create (matching
+		// Postgres). Omitting it on update avoids PATCHing a base type onto a pipe the
+		// backend stored under a legacy provider-flavored type.
+		if !isUpdate {
+			mysqlSource.Type = mysqlModel.Type.ValueString()
 		}
 
 		// Only attach a credentials block when the username is actually known.

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -835,18 +835,19 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								MarkdownDescription: fmt.Sprintf(
-									"The type of the Postgres source. (%s). Default is `%s`.",
-									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipePostgresSourceTypes),
+									"The type of the Postgres source. (%s). Default is `%s`. Provider-flavored values such as `rdspostgres` are deprecated; use the base `%s` type.",
+									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipePostgresAcceptedSourceTypes),
+									api.ClickPipePostgresSourceType,
 									api.ClickPipePostgresSourceType,
 								),
 								Computed: true,
 								Optional: true,
 								Default:  stringdefault.StaticString(api.ClickPipePostgresSourceType),
 								Validators: []validator.String{
-									stringvalidator.OneOf(api.ClickPipePostgresSourceTypes...),
+									stringvalidator.OneOf(api.ClickPipePostgresAcceptedSourceTypes...),
 								},
 								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.RequiresReplace(),
+									requiresReplaceIfBaseTypeChanges{collapse: api.CollapsePostgresSourceType},
 								},
 							},
 							"host": schema.StringAttribute{
@@ -1107,17 +1108,17 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								MarkdownDescription: fmt.Sprintf(
-									"The type of MySQL-compatible source. (%s). Default is `mysql`.",
-									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipeMySQLSourceTypes),
+									"The type of MySQL-compatible source. (%s). Default is `mysql`. Provider-flavored values such as `rdsmysql` are deprecated; use the base `mysql` or `mariadb` type.",
+									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipeMySQLAcceptedSourceTypes),
 								),
 								Optional: true,
 								Computed: true,
 								Default:  stringdefault.StaticString(api.ClickPipeMySQLSourceTypeMySQL),
 								Validators: []validator.String{
-									stringvalidator.OneOf(api.ClickPipeMySQLSourceTypes...),
+									stringvalidator.OneOf(api.ClickPipeMySQLAcceptedSourceTypes...),
 								},
 								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.RequiresReplace(),
+									requiresReplaceIfBaseTypeChanges{collapse: api.CollapseMySQLSourceType},
 								},
 							},
 							"host": schema.StringAttribute{
@@ -4339,9 +4340,9 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			TableMappings: types.SetNull(models.ClickPipePostgresTableMappingModel{}.ObjectType()),
 		}
 
-		// Set type from API response
+		// Set type from API response, collapsing legacy provider-flavored types to the base type.
 		if clickPipe.Source.Postgres.Type != "" {
-			postgresModel.Type = types.StringValue(clickPipe.Source.Postgres.Type)
+			postgresModel.Type = types.StringValue(api.CollapsePostgresSourceType(clickPipe.Source.Postgres.Type))
 		} else {
 			postgresModel.Type = types.StringValue(api.ClickPipePostgresSourceType)
 		}
@@ -4560,9 +4561,9 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			TableMappings: types.SetNull(models.ClickPipeMySQLTableMappingModel{}.ObjectType()),
 		}
 
-		// Set type from API response
+		// Set type from API response, collapsing legacy provider-flavored types to the base engine type.
 		if clickPipe.Source.MySQL.Type != "" {
-			mysqlModel.Type = types.StringValue(clickPipe.Source.MySQL.Type)
+			mysqlModel.Type = types.StringValue(api.CollapseMySQLSourceType(clickPipe.Source.MySQL.Type))
 		} else {
 			mysqlModel.Type = types.StringValue(api.ClickPipeMySQLSourceTypeMySQL)
 		}

--- a/pkg/resource/clickpipe_plan_modifiers.go
+++ b/pkg/resource/clickpipe_plan_modifiers.go
@@ -7,6 +7,33 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// requiresReplaceIfBaseTypeChanges requires replacement only when the base database type
+// changes. Legacy provider-flavored values (e.g. "rdspostgres") collapse to their base
+// ("postgres") via collapse, so upgrading a config from a flavored value to the base type
+// updates in place instead of destroying and recreating the pipe.
+type requiresReplaceIfBaseTypeChanges struct {
+	collapse func(string) string
+}
+
+func (r requiresReplaceIfBaseTypeChanges) Description(ctx context.Context) string {
+	return "Requires replacement only if the base database type changes."
+}
+
+func (r requiresReplaceIfBaseTypeChanges) MarkdownDescription(ctx context.Context) string {
+	return r.Description(ctx)
+}
+
+func (r requiresReplaceIfBaseTypeChanges) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Skip on create (no prior state) and destroy (no plan).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	if r.collapse(req.StateValue.ValueString()) != r.collapse(req.PlanValue.ValueString()) {
+		resp.RequiresReplace = true
+	}
+}
+
 // requiresReplaceIfSourceTypeChanges is a custom plan modifier that requires replacement
 // only when the source type changes (null → non-null or non-null → null), but allows
 // updates to fields within the same source type.

--- a/pkg/resource/clickpipe_plan_modifiers_test.go
+++ b/pkg/resource/clickpipe_plan_modifiers_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/pkg/internal/api"
 )
 
 func TestRequiresReplaceIfSourceTypeChanges(t *testing.T) {
@@ -227,5 +229,122 @@ func TestVolatileComputedString_Description(t *testing.T) {
 	}
 	if modifier.MarkdownDescription(context.Background()) == "" {
 		t.Error("MarkdownDescription should not be empty")
+	}
+}
+
+// TestRequiresReplaceIfBaseTypeChanges verifies that collapsing a legacy provider-flavored
+// source type to its base type (e.g. rdspostgres → postgres) updates in place, while a real
+// base-type change (mysql → mariadb) still forces replacement.
+func TestRequiresReplaceIfBaseTypeChanges(t *testing.T) {
+	t.Parallel()
+
+	nonNull := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{})
+
+	testCases := map[string]struct {
+		collapse                func(string) string
+		stateRaw                tftypes.Value
+		planRaw                 tftypes.Value
+		stateValue              types.String
+		planValue               types.String
+		expectedRequiresReplace bool
+	}{
+		"postgres flavor collapses to base - no replace": {
+			collapse:                api.CollapsePostgresSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 nonNull,
+			stateValue:              types.StringValue("rdspostgres"),
+			planValue:               types.StringValue("postgres"),
+			expectedRequiresReplace: false,
+		},
+		"postgres same base - no replace": {
+			collapse:                api.CollapsePostgresSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 nonNull,
+			stateValue:              types.StringValue("postgres"),
+			planValue:               types.StringValue("postgres"),
+			expectedRequiresReplace: false,
+		},
+		"mysql provider prefix collapses to base - no replace": {
+			collapse:                api.CollapseMySQLSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 nonNull,
+			stateValue:              types.StringValue("rdsmysql"),
+			planValue:               types.StringValue("mysql"),
+			expectedRequiresReplace: false,
+		},
+		"mariadb prefix collapses to mariadb - no replace": {
+			collapse:                api.CollapseMySQLSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 nonNull,
+			stateValue:              types.StringValue("rdsmariadb"),
+			planValue:               types.StringValue("mariadb"),
+			expectedRequiresReplace: false,
+		},
+		"mysql to mariadb changes engine - replace": {
+			collapse:                api.CollapseMySQLSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 nonNull,
+			stateValue:              types.StringValue("mysql"),
+			planValue:               types.StringValue("mariadb"),
+			expectedRequiresReplace: true,
+		},
+		"creating-resource - no replace": {
+			collapse:                api.CollapsePostgresSourceType,
+			stateRaw:                tftypes.NewValue(tftypes.Object{}, nil),
+			planRaw:                 nonNull,
+			stateValue:              types.StringNull(),
+			planValue:               types.StringValue("postgres"),
+			expectedRequiresReplace: false,
+		},
+		"destroying-resource - no replace": {
+			collapse:                api.CollapsePostgresSourceType,
+			stateRaw:                nonNull,
+			planRaw:                 tftypes.NewValue(tftypes.Object{}, nil),
+			stateValue:              types.StringValue("postgres"),
+			planValue:               types.StringNull(),
+			expectedRequiresReplace: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			modifier := requiresReplaceIfBaseTypeChanges{collapse: testCase.collapse}
+			req := planmodifier.StringRequest{
+				State:      tfsdk.State{Raw: testCase.stateRaw},
+				Plan:       tfsdk.Plan{Raw: testCase.planRaw},
+				StateValue: testCase.stateValue,
+				PlanValue:  testCase.planValue,
+			}
+			resp := &planmodifier.StringResponse{}
+
+			modifier.PlanModifyString(context.Background(), req, resp)
+
+			if resp.RequiresReplace != testCase.expectedRequiresReplace {
+				t.Errorf("expected RequiresReplace to be %v, got %v", testCase.expectedRequiresReplace, resp.RequiresReplace)
+			}
+		})
+	}
+}
+
+func TestCollapseSourceType(t *testing.T) {
+	t.Parallel()
+
+	if got := api.CollapsePostgresSourceType("aurorapostgres"); got != "postgres" {
+		t.Errorf("CollapsePostgresSourceType(aurorapostgres) = %q, want postgres", got)
+	}
+	if got := api.CollapsePostgresSourceType("postgres"); got != "postgres" {
+		t.Errorf("CollapsePostgresSourceType(postgres) = %q, want postgres", got)
+	}
+	if got := api.CollapseMySQLSourceType("auroramysql"); got != "mysql" {
+		t.Errorf("CollapseMySQLSourceType(auroramysql) = %q, want mysql", got)
+	}
+	if got := api.CollapseMySQLSourceType("rdsmariadb"); got != "mariadb" {
+		t.Errorf("CollapseMySQLSourceType(rdsmariadb) = %q, want mariadb", got)
+	}
+	// Unknown values pass through unchanged.
+	if got := api.CollapsePostgresSourceType("something-else"); got != "something-else" {
+		t.Errorf("CollapsePostgresSourceType(something-else) = %q, want something-else", got)
 	}
 }


### PR DESCRIPTION
## Context

The CDC ClickPipe UI hardcodes checks against the **base** source type (`if source.type === 'postgres'`, `=== 'mysql'`). When a pipe is created via the OpenAPI path with a provider-flavored type such as `rdspostgres`, `aurorapostgres`, `cloudsqlpostgres`, `rdsmysql`, etc., the UI can't match it — `detailsRows` comes back empty and connection settings / other panels fail to render.

This is the Terraform-provider side of the "fix-forward" approach: revert `source.<db>.type` to accept only the **base** connector type, so pipes created via TF stay renderable in the UI.

Related Slack discussion: https://clickhouse-inc.slack.com/archives/C08RWC9R5E1/p1783507863681749

## What changed

- **Validation (forcing function):** `source.postgres.type` now accepts only `postgres`; `source.mysql.type` only `mysql`/`mariadb`. Flavored values (`rdspostgres`, `rdsmysql`, …) are rejected at plan time.
- **Read normalization:** legacy flavored values returned by the API are collapsed to the base type on read (`CollapsePostgresSourceType` / `CollapseMySQLSourceType`), so existing state converges without a perpetual diff. The MySQL ↔ MariaDB engine distinction is preserved (`rdsmariadb` → `mariadb`, not `mysql`).
- **No destructive replace:** the `RequiresReplace()` plan modifier on `type` is replaced with `requiresReplaceIfBaseTypeChanges`, which only forces replacement when the **base** engine actually changes. Collapsing a flavored value to its base (`rdspostgres` → `postgres`) is an **in-place update** — no re-snapshot, no data disruption. A genuine `mysql` → `mariadb` change still requires replacement.
- Regenerated docs + unit tests for the plan modifier and collapse helpers.

## Customer migration

Existing configs with a flavored `type` will fail validation until updated. Recommended change:

```diff
 source {
   postgres {
-    type = "rdspostgres"
+    type = "postgres"
     ...
   }
 }
```

Because the collapse is treated as a non-replacing change, applying after the edit performs an in-place update — the pipe is **not** recreated. No `ignore_changes` needed.

## Open questions / follow-ups

- **Flavor visibility is dropped.** This PR removes the sub-type from `type` without a replacement field. If we want to retain provider/flavor info (per Marta's suggestion), a follow-up should add an optional `db_provider` (or similar) field once the API/OpenAPI supports it. Left out here because it depends on backend support.
- **Docs** were hand-aligned to the new schema descriptions; run `make docs` in CI to confirm they match tfplugindocs output.
- Draft pending the product decision in the thread (option 1 long-term vs. this fix-forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)