### PR TITLE
feat(clickpipes): Wake service upon clickpipe interaction

### DIFF
--- a/pkg/internal/api/clickpipe.go
+++ b/pkg/internal/api/clickpipe.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const (
@@ -363,12 +364,42 @@ func (c *ClientImpl) getClickPipePath(serviceId, clickPipeId, path string) strin
 	return c.getServicePath(serviceId, fmt.Sprintf("/clickpipes/%s%s", clickPipeId, path))
 }
 
+// serviceWakeMaxWaitSeconds caps how long doClickPipeRequest waits for an idle
+// service to reach the running state after sending the awake command.
+const serviceWakeMaxWaitSeconds = 10 * 60
+
+// doClickPipeRequest sends a ClickPipes API request through doRequest.
+// The ClickPipes API rejects requests with 424 FAILED_DEPENDENCY while the
+// target service is idle; in that case the service is woken up, we wait for it
+// to reach the running state and the original request is retried once.
+// https://github.com/ClickHouse/terraform-provider-clickhouse/issues/376
+func (c *ClientImpl) doClickPipeRequest(ctx context.Context, serviceId string, req *http.Request) ([]byte, error) {
+	body, err := c.doRequest(ctx, req)
+	if !IsServiceIdle(err) {
+		return body, err
+	}
+
+	tflog.Info(ctx, "ClickHouse service is idle; waking it up before retrying the ClickPipes request", map[string]any{
+		"serviceId": serviceId,
+	})
+
+	if wakeErr := c.wakeService(ctx, serviceId); wakeErr != nil {
+		return nil, fmt.Errorf("service %s is idle and waking it up failed: %w", serviceId, wakeErr)
+	}
+
+	if waitErr := c.waitForServiceRunning(ctx, serviceId, serviceWakeMaxWaitSeconds); waitErr != nil {
+		return nil, fmt.Errorf("service %s is idle and did not reach the running state after waking it up: %w", serviceId, waitErr)
+	}
+
+	return c.doRequest(ctx, req)
+}
+
 func (c *ClientImpl) GetClickPipe(ctx context.Context, serviceId string, clickPipeId string) (*ClickPipe, error) {
 	req, err := http.NewRequest(http.MethodGet, c.getClickPipePath(serviceId, clickPipeId, ""), nil)
 	if err != nil {
 		return nil, err
 	}
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +424,7 @@ func (c *ClientImpl) CreateClickPipe(ctx context.Context, serviceId string, clic
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +448,7 @@ func (c *ClientImpl) UpdateClickPipe(ctx context.Context, serviceId string, clic
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +500,7 @@ func (c *ClientImpl) ScalingClickPipe(ctx context.Context, serviceId string, cli
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +525,7 @@ func (c *ClientImpl) ChangeClickPipeState(ctx context.Context, serviceId string,
 	if err != nil {
 		return nil, err
 	}
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +543,7 @@ func (c *ClientImpl) DeleteClickPipe(ctx context.Context, serviceId string, clic
 	if err != nil {
 		return err
 	}
-	_, err = c.doRequest(ctx, req)
+	_, err = c.doClickPipeRequest(ctx, serviceId, req)
 	return err
 }
 
@@ -521,7 +552,7 @@ func (c *ClientImpl) GetClickPipeSettings(ctx context.Context, serviceId string,
 	if err != nil {
 		return nil, err
 	}
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +576,7 @@ func (c *ClientImpl) UpdateClickPipeSettings(ctx context.Context, serviceId stri
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +604,7 @@ func (c *ClientImpl) GetClickPipeCdcScaling(ctx context.Context, serviceId strin
 	if err != nil {
 		return nil, err
 	}
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +628,7 @@ func (c *ClientImpl) UpdateClickPipeCdcScaling(ctx context.Context, serviceId st
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/api/clickpipe_reverse_private_endpoint.go
+++ b/pkg/internal/api/clickpipe_reverse_private_endpoint.go
@@ -69,7 +69,7 @@ func (c *ClientImpl) ListReversePrivateEndpoints(ctx context.Context, serviceId 
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (c *ClientImpl) GetReversePrivateEndpoint(ctx context.Context, serviceId, r
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (c *ClientImpl) CreateReversePrivateEndpoint(ctx context.Context, serviceId
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (c *ClientImpl) UpdateReversePrivateEndpoint(ctx context.Context, serviceId
 		return nil, err
 	}
 
-	body, err := c.doRequest(ctx, req)
+	body, err := c.doClickPipeRequest(ctx, serviceId, req)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (c *ClientImpl) DeleteReversePrivateEndpoint(ctx context.Context, serviceId
 		return err
 	}
 
-	_, err = c.doRequest(ctx, req)
+	_, err = c.doClickPipeRequest(ctx, serviceId, req)
 	return err
 }
 

--- a/pkg/internal/api/clickpipe_test.go
+++ b/pkg/internal/api/clickpipe_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	testServiceID = "svc-1"
+	// getClickPipePath appends the (empty) pipe ID after the slash on create.
+	testClickPipesPath      = "/organizations/org-1/services/svc-1/clickpipes/"
+	testServiceInstancePath = "/organizations/org-1/services/svc-1"
+	testServiceStatePath    = "/organizations/org-1/services/svc-1/state"
+	idle424BodyFormat       = `{"requestId":"x","error":"FAILED_DEPENDENCY: ClickPipe creation is allowed only when the ClickHouse service is running. Current state: %s","status":424}`
+)
+
+// newClickPipeTestClient spins up an httptest.Server with the given handler
+// and returns a *ClientImpl pointed at it. Mirrors newPostgresTestClient.
+func newClickPipeTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(ClientConfig{
+		ApiURL:         server.URL,
+		OrganizationID: testOrgID,
+		TokenKey:       "key",
+		TokenSecret:    "secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client, server
+}
+
+// ----- doClickPipeRequest idle-service wake (issue #376) --------------------
+
+func TestCreateClickPipe_WakesIdleServiceAndRetries(t *testing.T) {
+	var createCalls, wakeCalls, stateGetCalls int
+
+	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == testClickPipesPath:
+			createCalls++
+			var gotPipe ClickPipe
+			if err := json.NewDecoder(r.Body).Decode(&gotPipe); err != nil {
+				t.Errorf("decoding create body (call %d): %v", createCalls, err)
+			}
+			if gotPipe.Name != "my-pipe" {
+				t.Errorf("create body (call %d) name = %q; want my-pipe (body must be replayed on retry)", createCalls, gotPipe.Name)
+			}
+			if wakeCalls == 0 {
+				w.WriteHeader(http.StatusFailedDependency)
+				fmt.Fprintf(w, idle424BodyFormat, "idle")
+				return
+			}
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[ClickPipe]{Result: ClickPipe{ID: "pipe-1", Name: "my-pipe", State: ClickPipeProvisioningState}})
+
+		case r.Method == http.MethodPatch && r.URL.Path == testServiceStatePath:
+			wakeCalls++
+			var stateUpdate ServiceStateUpdate
+			if err := json.NewDecoder(r.Body).Decode(&stateUpdate); err != nil {
+				t.Errorf("decoding state update body: %v", err)
+			}
+			if stateUpdate.Command != "awake" {
+				t.Errorf("state command = %q; want awake", stateUpdate.Command)
+			}
+			_, _ = w.Write([]byte(`{}`))
+
+		case r.Method == http.MethodGet && r.URL.Path == testServiceInstancePath:
+			stateGetCalls++
+			state := "idle"
+			if wakeCalls > 0 {
+				state = StateRunning
+			}
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[Service]{Result: Service{Id: testServiceID, State: state}})
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	pipe, err := client.CreateClickPipe(context.Background(), testServiceID, ClickPipe{Name: "my-pipe"})
+	if err != nil {
+		t.Fatalf("CreateClickPipe: %v", err)
+	}
+	if pipe.ID != "pipe-1" {
+		t.Errorf("pipe ID = %q; want pipe-1", pipe.ID)
+	}
+	if createCalls != 2 {
+		t.Errorf("create calls = %d; want 2 (initial 424 + retry after wake)", createCalls)
+	}
+	if wakeCalls != 1 {
+		t.Errorf("wake calls = %d; want 1", wakeCalls)
+	}
+	if stateGetCalls < 1 {
+		t.Errorf("service state polls = %d; want at least 1", stateGetCalls)
+	}
+}
+
+func TestCreateClickPipe_StoppedService424_DoesNotWake(t *testing.T) {
+	var createCalls int
+
+	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == testClickPipesPath:
+			createCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusFailedDependency)
+			fmt.Fprintf(w, idle424BodyFormat, "stopped")
+
+		default:
+			// A stopped service was stopped deliberately: the provider must
+			// neither wake it nor touch any other endpoint.
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	_, err := client.CreateClickPipe(context.Background(), testServiceID, ClickPipe{Name: "my-pipe"})
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "status: 424") {
+		t.Errorf("error = %v; want the original 424 passed through", err)
+	}
+	if createCalls != 1 {
+		t.Errorf("create calls = %d; want 1 (no retry)", createCalls)
+	}
+}
+
+func TestCreateClickPipe_WakeFails_ReturnsError(t *testing.T) {
+	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == testClickPipesPath:
+			w.WriteHeader(http.StatusFailedDependency)
+			fmt.Fprintf(w, idle424BodyFormat, "idle")
+
+		case r.Method == http.MethodPatch && r.URL.Path == testServiceStatePath:
+			http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	_, err := client.CreateClickPipe(context.Background(), testServiceID, ClickPipe{Name: "my-pipe"})
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "waking it up failed") {
+		t.Errorf("error = %v; want wake failure to be surfaced", err)
+	}
+}

--- a/pkg/internal/api/clickpipe_test.go
+++ b/pkg/internal/api/clickpipe_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -19,30 +18,12 @@ const (
 	idle424BodyFormat       = `{"requestId":"x","error":"FAILED_DEPENDENCY: ClickPipe creation is allowed only when the ClickHouse service is running. Current state: %s","status":424}`
 )
 
-// newClickPipeTestClient spins up an httptest.Server with the given handler
-// and returns a *ClientImpl pointed at it. Mirrors newPostgresTestClient.
-func newClickPipeTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
-	t.Helper()
-	server := httptest.NewServer(handler)
-	t.Cleanup(server.Close)
-	client, err := NewClient(ClientConfig{
-		ApiURL:         server.URL,
-		OrganizationID: testOrgID,
-		TokenKey:       "key",
-		TokenSecret:    "secret",
-	})
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	return client, server
-}
-
 // ----- doClickPipeRequest idle-service wake (issue #376) --------------------
 
 func TestCreateClickPipe_WakesIdleServiceAndRetries(t *testing.T) {
 	var createCalls, wakeCalls, stateGetCalls int
 
-	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
@@ -108,7 +89,7 @@ func TestCreateClickPipe_WakesIdleServiceAndRetries(t *testing.T) {
 func TestCreateClickPipe_StoppedService424_DoesNotWake(t *testing.T) {
 	var createCalls int
 
-	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == testClickPipesPath:
 			createCalls++
@@ -137,7 +118,7 @@ func TestCreateClickPipe_StoppedService424_DoesNotWake(t *testing.T) {
 }
 
 func TestCreateClickPipe_WakeFails_ReturnsError(t *testing.T) {
-	client, _ := newClickPipeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {

--- a/pkg/internal/api/common_test.go
+++ b/pkg/internal/api/common_test.go
@@ -3,11 +3,31 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+// newTestClient spins up an httptest.Server with the given handler and
+// returns a *ClientImpl pointed at it. Shared across the API test suites.
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := NewClient(ClientConfig{
+		ApiURL:         server.URL,
+		OrganizationID: testOrgID,
+		TokenKey:       "key",
+		TokenSecret:    "secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return client, server
+}
 
 func TestRedactSensitiveBody(t *testing.T) {
 	cases := []struct {

--- a/pkg/internal/api/constants.go
+++ b/pkg/internal/api/constants.go
@@ -12,6 +12,7 @@ const (
 	StateProvisioning = "provisioning"
 	StateStopped      = "stopped"
 	StateStopping     = "stopping"
+	StateRunning      = "running"
 
 	ResponseHeaderRateLimitReset = "X-RateLimit-Reset"
 

--- a/pkg/internal/api/errors.go
+++ b/pkg/internal/api/errors.go
@@ -40,6 +40,19 @@ func IsBadRequestWith(err error, needle string) bool {
 	return strings.HasPrefix(msg, "status: 400") && strings.Contains(msg, needle)
 }
 
+// IsServiceIdle returns true when err is the 424 FAILED_DEPENDENCY the
+// ClickPipes API returns because the target ClickHouse service is idle.
+// A 424 for a stopped service does NOT match: stopping is an explicit user
+// action the provider must not override by waking the service.
+func IsServiceIdle(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.HasPrefix(msg, "status: 424") && strings.Contains(msg, "Current state: idle")
+}
+
 func is5xx(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/internal/api/errors_test.go
+++ b/pkg/internal/api/errors_test.go
@@ -25,6 +25,39 @@ func TestIsForbidden(t *testing.T) {
 	}
 }
 
+func TestIsServiceIdle(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			name: "424 for idle service",
+			err:  errors.New(`status: 424, body: {"requestId":"x","error":"FAILED_DEPENDENCY: ClickPipe creation is allowed only when the ClickHouse service is running. Current state: idle","status":424}`),
+			want: true,
+		},
+		{
+			name: "424 for stopped service must not trigger a wake",
+			err:  errors.New(`status: 424, body: {"requestId":"x","error":"FAILED_DEPENDENCY: ClickPipe creation is allowed only when the ClickHouse service is running. Current state: stopped","status":424}`),
+			want: false,
+		},
+		{
+			name: "non-424 mentioning idle",
+			err:  errors.New("status: 400, body: Current state: idle"),
+			want: false,
+		},
+		{name: "non-status error", err: errors.New("connection refused"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsServiceIdle(tc.err); got != tc.want {
+				t.Errorf("IsServiceIdle(%v) = %v; want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsBadRequestWith(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/pkg/internal/api/postgres_test.go
+++ b/pkg/internal/api/postgres_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -21,24 +20,6 @@ const (
 	testPostgresListPath     = "/organizations/org-1/postgres"
 	testPostgresSizeXLarge   = "r6gd.xlarge"
 )
-
-// newPostgresTestClient spins up an httptest.Server with the given handler
-// and returns a *ClientImpl pointed at it. Mirrors newScheduledScalingTestClient.
-func newPostgresTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
-	t.Helper()
-	server := httptest.NewServer(handler)
-	t.Cleanup(server.Close)
-	client, err := NewClient(ClientConfig{
-		ApiURL:         server.URL,
-		OrganizationID: testOrgID,
-		TokenKey:       "key",
-		TokenSecret:    "secret",
-	})
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	return client, server
-}
 
 func assertBasicAuth(t *testing.T, r *http.Request) {
 	t.Helper()
@@ -68,7 +49,7 @@ func TestGetPostgres_HappyPath(t *testing.T) {
 		Hostname:  "my-pg.example.com",
 	}
 
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q; want GET", r.Method)
 		}
@@ -90,7 +71,7 @@ func TestGetPostgres_HappyPath(t *testing.T) {
 }
 
 func TestGetPostgres_NotFound(t *testing.T) {
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	})
 	_, err := client.GetPostgres(context.Background(), testPostgresID)
@@ -111,7 +92,7 @@ func TestListPostgres_HappyPath(t *testing.T) {
 		{Id: "pg-2", Name: "two", Provider: "aws", Region: "us-west-2", State: "creating", CreatedAt: "t2", IsPrimary: false},
 	}
 
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q; want GET", r.Method)
 		}
@@ -148,7 +129,7 @@ func TestCreatePostgres_HappyPath_PersistsServerGeneratedPassword(t *testing.T) 
 	}
 
 	var capturedBody PostgresCreate
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q; want POST", r.Method)
 		}
@@ -191,7 +172,7 @@ func TestCreatePostgres_NoPasswordInResponse_ReturnsEmptyPasswordOut(t *testing.
 		Id: "pg-new", Name: "my-pg", Provider: "aws", Region: "us-east-1",
 		Size: "r6gd.large", State: PostgresStateCreating,
 	}
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: pgServerSide})
 	})
 	_, password, err := client.CreatePostgres(context.Background(), PostgresCreate{
@@ -210,7 +191,7 @@ func TestCreatePostgres_NoPasswordInResponse_ReturnsEmptyPasswordOut(t *testing.
 func TestUpdatePostgres_PatchesOnlyChangedFields(t *testing.T) {
 	expectedPath := testPostgresInstancePath
 	var capturedBody map[string]any
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("method = %q; want PATCH", r.Method)
 		}
@@ -242,7 +223,7 @@ func TestUpdatePostgres_PatchesOnlyChangedFields(t *testing.T) {
 
 func TestDeletePostgres_HappyPath(t *testing.T) {
 	expectedPath := testPostgresInstancePath
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("method = %q; want DELETE", r.Method)
 		}
@@ -260,7 +241,7 @@ func TestDeletePostgres_HappyPath(t *testing.T) {
 }
 
 func TestDeletePostgres_NotFoundReturnsNil(t *testing.T) {
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	})
 	err := client.DeletePostgres(context.Background(), testPostgresID)
@@ -271,7 +252,7 @@ func TestDeletePostgres_NotFoundReturnsNil(t *testing.T) {
 
 func TestDeletePostgres_RetriesOn409(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		if n <= 2 {
 			http.Error(w, `{"error":"transient conflict"}`, http.StatusConflict)
@@ -297,7 +278,7 @@ func TestDeletePostgres_RetriesOn409WithoutDependentSignal(t *testing.T) {
 	// against the loose pattern match that an earlier draft of the heuristic
 	// allowed (OR rather than AND).
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		if n <= 2 {
 			w.Header().Set("Content-Type", "application/json")
@@ -319,7 +300,7 @@ func TestDeletePostgres_RetriesOn409WithoutDependentSignal(t *testing.T) {
 
 func TestDeletePostgres_FailsFastOnDependentReplica(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		// Server signals a dependent replica blocks deletion.
 		w.Header().Set("Content-Type", "application/json")
@@ -342,7 +323,7 @@ func TestDeletePostgres_FailsFastOnDependentReplica(t *testing.T) {
 
 func TestWaitForPostgresState_TransitionsToRunning(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		state := PostgresStateCreating
 		if n >= 3 {
@@ -362,7 +343,7 @@ func TestWaitForPostgresState_TransitionsToRunning(t *testing.T) {
 }
 
 func TestWaitForPostgresState_TimesOutWithLastSeenState(t *testing.T) {
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: PostgresStateCreating}})
 	})
 	err := client.waitForPostgresStateWithInterval(context.Background(), testPostgresID,
@@ -381,7 +362,7 @@ func TestWaitForPostgresState_PropagatesGetErrors(t *testing.T) {
 	// token revoked), the helper must surface the real error rather than
 	// rewriting it to the misleading "did not reach the expected state"
 	// timeout message. Same shape as the LeaveAndReturn equivalent test.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	})
 	err := client.waitForPostgresStateWithInterval(context.Background(), testPostgresID,
@@ -399,7 +380,7 @@ func TestWaitForPostgresState_PropagatesGetErrors(t *testing.T) {
 }
 
 func TestWaitForPostgresState_UnknownStateDoesNotCrash(t *testing.T) {
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: "something_brand_new"}})
 	})
 	err := client.waitForPostgresStateWithInterval(context.Background(), testPostgresID,
@@ -428,7 +409,7 @@ func TestWaitForPostgresMatch_SucceedsOnConsecutivePredicateMatches(t *testing.T
 	// case (server applied the change before our first poll). Helper must
 	// succeed after settleRetries consecutive matching polls.
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: PostgresStateRunning, Size: testPostgresSizeXLarge}})
 	})
@@ -448,7 +429,7 @@ func TestWaitForPostgresMatch_QueuedWorkWaitsForFieldFlip(t *testing.T) {
 	// because Ubicloud has queued the work. The helper must NOT succeed
 	// until the field reflects the requested value.
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		size := "r6gd.large" // pre-PATCH steady state
 		if n >= 4 {
@@ -472,7 +453,7 @@ func TestWaitForPostgresMatch_TransientMatchResetsSettleWindow(t *testing.T) {
 	// to non-matching, then matches stably. Settle must reset across the
 	// inversion so success is anchored to STABLE matching, not transient.
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		size := testPostgresSizeXLarge
 		if n == 2 {
@@ -494,7 +475,7 @@ func TestWaitForPostgresMatch_TransientMatchResetsSettleWindow(t *testing.T) {
 func TestWaitForPostgresMatch_PropagatesGetErrors(t *testing.T) {
 	// Polling repeatedly errors (instance deleted out-of-band, auth expired).
 	// Helper must surface the error rather than silently returning nil.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
 	})
 	err := client.waitForPostgresMatchWithInterval(context.Background(), testPostgresID,
@@ -511,7 +492,7 @@ func TestWaitForPostgresMatch_NeverMatchesTimesOut(t *testing.T) {
 	// Field never flips (Ubicloud silently dropped the work, or the server
 	// is in an unrecoverable state). Helper must time out rather than
 	// silently report success.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: PostgresStateRunning, Size: "r6gd.large"}})
 	})
 	err := client.waitForPostgresMatchWithInterval(context.Background(), testPostgresID,
@@ -530,7 +511,7 @@ func TestWaitForPostgresMatch_NeverMatchesTimesOut(t *testing.T) {
 func TestWaitForPostgresMatch_HonorsContextCancellation(t *testing.T) {
 	// Predicate never matches → without ctx-aware backoff, the helper would
 	// burn the full budget. With backoff.WithContext, cancellation bails fast.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: PostgresStateRunning, Size: "r6gd.large"}})
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -551,7 +532,7 @@ func TestWaitForPostgresMatch_HonorsContextCancellation(t *testing.T) {
 
 func TestWaitForPostgresState_HonorsContextCancellation(t *testing.T) {
 	// Same guarantee for the simpler state-only helper.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[Postgres]{Result: Postgres{Id: "pg-1", State: PostgresStateCreating}})
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -573,7 +554,7 @@ func TestWaitForPostgresState_HonorsContextCancellation(t *testing.T) {
 func TestSetPostgresPassword_UserSuppliedReturnsEmpty(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/pg-1/password"
 	var capturedBody PostgresPassword
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("method = %q; want PATCH", r.Method)
 		}
@@ -607,7 +588,7 @@ func TestSetPostgresPassword_UserSuppliedReturnsEmpty(t *testing.T) {
 }
 
 func TestSetPostgresPassword_ServerGeneratedReturnsValue(t *testing.T) {
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[PostgresPassword]{Result: PostgresPassword{Password: "ServerGen-Aa1!password"}})
 	})
 	got, err := client.SetPostgresPassword(context.Background(), testPostgresID, PostgresPassword{})
@@ -625,7 +606,7 @@ func TestSetPostgresPassword_ServerGeneratedReturnsValue(t *testing.T) {
 func TestSetPostgresPassword_IdempotencyForUserSuppliedValue(t *testing.T) {
 	// User-supplied password is idempotent: server re-sets the same value
 	// and returns an empty Password both times.
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[PostgresPassword]{Result: PostgresPassword{}})
 	})
 	supplied := "User-Supplied-Aa1!password"
@@ -646,7 +627,7 @@ func TestSetPostgresPassword_IdempotencyForUserSuppliedValue(t *testing.T) {
 
 func TestGetPostgresConfig_HappyPath(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/pg-1/config"
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q; want GET", r.Method)
 		}
@@ -670,7 +651,7 @@ func TestGetPostgresConfig_HappyPath(t *testing.T) {
 func TestReplacePostgresConfig_PostsBothMaps(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/pg-1/config"
 	var captured PostgresConfig
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q; want POST", r.Method)
 		}
@@ -705,7 +686,7 @@ func TestReplacePostgresConfig_AcceptsEmptyMaps(t *testing.T) {
 	// Per Phase 0 Curl 3, runtime validator wins: {} is accepted by the server.
 	// The client should send {} (not omitempty) so users can clear all parameters.
 	var captured map[string]any
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("read request body: %v", err)
@@ -742,7 +723,7 @@ func TestReplacePostgresConfig_AcceptsEmptyMaps(t *testing.T) {
 
 func TestRestorePostgres_HappyPath(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/source-id/restoredService"
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q; want POST", r.Method)
 		}
@@ -764,7 +745,7 @@ func TestRestorePostgres_HappyPath(t *testing.T) {
 
 func TestCreatePostgresReadReplica_HappyPath(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/primary-id/readReplica"
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q; want POST", r.Method)
 		}
@@ -784,7 +765,7 @@ func TestCreatePostgresReadReplica_HappyPath(t *testing.T) {
 
 func TestCreatePostgresReadReplica_RetriesWhileParentNotReady(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		if n <= 2 {
 			w.Header().Set("Content-Type", "application/json")
@@ -808,7 +789,7 @@ func TestCreatePostgresReadReplica_RetriesWhileParentNotReady(t *testing.T) {
 
 func TestCreatePostgresReadReplica_FailsFastOnOtherBadRequest(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -825,7 +806,7 @@ func TestCreatePostgresReadReplica_FailsFastOnOtherBadRequest(t *testing.T) {
 
 func TestCreatePostgresReadReplica_FailsFastOnConflict(t *testing.T) {
 	var calls atomic.Int32
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
@@ -845,7 +826,7 @@ func TestCreatePostgresReadReplica_FailsFastOnConflict(t *testing.T) {
 func TestGetPostgresCaCertificates_ReturnsRawPEM(t *testing.T) {
 	expectedPath := "/organizations/org-1/postgres/pg-1/caCertificates"
 	pem := "-----BEGIN CERTIFICATE-----\nMIID...\n-----END CERTIFICATE-----\n"
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q; want GET", r.Method)
 		}
@@ -869,7 +850,7 @@ func TestGetPostgresCaCertificates_ReturnsRawPEM(t *testing.T) {
 func TestPostgres_RateLimit429HonorsResetHeader(t *testing.T) {
 	var calls atomic.Int32
 	start := time.Now()
-	client, _ := newPostgresTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		n := calls.Add(1)
 		if n == 1 {
 			w.Header().Set(ResponseHeaderRateLimitReset, "0")

--- a/pkg/internal/api/scheduled_scaling_test.go
+++ b/pkg/internal/api/scheduled_scaling_test.go
@@ -5,28 +5,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
-
-func newScheduledScalingTestClient(t *testing.T, handler http.HandlerFunc) (*ClientImpl, *httptest.Server) {
-	t.Helper()
-	server := httptest.NewServer(handler)
-	t.Cleanup(server.Close)
-	client, err := NewClient(ClientConfig{
-		ApiURL:         server.URL,
-		OrganizationID: "org-1",
-		TokenKey:       "key",
-		TokenSecret:    "secret",
-	})
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	return client, server
-}
 
 func intPtr(v int) *int    { return &v }
 func boolPtr(v bool) *bool { return &v }
@@ -57,7 +40,7 @@ func TestGetScheduledScaling(t *testing.T) {
 		ActiveEntryID: "entry-1",
 	}
 
-	client, _ := newScheduledScalingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q; want GET", r.Method)
 		}
@@ -96,7 +79,7 @@ func TestUpdateScheduledScaling_PostsEntriesAndOmitsServerOnlyFields(t *testing.
 	}
 
 	var capturedBody map[string]any
-	client, _ := newScheduledScalingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q; want POST", r.Method)
 		}
@@ -131,7 +114,7 @@ func TestUpdateScheduledScaling_PostsEntriesAndOmitsServerOnlyFields(t *testing.
 
 func TestUpdateScheduledScaling_EmptyEntriesSerializesToEmptyArray(t *testing.T) {
 	var captured string
-	client, _ := newScheduledScalingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		captured = string(body)
 		_ = json.NewEncoder(w).Encode(ResponseWithResult[AutoScalingSchedule]{Result: AutoScalingSchedule{Entries: []AutoScalingScheduleEntry{}}})
@@ -148,7 +131,7 @@ func TestUpdateScheduledScaling_EmptyEntriesSerializesToEmptyArray(t *testing.T)
 
 func TestDeleteScheduledScaling(t *testing.T) {
 	expectedPath := "/organizations/org-1/services/svc-1/scalingSchedule"
-	client, _ := newScheduledScalingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("method = %q; want DELETE", r.Method)
 		}

--- a/pkg/internal/api/service.go
+++ b/pkg/internal/api/service.go
@@ -130,6 +130,76 @@ func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, 
 	return nil
 }
 
+// getServiceState returns just the service state. Unlike GetService it does
+// not fan out to the private endpoint config, backup configuration and query
+// endpoints sub-resources, so it is cheap enough to poll.
+func (c *ClientImpl) getServiceState(ctx context.Context, serviceId string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, c.getServicePath(serviceId, ""), nil)
+	if err != nil {
+		return "", err
+	}
+	body, err := c.doRequest(ctx, req)
+	if err != nil {
+		return "", err
+	}
+
+	serviceResponse := ResponseWithResult[Service]{}
+	if err := json.Unmarshal(body, &serviceResponse); err != nil {
+		return "", err
+	}
+
+	return serviceResponse.Result.State, nil
+}
+
+// wakeService asks the API to un-idle the service. The "awake" command is a
+// no-op on a service that is already running or waking up.
+func (c *ClientImpl) wakeService(ctx context.Context, serviceId string) error {
+	rb, err := json.Marshal(ServiceStateUpdate{
+		Command: "awake",
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, c.getServicePath(serviceId, "/state"), strings.NewReader(string(rb)))
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(ctx, req)
+	return err
+}
+
+// waitForServiceRunning polls the service state until it is running — the
+// only state in which the ClickPipes API accepts creations and updates
+// (partially_running is NOT sufficient). It is a lightweight alternative to
+// WaitForServiceState for internal use (e.g. after wakeService), polling only
+// the state instead of the full GetService fan-out.
+func (c *ClientImpl) waitForServiceRunning(ctx context.Context, serviceId string, maxWaitSeconds int) error {
+	checkState := func() error {
+		state, err := c.getServiceState(ctx, serviceId)
+		if is5xx(err) {
+			// 500s are automatically retried in `doRequest`.
+			// If we get it here, we consider it an unrecoverable error.
+			return backoff.Permanent(err)
+		} else if err != nil {
+			return err
+		}
+
+		if state == StateRunning {
+			return nil
+		}
+
+		return fmt.Errorf("service %s is in state %s", serviceId, state)
+	}
+
+	if maxWaitSeconds < 5 {
+		maxWaitSeconds = 5
+	}
+
+	return backoff.Retry(checkState, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), uint64(maxWaitSeconds/5)), ctx)) //nolint:gosec
+}
+
 func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error) {
 	rb, err := json.Marshal(s)
 	if err != nil {


### PR DESCRIPTION
This changes the behavior of ClickPipes requests so upon 424: service not awake, it will attempt to awaken the service and retry the request after the service has switched to running state.

This resolves #376