### PR TITLE
fix(scheduled_scaling): unable to apply with idle scaling

### DIFF
--- a/docs/resources/service_scheduled_scaling.md
+++ b/docs/resources/service_scheduled_scaling.md
@@ -135,7 +135,7 @@ resource "clickhouse_service_scheduled_scaling" "example" {
 
 ### Required
 
-- `entries` (Attributes Set) Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies. (see [below for nested schema](#nestedatt--entries))
+- `entries` (Attributes List) Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies. (see [below for nested schema](#nestedatt--entries))
 - `service_id` (String) ClickHouse Cloud service ID this schedule applies to.
 
 ### Read-Only

--- a/pkg/resource/models/service_scheduled_scaling_resource.go
+++ b/pkg/resource/models/service_scheduled_scaling_resource.go
@@ -92,6 +92,6 @@ func (m ScheduledScalingBaseConfigModel) ObjectValue() basetypes.ObjectValue {
 type ServiceScheduledScalingResourceModel struct {
 	ID         types.String `tfsdk:"id"`
 	ServiceID  types.String `tfsdk:"service_id"`
-	Entries    types.Set    `tfsdk:"entries"`
+	Entries    types.List   `tfsdk:"entries"`
 	BaseConfig types.Object `tfsdk:"base_config"`
 }

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -66,12 +67,20 @@ func (r *ServiceScheduledScalingResource) Schema(_ context.Context, _ resource.S
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"entries": schema.SetNestedAttribute{
+			"entries": schema.ListNestedAttribute{
+				// A list (not a set) is deliberate: entries carry Computed
+				// nested attributes (replicas/memory/idle_*) that the server may
+				// fill in or normalize. Terraform cannot correlate set elements
+				// that contain unknown values, nor tolerate any post-apply
+				// normalization of a set element, which surfaces as "Provider
+				// produced inconsistent result after apply ... does not correlate
+				// with any element in actual". A list correlates by index and
+				// permits Computed fields to resolve after apply.
 				Description: "Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies.",
 				Required:    true,
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(api.MaxAutoScalingScheduleEntries),
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(api.MaxAutoScalingScheduleEntries),
 				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -408,15 +417,15 @@ func validateScheduledScalingEntries(entries []models.ScheduledScalingEntryModel
 }
 
 // planEntriesToAPI converts the Terraform plan set of entries into API entries.
-func planEntriesToAPI(ctx context.Context, entriesSet types.Set) ([]api.AutoScalingScheduleEntry, diag.Diagnostics) {
+func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoScalingScheduleEntry, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	if entriesSet.IsNull() || entriesSet.IsUnknown() {
+	if entriesList.IsNull() || entriesList.IsUnknown() {
 		return []api.AutoScalingScheduleEntry{}, diags
 	}
 
 	var entryModels []models.ScheduledScalingEntryModel
-	diags.Append(entriesSet.ElementsAs(ctx, &entryModels, false)...)
+	diags.Append(entriesList.ElementsAs(ctx, &entryModels, false)...)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -474,13 +483,55 @@ func planEntriesToAPI(ctx context.Context, entriesSet types.Set) ([]api.AutoScal
 	return result, diags
 }
 
+// orderEntriesToPrior reorders apiEntries to follow the entry-name order of
+// prior (the current plan or state list) so the list attribute stays stable
+// regardless of the order the API returns entries in. Entries whose names are
+// not present in prior keep their server order and are appended at the end.
+func orderEntriesToPrior(apiEntries []api.AutoScalingScheduleEntry, prior types.List) []api.AutoScalingScheduleEntry {
+	if prior.IsNull() || prior.IsUnknown() || len(prior.Elements()) == 0 {
+		return apiEntries
+	}
+
+	var priorModels []models.ScheduledScalingEntryModel
+	if d := prior.ElementsAs(context.Background(), &priorModels, false); d.HasError() {
+		// Fall back to server order if the prior list can't be decoded.
+		return apiEntries
+	}
+
+	firstIndexByName := make(map[string]int, len(apiEntries))
+	for i, e := range apiEntries {
+		if _, seen := firstIndexByName[e.Name]; !seen {
+			firstIndexByName[e.Name] = i
+		}
+	}
+
+	used := make([]bool, len(apiEntries))
+	ordered := make([]api.AutoScalingScheduleEntry, 0, len(apiEntries))
+	for _, pm := range priorModels {
+		if idx, ok := firstIndexByName[pm.Name.ValueString()]; ok && !used[idx] {
+			ordered = append(ordered, apiEntries[idx])
+			used[idx] = true
+		}
+	}
+	for i, e := range apiEntries {
+		if !used[i] {
+			ordered = append(ordered, e)
+		}
+	}
+	return ordered
+}
+
 // applyScheduleToState maps an API AutoScalingSchedule response into the
 // Terraform state model.
 func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	entryValues := make([]attr.Value, len(schedule.Entries))
-	for i, e := range schedule.Entries {
+	// Preserve the plan/state ordering so the list attribute does not churn if
+	// the API returns entries in a different order than they were written.
+	ordered := orderEntriesToPrior(schedule.Entries, state.Entries)
+
+	entryValues := make([]attr.Value, len(ordered))
+	for i, e := range ordered {
 		entryModel, d := apiEntryToModel(e)
 		diags.Append(d...)
 		if diags.HasError() {
@@ -488,12 +539,12 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 		}
 		entryValues[i] = entryModel.ObjectValue()
 	}
-	entriesSet, d := types.SetValue(models.ScheduledScalingEntryModel{}.ObjectType(), entryValues)
+	entriesList, d := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), entryValues)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
-	state.Entries = entriesSet
+	state.Entries = entriesList
 
 	if schedule.BaseConfig != nil {
 		state.BaseConfig = apiBaseConfigToModel(*schedule.BaseConfig).ObjectValue()
@@ -526,7 +577,11 @@ func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEnt
 		MaxReplicaMemoryGb: int64PtrToValue(e.MaxReplicaMemoryGb),
 		MinReplicas:        int64PtrToValue(e.MinReplicas),
 		MaxReplicas:        int64PtrToValue(e.MaxReplicas),
-		IdleScaling:        boolPtrToValue(e.IdleScaling),
+		// idle_scaling has a meaningful default of false, and the server omits
+		// it for non-idle entries. Map a nil response to an explicit false so it
+		// round-trips against a user's idle_scaling = false instead of becoming
+		// null (which would never correlate with the plan).
+		IdleScaling:        boolPtrToValueDefaultFalse(e.IdleScaling),
 		IdleTimeoutMinutes: int64PtrToValue(e.IdleTimeoutMinutes),
 	}
 
@@ -554,6 +609,16 @@ func int64PtrToValue(v *int) types.Int64 {
 func boolPtrToValue(v *bool) types.Bool {
 	if v == nil {
 		return types.BoolNull()
+	}
+	return types.BoolValue(*v)
+}
+
+// boolPtrToValueDefaultFalse maps a nil pointer to an explicit false rather than
+// null. Used for entry idle_scaling, which has a meaningful default of false and
+// is omitted by the server for non-idle entries.
+func boolPtrToValueDefaultFalse(v *bool) types.Bool {
+	if v == nil {
+		return types.BoolValue(false)
 	}
 	return types.BoolValue(*v)
 }

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -135,25 +135,25 @@ func TestApplyScheduleToState_CapturesAllEntries(t *testing.T) {
 	}
 }
 
-// buildEntrySet constructs a types.Set of ScheduledScalingEntryModel for
+// buildEntryList constructs a types.List of ScheduledScalingEntryModel for
 // driving planEntriesToAPI in tests.
-func buildEntrySet(t *testing.T, entries ...models.ScheduledScalingEntryModel) types.Set {
+func buildEntryList(t *testing.T, entries ...models.ScheduledScalingEntryModel) types.List {
 	t.Helper()
 	values := make([]attr.Value, len(entries))
 	for i, e := range entries {
 		values[i] = e.ObjectValue()
 	}
-	set, diags := types.SetValue(models.ScheduledScalingEntryModel{}.ObjectType(), values)
+	list, diags := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), values)
 	if diags.HasError() {
-		t.Fatalf("SetValue: %v", diags)
+		t.Fatalf("ListValue: %v", diags)
 	}
-	return set
+	return list
 }
 
 func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 	ctx := context.Background()
 
-	got, diags := planEntriesToAPI(ctx, types.SetNull(models.ScheduledScalingEntryModel{}.ObjectType()))
+	got, diags := planEntriesToAPI(ctx, types.ListNull(models.ScheduledScalingEntryModel{}.ObjectType()))
 	if diags.HasError() {
 		t.Fatalf("null input diags: %v", diags)
 	}
@@ -161,7 +161,7 @@ func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 		t.Errorf("null input: len = %d; want 0", len(got))
 	}
 
-	got, diags = planEntriesToAPI(ctx, buildEntrySet(t))
+	got, diags = planEntriesToAPI(ctx, buildEntryList(t))
 	if diags.HasError() {
 		t.Fatalf("empty input diags: %v", diags)
 	}
@@ -191,7 +191,7 @@ func TestPlanEntriesToAPI_ConvertsAllFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Value(15),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntrySet(t, entry))
+	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -372,7 +372,7 @@ func TestPlanEntriesToAPI_OmitsNullOptionalFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Null(),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntrySet(t, entry))
+	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -452,7 +452,7 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 		IdleScaling:        types.BoolValue(true),
 		IdleTimeoutMinutes: types.Int64Value(15),
 	}
-	planList := buildEntrySet(t, planEntry)
+	planList := buildEntryList(t, planEntry)
 
 	apiEntries, d := planEntriesToAPI(ctx, planList)
 	if d.HasError() {
@@ -500,5 +500,96 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 	sort.Ints(got)
 	if !reflect.DeepEqual(got, []int{1, 2, 3}) {
 		t.Errorf("weekdays = %v; want [1 2 3]", got)
+	}
+}
+
+// TestRoundTrip_NonIdleEntryServerOmitsIdleFields reproduces the reported
+// "Provider produced inconsistent result after apply" bug: for a non-idle
+// entry the server omits idleScaling/idleTimeoutMinutes from its response.
+// idle_scaling must map back to an explicit false (not null) so it correlates
+// with a user's idle_scaling = false. idle_timeout_minutes stays null and is
+// expected to be left unset (or Computed) by the caller.
+func TestRoundTrip_NonIdleEntryServerOmitsIdleFields(t *testing.T) {
+	ctx := context.Background()
+
+	// Server echoes a memory-based, non-idle entry but omits the idle fields.
+	serverResponse := &api.AutoScalingSchedule{
+		Entries: []api.AutoScalingScheduleEntry{
+			{
+				Name:               "Business Hours",
+				Weekdays:           []int{0, 1, 2, 3, 4, 5, 6},
+				StartHourUtc:       5,
+				EndHourUtc:         19,
+				MinReplicaMemoryGb: intPtr(236),
+				MaxReplicaMemoryGb: intPtr(236),
+				MinReplicas:        intPtr(10),
+				MaxReplicas:        intPtr(10),
+				IdleScaling:        nil, // server omits for non-idle entries
+				IdleTimeoutMinutes: nil,
+			},
+		},
+	}
+
+	state := &models.ServiceScheduledScalingResourceModel{}
+	if d := applyScheduleToState(serverResponse, state); d.HasError() {
+		t.Fatalf("applyScheduleToState: %v", d)
+	}
+
+	var entries []models.ScheduledScalingEntryModel
+	if d := state.Entries.ElementsAs(ctx, &entries, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d; want 1", len(entries))
+	}
+	e := entries[0]
+	if e.IdleScaling.IsNull() {
+		t.Errorf("idle_scaling is null; want explicit false so it correlates with the plan")
+	}
+	if e.IdleScaling.ValueBool() {
+		t.Errorf("idle_scaling = true; want false")
+	}
+	if !e.IdleTimeoutMinutes.IsNull() {
+		t.Errorf("idle_timeout_minutes = %v; want null when server omits it", e.IdleTimeoutMinutes)
+	}
+}
+
+// TestOrderEntriesToPrior asserts the API response is reordered to follow the
+// plan/state order, so the list attribute stays stable when the server returns
+// entries in a different order.
+func TestOrderEntriesToPrior(t *testing.T) {
+	nameOnly := func(n string) models.ScheduledScalingEntryModel {
+		return models.ScheduledScalingEntryModel{
+			Name:               types.StringValue(n),
+			Weekdays:           types.SetNull(types.Int64Type),
+			StartHourUtc:       types.Int64Null(),
+			EndHourUtc:         types.Int64Null(),
+			MinReplicaMemoryGb: types.Int64Null(),
+			MaxReplicaMemoryGb: types.Int64Null(),
+			MinReplicas:        types.Int64Null(),
+			MaxReplicas:        types.Int64Null(),
+			IdleScaling:        types.BoolNull(),
+			IdleTimeoutMinutes: types.Int64Null(),
+		}
+	}
+	prior := buildEntryList(t, nameOnly("a"), nameOnly("b"), nameOnly("c"))
+
+	// Server returns them shuffled.
+	apiEntries := []api.AutoScalingScheduleEntry{
+		{Name: "c"}, {Name: "a"}, {Name: "b"},
+	}
+
+	got := orderEntriesToPrior(apiEntries, prior)
+	gotNames := []string{got[0].Name, got[1].Name, got[2].Name}
+	if !reflect.DeepEqual(gotNames, []string{"a", "b", "c"}) {
+		t.Errorf("order = %v; want [a b c]", gotNames)
+	}
+
+	// A server-only entry (not in prior) is appended after the matched ones.
+	apiEntries = []api.AutoScalingScheduleEntry{{Name: "b"}, {Name: "new"}, {Name: "a"}}
+	got = orderEntriesToPrior(apiEntries, prior)
+	gotNames = []string{got[0].Name, got[1].Name, got[2].Name}
+	if !reflect.DeepEqual(gotNames, []string{"a", "b", "new"}) {
+		t.Errorf("order with extra = %v; want [a b new]", gotNames)
 	}
 }


### PR DESCRIPTION
## Summary

`clickhouse_service_scheduled_scaling` fails to apply for any entry with `idle_scaling = false` (the common case), with:

```
Error: Provider produced inconsistent result after apply
When applying changes to clickhouse_service_scheduled_scaling.reader, provider ... produced
an unexpected new value: .entries: planned set element cty.ObjectVal(...) does not correlate
with any element in actual.
This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

## Root cause

`entries` is a `SetNestedAttribute` whose nested fields (`min_replicas`, `max_replicas`, `min_replica_memory_gb`, `max_replica_memory_gb`, `idle_scaling`, `idle_timeout_minutes`) are `Optional + Computed`. Terraform identifies set elements by a hash of their contents, which breaks in two ways:

1. **Unknowns can't be correlated.** Any nested field the user leaves unset is `(known after apply)` at plan time. A set element containing an unknown has an indeterminate hash, so Terraform cannot match it to a returned element → "does not correlate".
2. **No tolerance for server normalization.** For a non-idle entry the server omits the idle fields from its response. `apiEntryToModel` maps them back with `nil → null` (`boolPtrToValue`/`int64PtrToValue`), so the applied element diverges from the plan even when every field was specified → same error.

This is invisible in the current tests because the only round-trip test (`TestRoundTrip_NoServerNormalization`) uses `idle_scaling = true`, where the server preserves the idle fields.

## Fix

- **Model `entries` as a `ListNestedAttribute`.** Lists correlate by index and permit `Computed` fields to resolve to any value after apply (including null), which is the idiomatic Terraform-plugin-framework choice for nested objects with computed attributes.
- **Map a nil `idle_scaling` response to explicit `false`** (`boolPtrToValueDefaultFalse`) so it round-trips against a user's `idle_scaling = false` instead of becoming null.
- **Preserve plan/state ordering** (`orderEntriesToPrior`) so the list attribute doesn't churn if the API returns entries in a different order; entries are matched by name, with unmatched (server-only) entries appended.
- **Regression tests:** a non-idle entry whose idle fields the server omits (would fail before this change), and entry reordering.

## Compatibility

`entries` changes from a set to a list. The resource is flagged **alpha** (`utils.AlphaWarning`), so this behavioral change is within the documented "may change in future provider versions" contract. Ordering is now the config order.

## Testing

- `go build ./...`, `go vet ./pkg/...` — clean
- `golangci-lint run` — 0 issues
- `go test ./pkg/resource/... ./pkg/resource/models/...` — pass, including the new regression tests

## Notes for reviewers

- One remaining edge case left deliberately untouched for discussion: an entry with `idle_scaling = false` **and** an explicit `idle_timeout_minutes` (which `TestValidateScheduledScalingEntries` documents as a UI-persisted combination from #536). With the list change this no longer errors on unset idle fields, but if the server normalizes an explicitly-set `idle_timeout_minutes` away for a non-idle entry, that specific combination could still drift. Options include rejecting it in `ValidateConfig` or suppressing the diff — happy to follow whichever you prefer.
