### PR TITLE
fix(scheduled_scaling): make entries applyable with idle_scaling = false

### DIFF
--- a/docs/resources/service_scheduled_scaling.md
+++ b/docs/resources/service_scheduled_scaling.md
@@ -4,7 +4,7 @@ page_title: "clickhouse_service_scheduled_scaling Resource - clickhouse"
 subcategory: ""
 description: |-
   You can use the clickhouse_service_scheduled_scaling resource to manage time-based scaling rules for a ClickHouse Cloud service.
-  A schedule is a set of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
+  A schedule is a list of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
   ~> Note: This resource is in alpha. Scheduled scaling must be enabled for your organization (canUseScheduledAutoscaling). Reach out to ClickHouse support if the API returns 403 FORBIDDEN. The server currently requires min_replicas == max_replicas per entry, and a maximum of 10 entries per schedule.
   Hour ranges
   Hour ranges are asymmetric:
@@ -46,7 +46,7 @@ description: |-
 
 You can use the *clickhouse_service_scheduled_scaling* resource to manage time-based scaling rules for a ClickHouse Cloud service.
 
-A schedule is a set of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
+A schedule is a list of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
 
 ~> **Note:** This resource is in alpha. Scheduled scaling must be enabled for your organization (`canUseScheduledAutoscaling`). Reach out to ClickHouse support if the API returns `403 FORBIDDEN`. The server currently requires `min_replicas == max_replicas` per entry, and a maximum of 10 entries per schedule.
 
@@ -135,7 +135,7 @@ resource "clickhouse_service_scheduled_scaling" "example" {
 
 ### Required
 
-- `entries` (Attributes Set) Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies. (see [below for nested schema](#nestedatt--entries))
+- `entries` (Attributes List) Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies. Ordering is not significant to the server, but as a list the order is tracked in state. (see [below for nested schema](#nestedatt--entries))
 - `service_id` (String) ClickHouse Cloud service ID this schedule applies to.
 
 ### Read-Only

--- a/pkg/internal/api/scheduled_scaling.go
+++ b/pkg/internal/api/scheduled_scaling.go
@@ -13,7 +13,11 @@ import (
 const MaxAutoScalingScheduleEntries = 10
 
 // AutoScalingScheduleEntry mirrors the OpenAPI public AutoScalingScheduleEntryV1
-// shape: a single weekly recurring scaling window.
+// shape: a single weekly recurring scaling window. Responses always express the
+// replica count and memory as min/max bands (equal min == max for a vertical
+// entry, per UC-1252 / control-plane#35956); the response also carries an
+// autoscalingMode discriminator that this struct deliberately does not model —
+// the provider only writes vertical entries (min_replicas == max_replicas).
 type AutoScalingScheduleEntry struct {
 	// ID is server-generated; empty when sent in a POST request.
 	ID                 string `json:"id,omitempty"`

--- a/pkg/resource/descriptions/service_scheduled_scaling.md
+++ b/pkg/resource/descriptions/service_scheduled_scaling.md
@@ -1,6 +1,6 @@
 You can use the *clickhouse_service_scheduled_scaling* resource to manage time-based scaling rules for a ClickHouse Cloud service.
 
-A schedule is a set of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
+A schedule is a list of recurring weekly windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment. While a window is active the service uses the replica count, memory bounds, and idle-scaling settings declared on that entry; otherwise the service falls back to its base auto-scaling configuration.
 
 ~> **Note:** This resource is in alpha. Scheduled scaling must be enabled for your organization (`canUseScheduledAutoscaling`). Reach out to ClickHouse support if the API returns `403 FORBIDDEN`. The server currently requires `min_replicas == max_replicas` per entry, and a maximum of 10 entries per schedule.
 

--- a/pkg/resource/models/service_scheduled_scaling_resource.go
+++ b/pkg/resource/models/service_scheduled_scaling_resource.go
@@ -92,6 +92,6 @@ func (m ScheduledScalingBaseConfigModel) ObjectValue() basetypes.ObjectValue {
 type ServiceScheduledScalingResourceModel struct {
 	ID         types.String `tfsdk:"id"`
 	ServiceID  types.String `tfsdk:"service_id"`
-	Entries    types.Set    `tfsdk:"entries"`
+	Entries    types.List   `tfsdk:"entries"`
 	BaseConfig types.Object `tfsdk:"base_config"`
 }

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -284,7 +284,7 @@ func (r *ServiceScheduledScalingResource) Read(ctx context.Context, req resource
 	}
 
 	state.ID = state.ServiceID
-	resp.Diagnostics.Append(applyScheduleToState(schedule, &state)...)
+	resp.Diagnostics.Append(applyScheduleToState(ctx, schedule, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -412,7 +412,10 @@ func (r *ServiceScheduledScalingResource) UpgradeState(_ context.Context) map[in
 				entries := types.ListNull(entryType)
 				if !prior.Entries.IsNull() && !prior.Entries.IsUnknown() {
 					// The set's elements are already values of the list's
-					// element type; re-wrap them directly.
+					// element type; re-wrap them directly. This relies on the
+					// v0 and v1 entry object types being identical — if a
+					// future schema version changes the entry type, this
+					// upgrader must decode and convert instead.
 					list, d := types.ListValue(entryType, prior.Entries.Elements())
 					resp.Diagnostics.Append(d...)
 					if resp.Diagnostics.HasError() {
@@ -569,17 +572,56 @@ func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoSc
 // applyScheduleToState maps an API AutoScalingSchedule response into the
 // Terraform state model, taking entry contents from the server response. Used
 // on Read, where no plan is available to reconcile against.
-func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
+//
+// Because entries is a list, element identity is positional: writing the
+// response order verbatim would surface a spurious, non-converging reorder
+// diff after any refresh where the server returns entries in a different
+// order than the config. Entries are therefore reordered to match the prior
+// state (correlated by their identity key); entries not in prior state are
+// appended in server order. On import, prior state is empty and server order
+// is kept.
+func applyScheduleToState(ctx context.Context, schedule *api.AutoScalingSchedule, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	entryValues := make([]attr.Value, len(schedule.Entries))
+	serverModels := make([]models.ScheduledScalingEntryModel, len(schedule.Entries))
 	for i, e := range schedule.Entries {
 		entryModel, d := apiEntryToModel(e)
 		diags.Append(d...)
 		if diags.HasError() {
 			return diags
 		}
-		entryValues[i] = entryModel.ObjectValue()
+		serverModels[i] = entryModel
+	}
+
+	var priorModels []models.ScheduledScalingEntryModel
+	if !state.Entries.IsNull() && !state.Entries.IsUnknown() {
+		diags.Append(state.Entries.ElementsAs(ctx, &priorModels, false)...)
+		if diags.HasError() {
+			return diags
+		}
+	}
+
+	ordered := make([]models.ScheduledScalingEntryModel, 0, len(serverModels))
+	used := make([]bool, len(serverModels))
+	for _, pm := range priorModels {
+		key := modelEntryKey(pm)
+		for j, sm := range serverModels {
+			if !used[j] && modelEntryKey(sm) == key {
+				ordered = append(ordered, sm)
+				used[j] = true
+				break
+			}
+		}
+	}
+	for j, sm := range serverModels {
+		if !used[j] {
+			ordered = append(ordered, sm)
+		}
+	}
+
+	entryValues := make([]attr.Value, len(ordered))
+	for i, em := range ordered {
+		entryValues[i] = em.ObjectValue()
 	}
 	entriesList, d := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), entryValues)
 	diags.Append(d...)
@@ -590,6 +632,27 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 
 	applyBaseConfigToState(schedule, state)
 	return diags
+}
+
+// apiEntryKey / modelEntryKey compute a schedule entry's identity from its
+// user-declared fields: name plus the window itself (sorted weekdays and
+// hours). Names alone are not guaranteed unique, but two entries cannot cover
+// the same window (the server rejects overlaps), so the combined key is.
+func apiEntryKey(e api.AutoScalingScheduleEntry) string {
+	wd := append([]int(nil), e.Weekdays...)
+	sort.Ints(wd)
+	return fmt.Sprintf("%s|%v|%d|%d", e.Name, wd, e.StartHourUtc, e.EndHourUtc)
+}
+
+func modelEntryKey(m models.ScheduledScalingEntryModel) string {
+	wd := make([]int, 0, len(m.Weekdays.Elements()))
+	for _, v := range m.Weekdays.Elements() {
+		if iv, ok := v.(types.Int64); ok && !iv.IsNull() && !iv.IsUnknown() {
+			wd = append(wd, int(iv.ValueInt64()))
+		}
+	}
+	sort.Ints(wd)
+	return fmt.Sprintf("%s|%v|%d|%d", m.Name.ValueString(), wd, m.StartHourUtc.ValueInt64(), m.EndHourUtc.ValueInt64())
 }
 
 // applyScheduleToStateWithPlan is the Create/Update counterpart of
@@ -607,10 +670,10 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 // Each planned value the user set (known in the plan) is kept; only fields the
 // user left unset (unknown) resolve from the server's echoed value. Entries
 // correlate to the server response by index — the POST replaces the full
-// schedule and the server preserves entry order — but the name is verified
-// before merging so a reordered response can never fill unset fields from the
-// wrong entry (they resolve to null instead, which is a valid outcome for an
-// unknown).
+// schedule and the server preserves entry order — but the entry's identity key
+// (name + window, see apiEntryKey) is verified before merging so a reordered
+// response can never fill unset fields from the wrong entry (they resolve to
+// null instead, which is a valid outcome for an unknown).
 func applyScheduleToStateWithPlan(schedule *api.AutoScalingSchedule, planModels []models.ScheduledScalingEntryModel, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -619,7 +682,7 @@ func applyScheduleToStateWithPlan(schedule *api.AutoScalingSchedule, planModels 
 		// The zero model is all-null: the fallback when the server returned no
 		// matching entry at this index.
 		var server models.ScheduledScalingEntryModel
-		if i < len(schedule.Entries) && schedule.Entries[i].Name == pm.Name.ValueString() {
+		if i < len(schedule.Entries) && apiEntryKey(schedule.Entries[i]) == modelEntryKey(pm) {
 			sm, d := apiEntryToModel(schedule.Entries[i])
 			diags.Append(d...)
 			if diags.HasError() {

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -599,10 +599,15 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 
 // applyScheduleToStateWithPlan is the Create/Update counterpart of
 // applyScheduleToState. It reconciles the server response against the plan so
-// that values the user set explicitly survive server-side normalization. The
-// server drops the idle fields for a non-idle entry (idle_scaling=false), so a
-// server-only mapping would turn a planned idle_scaling=false into null and
-// trip Terraform's "produced inconsistent result after apply" check.
+// that values the user set explicitly survive server-side normalization: any
+// field the server echoes differently from how it was sent (or not at all)
+// would otherwise land in state as null and trip Terraform's "produced
+// inconsistent result after apply" check. The known instance of this was
+// UC-1252 (issue #611): the server normalized a vertical entry's equal
+// minReplicas/maxReplicas band to numReplicas and omitted the band from the
+// response. That is fixed server-side (control-plane#35956), but reconciling
+// against the plan keeps Create/Update correct regardless of which fields any
+// server version echoes.
 func applyScheduleToStateWithPlan(ctx context.Context, schedule *api.AutoScalingSchedule, planEntries types.List, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
 	entriesList, diags := reconcileEntriesWithPlan(ctx, schedule, planEntries)
 	if diags.HasError() {
@@ -721,9 +726,9 @@ func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEnt
 		MaxReplicaMemoryGb: int64PtrToValue(e.MaxReplicaMemoryGb),
 		MinReplicas:        int64PtrToValue(e.MinReplicas),
 		MaxReplicas:        int64PtrToValue(e.MaxReplicas),
-		// The server omits the idle fields for a non-idle entry; treat a missing
-		// idle_scaling as its effective value, false, so a refresh of an entry
-		// written with idle_scaling=false does not show perpetual drift.
+		// The server echoes idle_scaling in practice, but treat a missing value
+		// as its effective default, false, so a refresh of a non-idle entry can
+		// never show perpetual drift if a server version omits it.
 		IdleScaling:        boolPtrToValueDefault(e.IdleScaling, false),
 		IdleTimeoutMinutes: int64PtrToValue(e.IdleTimeoutMinutes),
 	}

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -28,9 +29,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &ServiceScheduledScalingResource{}
-	_ resource.ResourceWithConfigure   = &ServiceScheduledScalingResource{}
-	_ resource.ResourceWithImportState = &ServiceScheduledScalingResource{}
+	_ resource.Resource                 = &ServiceScheduledScalingResource{}
+	_ resource.ResourceWithConfigure    = &ServiceScheduledScalingResource{}
+	_ resource.ResourceWithImportState  = &ServiceScheduledScalingResource{}
+	_ resource.ResourceWithUpgradeState = &ServiceScheduledScalingResource{}
 )
 
 //go:embed descriptions/service_scheduled_scaling.md
@@ -50,6 +52,8 @@ func (r *ServiceScheduledScalingResource) Metadata(_ context.Context, req resour
 
 func (r *ServiceScheduledScalingResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		// v1 changed `entries` from a set to a list; see UpgradeState.
+		Version:             1,
 		MarkdownDescription: serviceScheduledScalingResourceDescription,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -66,12 +70,12 @@ func (r *ServiceScheduledScalingResource) Schema(_ context.Context, _ resource.S
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"entries": schema.SetNestedAttribute{
-				Description: "Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies.",
+			"entries": schema.ListNestedAttribute{
+				Description: "Recurring scaling windows. The server rejects any pair of entries that overlap in time, so at most one window is active at any moment; otherwise base_config applies. Ordering is not significant to the server, but as a list the order is tracked in state.",
 				Required:    true,
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.SizeAtMost(api.MaxAutoScalingScheduleEntries),
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.SizeAtMost(api.MaxAutoScalingScheduleEntries),
 				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
@@ -251,7 +255,7 @@ func (r *ServiceScheduledScalingResource) Create(ctx context.Context, req resour
 	}
 
 	plan.ID = plan.ServiceID
-	resp.Diagnostics.Append(applyScheduleToState(schedule, &plan)...)
+	resp.Diagnostics.Append(applyScheduleToStateWithPlan(ctx, schedule, plan.Entries, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -315,7 +319,7 @@ func (r *ServiceScheduledScalingResource) Update(ctx context.Context, req resour
 	}
 
 	plan.ID = plan.ServiceID
-	resp.Diagnostics.Append(applyScheduleToState(schedule, &plan)...)
+	resp.Diagnostics.Append(applyScheduleToStateWithPlan(ctx, schedule, plan.Entries, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -340,6 +344,99 @@ func (r *ServiceScheduledScalingResource) ImportState(ctx context.Context, req r
 	// `id` and `service_id` are equal — write both so Read finds the service.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), req.ID)...)
+}
+
+// scheduledScalingModelV0 is the v0 state layout, where `entries` was a set.
+type scheduledScalingModelV0 struct {
+	ID         types.String `tfsdk:"id"`
+	ServiceID  types.String `tfsdk:"service_id"`
+	Entries    types.Set    `tfsdk:"entries"`
+	BaseConfig types.Object `tfsdk:"base_config"`
+}
+
+// scheduledScalingSchemaV0 mirrors the v0 schema's types so prior state can be
+// decoded. Only attribute types matter here (validators, descriptions, and plan
+// modifiers do not affect decoding), so this is intentionally minimal.
+func scheduledScalingSchemaV0() schema.Schema {
+	entryAttrs := map[string]schema.Attribute{
+		"name":                  schema.StringAttribute{Required: true},
+		"weekdays":              schema.SetAttribute{Required: true, ElementType: types.Int64Type},
+		"start_hour_utc":        schema.Int64Attribute{Required: true},
+		"end_hour_utc":          schema.Int64Attribute{Required: true},
+		"min_replica_memory_gb": schema.Int64Attribute{Optional: true, Computed: true},
+		"max_replica_memory_gb": schema.Int64Attribute{Optional: true, Computed: true},
+		"min_replicas":          schema.Int64Attribute{Optional: true, Computed: true},
+		"max_replicas":          schema.Int64Attribute{Optional: true, Computed: true},
+		"idle_scaling":          schema.BoolAttribute{Optional: true, Computed: true},
+		"idle_timeout_minutes":  schema.Int64Attribute{Optional: true, Computed: true},
+	}
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			"id":         schema.StringAttribute{Computed: true},
+			"service_id": schema.StringAttribute{Required: true},
+			"entries": schema.SetNestedAttribute{
+				Required:     true,
+				NestedObject: schema.NestedAttributeObject{Attributes: entryAttrs},
+			},
+			"base_config": schema.SingleNestedAttribute{
+				Computed: true,
+				Attributes: map[string]schema.Attribute{
+					"min_replica_memory_gb": schema.Int64Attribute{Computed: true},
+					"max_replica_memory_gb": schema.Int64Attribute{Computed: true},
+					"min_replicas":          schema.Int64Attribute{Computed: true},
+					"max_replicas":          schema.Int64Attribute{Computed: true},
+					"idle_scaling":          schema.BoolAttribute{Computed: true},
+					"idle_timeout_minutes":  schema.Int64Attribute{Computed: true},
+				},
+			},
+		},
+	}
+}
+
+// UpgradeState migrates v0 state (entries as a set) to v1 (entries as a list).
+// The entry object type is unchanged, so the collection is simply re-wrapped.
+func (r *ServiceScheduledScalingResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	priorSchema := scheduledScalingSchemaV0()
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &priorSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var prior scheduledScalingModelV0
+				resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				entryType := models.ScheduledScalingEntryModel{}.ObjectType()
+				entries := types.ListNull(entryType)
+				if !prior.Entries.IsNull() && !prior.Entries.IsUnknown() {
+					var entryModels []models.ScheduledScalingEntryModel
+					resp.Diagnostics.Append(prior.Entries.ElementsAs(ctx, &entryModels, false)...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					values := make([]attr.Value, len(entryModels))
+					for i, em := range entryModels {
+						values[i] = em.ObjectValue()
+					}
+					list, d := types.ListValue(entryType, values)
+					resp.Diagnostics.Append(d...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					entries = list
+				}
+
+				resp.Diagnostics.Append(resp.State.Set(ctx, &models.ServiceScheduledScalingResourceModel{
+					ID:         prior.ID,
+					ServiceID:  prior.ServiceID,
+					Entries:    entries,
+					BaseConfig: prior.BaseConfig,
+				})...)
+			},
+		},
+	}
 }
 
 func (r *ServiceScheduledScalingResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -407,16 +504,16 @@ func validateScheduledScalingEntries(entries []models.ScheduledScalingEntryModel
 	return diags
 }
 
-// planEntriesToAPI converts the Terraform plan set of entries into API entries.
-func planEntriesToAPI(ctx context.Context, entriesSet types.Set) ([]api.AutoScalingScheduleEntry, diag.Diagnostics) {
+// planEntriesToAPI converts the Terraform plan list of entries into API entries.
+func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoScalingScheduleEntry, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	if entriesSet.IsNull() || entriesSet.IsUnknown() {
+	if entriesList.IsNull() || entriesList.IsUnknown() {
 		return []api.AutoScalingScheduleEntry{}, diags
 	}
 
 	var entryModels []models.ScheduledScalingEntryModel
-	diags.Append(entriesSet.ElementsAs(ctx, &entryModels, false)...)
+	diags.Append(entriesList.ElementsAs(ctx, &entryModels, false)...)
 	if diags.HasError() {
 		return nil, diags
 	}
@@ -475,7 +572,8 @@ func planEntriesToAPI(ctx context.Context, entriesSet types.Set) ([]api.AutoScal
 }
 
 // applyScheduleToState maps an API AutoScalingSchedule response into the
-// Terraform state model.
+// Terraform state model, taking entry contents from the server response. Used
+// on Read, where no plan is available to reconcile against.
 func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 
@@ -488,20 +586,117 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 		}
 		entryValues[i] = entryModel.ObjectValue()
 	}
-	entriesSet, d := types.SetValue(models.ScheduledScalingEntryModel{}.ObjectType(), entryValues)
+	entriesList, d := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), entryValues)
 	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
-	state.Entries = entriesSet
+	state.Entries = entriesList
 
+	applyBaseConfigToState(schedule, state)
+	return diags
+}
+
+// applyScheduleToStateWithPlan is the Create/Update counterpart of
+// applyScheduleToState. It reconciles the server response against the plan so
+// that values the user set explicitly survive server-side normalization. The
+// server drops the idle fields for a non-idle entry (idle_scaling=false), so a
+// server-only mapping would turn a planned idle_scaling=false into null and
+// trip Terraform's "produced inconsistent result after apply" check.
+func applyScheduleToStateWithPlan(ctx context.Context, schedule *api.AutoScalingSchedule, planEntries types.List, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
+	entriesList, diags := reconcileEntriesWithPlan(ctx, schedule, planEntries)
+	if diags.HasError() {
+		return diags
+	}
+	state.Entries = entriesList
+
+	applyBaseConfigToState(schedule, state)
+	return diags
+}
+
+func applyBaseConfigToState(schedule *api.AutoScalingSchedule, state *models.ServiceScheduledScalingResourceModel) {
 	if schedule.BaseConfig != nil {
 		state.BaseConfig = apiBaseConfigToModel(*schedule.BaseConfig).ObjectValue()
 	} else {
 		state.BaseConfig = types.ObjectNull(models.ScheduledScalingBaseConfigModel{}.ObjectType().AttrTypes)
 	}
+}
 
-	return diags
+// reconcileEntriesWithPlan builds the entries list for state by keeping each
+// planned value the user set (known in the plan) and only falling back to the
+// server's echoed value where the plan left a field unset (unknown). Entries
+// correlate to the server response by index: the POST replaces the full
+// schedule and the server preserves entry order.
+func reconcileEntriesWithPlan(ctx context.Context, schedule *api.AutoScalingSchedule, planEntries types.List) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	entryType := models.ScheduledScalingEntryModel{}.ObjectType()
+
+	var planModels []models.ScheduledScalingEntryModel
+	diags.Append(planEntries.ElementsAs(ctx, &planModels, false)...)
+	if diags.HasError() {
+		return types.ListNull(entryType), diags
+	}
+
+	values := make([]attr.Value, len(planModels))
+	for i, pm := range planModels {
+		// When the server returns a matching entry, use its values to resolve
+		// fields the user left unset; otherwise resolve them to null.
+		server := models.ScheduledScalingEntryModel{
+			MinReplicaMemoryGb: types.Int64Null(),
+			MaxReplicaMemoryGb: types.Int64Null(),
+			MinReplicas:        types.Int64Null(),
+			MaxReplicas:        types.Int64Null(),
+			IdleScaling:        types.BoolNull(),
+			IdleTimeoutMinutes: types.Int64Null(),
+		}
+		if i < len(schedule.Entries) {
+			sm, d := apiEntryToModel(schedule.Entries[i])
+			diags.Append(d...)
+			if diags.HasError() {
+				return types.ListNull(entryType), diags
+			}
+			server = sm
+		}
+
+		merged := models.ScheduledScalingEntryModel{
+			// Required fields are always known in the plan.
+			Name:         pm.Name,
+			Weekdays:     pm.Weekdays,
+			StartHourUtc: pm.StartHourUtc,
+			EndHourUtc:   pm.EndHourUtc,
+			// Optional+Computed: keep the planned value when the user set one.
+			MinReplicaMemoryGb: pickInt64(pm.MinReplicaMemoryGb, server.MinReplicaMemoryGb),
+			MaxReplicaMemoryGb: pickInt64(pm.MaxReplicaMemoryGb, server.MaxReplicaMemoryGb),
+			MinReplicas:        pickInt64(pm.MinReplicas, server.MinReplicas),
+			MaxReplicas:        pickInt64(pm.MaxReplicas, server.MaxReplicas),
+			IdleScaling:        pickBool(pm.IdleScaling, server.IdleScaling),
+			IdleTimeoutMinutes: pickInt64(pm.IdleTimeoutMinutes, server.IdleTimeoutMinutes),
+		}
+		values[i] = merged.ObjectValue()
+	}
+
+	entriesList, d := types.ListValue(entryType, values)
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.ListNull(entryType), diags
+	}
+	return entriesList, diags
+}
+
+// pickInt64 returns the planned value unless the user left it unset (unknown),
+// in which case the server-resolved value is used.
+func pickInt64(plan, server types.Int64) types.Int64 {
+	if plan.IsUnknown() {
+		return server
+	}
+	return plan
+}
+
+func pickBool(plan, server types.Bool) types.Bool {
+	if plan.IsUnknown() {
+		return server
+	}
+	return plan
 }
 
 func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEntryModel, diag.Diagnostics) {
@@ -526,7 +721,10 @@ func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEnt
 		MaxReplicaMemoryGb: int64PtrToValue(e.MaxReplicaMemoryGb),
 		MinReplicas:        int64PtrToValue(e.MinReplicas),
 		MaxReplicas:        int64PtrToValue(e.MaxReplicas),
-		IdleScaling:        boolPtrToValue(e.IdleScaling),
+		// The server omits the idle fields for a non-idle entry; treat a missing
+		// idle_scaling as its effective value, false, so a refresh of an entry
+		// written with idle_scaling=false does not show perpetual drift.
+		IdleScaling:        boolPtrToValueDefault(e.IdleScaling, false),
 		IdleTimeoutMinutes: int64PtrToValue(e.IdleTimeoutMinutes),
 	}
 
@@ -554,6 +752,13 @@ func int64PtrToValue(v *int) types.Int64 {
 func boolPtrToValue(v *bool) types.Bool {
 	if v == nil {
 		return types.BoolNull()
+	}
+	return types.BoolValue(*v)
+}
+
+func boolPtrToValueDefault(v *bool, def bool) types.Bool {
+	if v == nil {
+		return types.BoolValue(def)
 	}
 	return types.BoolValue(*v)
 }

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -235,7 +235,7 @@ func (r *ServiceScheduledScalingResource) Create(ctx context.Context, req resour
 		return
 	}
 
-	entries, d := planEntriesToAPI(ctx, plan.Entries)
+	entries, planModels, d := planEntriesToAPI(ctx, plan.Entries)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -255,7 +255,7 @@ func (r *ServiceScheduledScalingResource) Create(ctx context.Context, req resour
 	}
 
 	plan.ID = plan.ServiceID
-	resp.Diagnostics.Append(applyScheduleToStateWithPlan(ctx, schedule, plan.Entries, &plan)...)
+	resp.Diagnostics.Append(applyScheduleToStateWithPlan(schedule, planModels, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -299,7 +299,7 @@ func (r *ServiceScheduledScalingResource) Update(ctx context.Context, req resour
 		return
 	}
 
-	entries, d := planEntriesToAPI(ctx, plan.Entries)
+	entries, planModels, d := planEntriesToAPI(ctx, plan.Entries)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -319,7 +319,7 @@ func (r *ServiceScheduledScalingResource) Update(ctx context.Context, req resour
 	}
 
 	plan.ID = plan.ServiceID
-	resp.Diagnostics.Append(applyScheduleToStateWithPlan(ctx, schedule, plan.Entries, &plan)...)
+	resp.Diagnostics.Append(applyScheduleToStateWithPlan(schedule, planModels, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -411,16 +411,9 @@ func (r *ServiceScheduledScalingResource) UpgradeState(_ context.Context) map[in
 				entryType := models.ScheduledScalingEntryModel{}.ObjectType()
 				entries := types.ListNull(entryType)
 				if !prior.Entries.IsNull() && !prior.Entries.IsUnknown() {
-					var entryModels []models.ScheduledScalingEntryModel
-					resp.Diagnostics.Append(prior.Entries.ElementsAs(ctx, &entryModels, false)...)
-					if resp.Diagnostics.HasError() {
-						return
-					}
-					values := make([]attr.Value, len(entryModels))
-					for i, em := range entryModels {
-						values[i] = em.ObjectValue()
-					}
-					list, d := types.ListValue(entryType, values)
+					// The set's elements are already values of the list's
+					// element type; re-wrap them directly.
+					list, d := types.ListValue(entryType, prior.Entries.Elements())
 					resp.Diagnostics.Append(d...)
 					if resp.Diagnostics.HasError() {
 						return
@@ -504,18 +497,20 @@ func validateScheduledScalingEntries(entries []models.ScheduledScalingEntryModel
 	return diags
 }
 
-// planEntriesToAPI converts the Terraform plan list of entries into API entries.
-func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoScalingScheduleEntry, diag.Diagnostics) {
+// planEntriesToAPI converts the Terraform plan list of entries into API
+// entries. It also returns the decoded plan models so Create/Update can
+// reconcile the server response against the plan without decoding twice.
+func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoScalingScheduleEntry, []models.ScheduledScalingEntryModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	if entriesList.IsNull() || entriesList.IsUnknown() {
-		return []api.AutoScalingScheduleEntry{}, diags
+		return []api.AutoScalingScheduleEntry{}, nil, diags
 	}
 
 	var entryModels []models.ScheduledScalingEntryModel
 	diags.Append(entriesList.ElementsAs(ctx, &entryModels, false)...)
 	if diags.HasError() {
-		return nil, diags
+		return nil, nil, diags
 	}
 
 	result := make([]api.AutoScalingScheduleEntry, len(entryModels))
@@ -523,7 +518,7 @@ func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoSc
 		var weekdays []int64
 		diags.Append(em.Weekdays.ElementsAs(ctx, &weekdays, false)...)
 		if diags.HasError() {
-			return nil, diags
+			return nil, nil, diags
 		}
 		intWeekdays := make([]int, len(weekdays))
 		for j, w := range weekdays {
@@ -568,7 +563,7 @@ func planEntriesToAPI(ctx context.Context, entriesList types.List) ([]api.AutoSc
 		result[i] = entry
 	}
 
-	return result, diags
+	return result, entryModels, diags
 }
 
 // applyScheduleToState maps an API AutoScalingSchedule response into the
@@ -608,8 +603,54 @@ func applyScheduleToState(schedule *api.AutoScalingSchedule, state *models.Servi
 // response. That is fixed server-side (control-plane#35956), but reconciling
 // against the plan keeps Create/Update correct regardless of which fields any
 // server version echoes.
-func applyScheduleToStateWithPlan(ctx context.Context, schedule *api.AutoScalingSchedule, planEntries types.List, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
-	entriesList, diags := reconcileEntriesWithPlan(ctx, schedule, planEntries)
+//
+// Each planned value the user set (known in the plan) is kept; only fields the
+// user left unset (unknown) resolve from the server's echoed value. Entries
+// correlate to the server response by index — the POST replaces the full
+// schedule and the server preserves entry order — but the name is verified
+// before merging so a reordered response can never fill unset fields from the
+// wrong entry (they resolve to null instead, which is a valid outcome for an
+// unknown).
+func applyScheduleToStateWithPlan(schedule *api.AutoScalingSchedule, planModels []models.ScheduledScalingEntryModel, state *models.ServiceScheduledScalingResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	values := make([]attr.Value, len(planModels))
+	for i, pm := range planModels {
+		// The zero model is all-null: the fallback when the server returned no
+		// matching entry at this index.
+		var server models.ScheduledScalingEntryModel
+		if i < len(schedule.Entries) && schedule.Entries[i].Name == pm.Name.ValueString() {
+			sm, d := apiEntryToModel(schedule.Entries[i])
+			diags.Append(d...)
+			if diags.HasError() {
+				return diags
+			}
+			server = sm
+		}
+
+		if pm.MinReplicaMemoryGb.IsUnknown() {
+			pm.MinReplicaMemoryGb = server.MinReplicaMemoryGb
+		}
+		if pm.MaxReplicaMemoryGb.IsUnknown() {
+			pm.MaxReplicaMemoryGb = server.MaxReplicaMemoryGb
+		}
+		if pm.MinReplicas.IsUnknown() {
+			pm.MinReplicas = server.MinReplicas
+		}
+		if pm.MaxReplicas.IsUnknown() {
+			pm.MaxReplicas = server.MaxReplicas
+		}
+		if pm.IdleScaling.IsUnknown() {
+			pm.IdleScaling = server.IdleScaling
+		}
+		if pm.IdleTimeoutMinutes.IsUnknown() {
+			pm.IdleTimeoutMinutes = server.IdleTimeoutMinutes
+		}
+		values[i] = pm.ObjectValue()
+	}
+
+	entriesList, d := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), values)
+	diags.Append(d...)
 	if diags.HasError() {
 		return diags
 	}
@@ -625,83 +666,6 @@ func applyBaseConfigToState(schedule *api.AutoScalingSchedule, state *models.Ser
 	} else {
 		state.BaseConfig = types.ObjectNull(models.ScheduledScalingBaseConfigModel{}.ObjectType().AttrTypes)
 	}
-}
-
-// reconcileEntriesWithPlan builds the entries list for state by keeping each
-// planned value the user set (known in the plan) and only falling back to the
-// server's echoed value where the plan left a field unset (unknown). Entries
-// correlate to the server response by index: the POST replaces the full
-// schedule and the server preserves entry order.
-func reconcileEntriesWithPlan(ctx context.Context, schedule *api.AutoScalingSchedule, planEntries types.List) (types.List, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	entryType := models.ScheduledScalingEntryModel{}.ObjectType()
-
-	var planModels []models.ScheduledScalingEntryModel
-	diags.Append(planEntries.ElementsAs(ctx, &planModels, false)...)
-	if diags.HasError() {
-		return types.ListNull(entryType), diags
-	}
-
-	values := make([]attr.Value, len(planModels))
-	for i, pm := range planModels {
-		// When the server returns a matching entry, use its values to resolve
-		// fields the user left unset; otherwise resolve them to null.
-		server := models.ScheduledScalingEntryModel{
-			MinReplicaMemoryGb: types.Int64Null(),
-			MaxReplicaMemoryGb: types.Int64Null(),
-			MinReplicas:        types.Int64Null(),
-			MaxReplicas:        types.Int64Null(),
-			IdleScaling:        types.BoolNull(),
-			IdleTimeoutMinutes: types.Int64Null(),
-		}
-		if i < len(schedule.Entries) {
-			sm, d := apiEntryToModel(schedule.Entries[i])
-			diags.Append(d...)
-			if diags.HasError() {
-				return types.ListNull(entryType), diags
-			}
-			server = sm
-		}
-
-		merged := models.ScheduledScalingEntryModel{
-			// Required fields are always known in the plan.
-			Name:         pm.Name,
-			Weekdays:     pm.Weekdays,
-			StartHourUtc: pm.StartHourUtc,
-			EndHourUtc:   pm.EndHourUtc,
-			// Optional+Computed: keep the planned value when the user set one.
-			MinReplicaMemoryGb: pickInt64(pm.MinReplicaMemoryGb, server.MinReplicaMemoryGb),
-			MaxReplicaMemoryGb: pickInt64(pm.MaxReplicaMemoryGb, server.MaxReplicaMemoryGb),
-			MinReplicas:        pickInt64(pm.MinReplicas, server.MinReplicas),
-			MaxReplicas:        pickInt64(pm.MaxReplicas, server.MaxReplicas),
-			IdleScaling:        pickBool(pm.IdleScaling, server.IdleScaling),
-			IdleTimeoutMinutes: pickInt64(pm.IdleTimeoutMinutes, server.IdleTimeoutMinutes),
-		}
-		values[i] = merged.ObjectValue()
-	}
-
-	entriesList, d := types.ListValue(entryType, values)
-	diags.Append(d...)
-	if diags.HasError() {
-		return types.ListNull(entryType), diags
-	}
-	return entriesList, diags
-}
-
-// pickInt64 returns the planned value unless the user left it unset (unknown),
-// in which case the server-resolved value is used.
-func pickInt64(plan, server types.Int64) types.Int64 {
-	if plan.IsUnknown() {
-		return server
-	}
-	return plan
-}
-
-func pickBool(plan, server types.Bool) types.Bool {
-	if plan.IsUnknown() {
-		return server
-	}
-	return plan
 }
 
 func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEntryModel, diag.Diagnostics) {
@@ -729,7 +693,7 @@ func apiEntryToModel(e api.AutoScalingScheduleEntry) (models.ScheduledScalingEnt
 		// The server echoes idle_scaling in practice, but treat a missing value
 		// as its effective default, false, so a refresh of a non-idle entry can
 		// never show perpetual drift if a server version omits it.
-		IdleScaling:        boolPtrToValueDefault(e.IdleScaling, false),
+		IdleScaling:        types.BoolValue(e.IdleScaling != nil && *e.IdleScaling),
 		IdleTimeoutMinutes: int64PtrToValue(e.IdleTimeoutMinutes),
 	}
 
@@ -757,13 +721,6 @@ func int64PtrToValue(v *int) types.Int64 {
 func boolPtrToValue(v *bool) types.Bool {
 	if v == nil {
 		return types.BoolNull()
-	}
-	return types.BoolValue(*v)
-}
-
-func boolPtrToValueDefault(v *bool, def bool) types.Bool {
-	if v == nil {
-		return types.BoolValue(def)
 	}
 	return types.BoolValue(*v)
 }

--- a/pkg/resource/service_scheduled_scaling.go
+++ b/pkg/resource/service_scheduled_scaling.go
@@ -394,8 +394,31 @@ func scheduledScalingSchemaV0() schema.Schema {
 	}
 }
 
+// entryObjectTypeV1 is the entry object type frozen as of schema v1. The v0->v1
+// upgrader targets this rather than models.ScheduledScalingEntryModel{}.ObjectType()
+// so a future v2 that changes the entry shape cannot silently break this
+// upgrader: the 0: upgrader must keep emitting the v1 type while re-wrapping
+// v0-typed elements, and a live-model type would then mismatch.
+func entryObjectTypeV1() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: map[string]attr.Type{
+			"name":                  types.StringType,
+			"weekdays":              types.SetType{ElemType: types.Int64Type},
+			"start_hour_utc":        types.Int64Type,
+			"end_hour_utc":          types.Int64Type,
+			"min_replica_memory_gb": types.Int64Type,
+			"max_replica_memory_gb": types.Int64Type,
+			"min_replicas":          types.Int64Type,
+			"max_replicas":          types.Int64Type,
+			"idle_scaling":          types.BoolType,
+			"idle_timeout_minutes":  types.Int64Type,
+		},
+	}
+}
+
 // UpgradeState migrates v0 state (entries as a set) to v1 (entries as a list).
-// The entry object type is unchanged, so the collection is simply re-wrapped.
+// The v0 and v1 entry object types are identical, so the collection is simply
+// re-wrapped into the frozen v1 type.
 func (r *ServiceScheduledScalingResource) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
 	priorSchema := scheduledScalingSchemaV0()
 	return map[int64]resource.StateUpgrader{
@@ -408,10 +431,10 @@ func (r *ServiceScheduledScalingResource) UpgradeState(_ context.Context) map[in
 					return
 				}
 
-				entryType := models.ScheduledScalingEntryModel{}.ObjectType()
+				entryType := entryObjectTypeV1()
 				entries := types.ListNull(entryType)
 				if !prior.Entries.IsNull() && !prior.Entries.IsUnknown() {
-					// The set's elements are already values of the list's
+					// The set's elements are already values of the frozen v1
 					// element type; re-wrap them directly. This relies on the
 					// v0 and v1 entry object types being identical — if a
 					// future schema version changes the entry type, this
@@ -637,11 +660,17 @@ func applyScheduleToState(ctx context.Context, schedule *api.AutoScalingSchedule
 // apiEntryKey / modelEntryKey compute a schedule entry's identity from its
 // user-declared fields: name plus the window itself (sorted weekdays and
 // hours). Names alone are not guaranteed unique, but two entries cannot cover
-// the same window (the server rejects overlaps), so the combined key is.
-func apiEntryKey(e api.AutoScalingScheduleEntry) string {
-	wd := append([]int(nil), e.Weekdays...)
+// the same window (the server rejects overlaps), so the combined key is. Both
+// delegate to entryKey so the two representations can never drift in format —
+// a divergence would silently break correlation with no compile error.
+func entryKey(name string, weekdays []int, startHourUtc, endHourUtc int) string {
+	wd := append([]int(nil), weekdays...)
 	sort.Ints(wd)
-	return fmt.Sprintf("%s|%v|%d|%d", e.Name, wd, e.StartHourUtc, e.EndHourUtc)
+	return fmt.Sprintf("%s|%v|%d|%d", name, wd, startHourUtc, endHourUtc)
+}
+
+func apiEntryKey(e api.AutoScalingScheduleEntry) string {
+	return entryKey(e.Name, e.Weekdays, e.StartHourUtc, e.EndHourUtc)
 }
 
 func modelEntryKey(m models.ScheduledScalingEntryModel) string {
@@ -651,8 +680,7 @@ func modelEntryKey(m models.ScheduledScalingEntryModel) string {
 			wd = append(wd, int(iv.ValueInt64()))
 		}
 	}
-	sort.Ints(wd)
-	return fmt.Sprintf("%s|%v|%d|%d", m.Name.ValueString(), wd, m.StartHourUtc.ValueInt64(), m.EndHourUtc.ValueInt64())
+	return entryKey(m.Name.ValueString(), wd, int(m.StartHourUtc.ValueInt64()), int(m.EndHourUtc.ValueInt64()))
 }
 
 // applyScheduleToStateWithPlan is the Create/Update counterpart of

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -153,7 +153,7 @@ func buildEntryList(t *testing.T, entries ...models.ScheduledScalingEntryModel) 
 func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 	ctx := context.Background()
 
-	got, diags := planEntriesToAPI(ctx, types.ListNull(models.ScheduledScalingEntryModel{}.ObjectType()))
+	got, _, diags := planEntriesToAPI(ctx, types.ListNull(models.ScheduledScalingEntryModel{}.ObjectType()))
 	if diags.HasError() {
 		t.Fatalf("null input diags: %v", diags)
 	}
@@ -161,7 +161,7 @@ func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 		t.Errorf("null input: len = %d; want 0", len(got))
 	}
 
-	got, diags = planEntriesToAPI(ctx, buildEntryList(t))
+	got, _, diags = planEntriesToAPI(ctx, buildEntryList(t))
 	if diags.HasError() {
 		t.Fatalf("empty input diags: %v", diags)
 	}
@@ -191,7 +191,7 @@ func TestPlanEntriesToAPI_ConvertsAllFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Value(15),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
+	got, _, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -217,18 +217,6 @@ func TestPlanEntriesToAPI_ConvertsAllFields(t *testing.T) {
 }
 
 func TestValidateScheduledScalingEntries(t *testing.T) {
-	mustSet := func(vals ...int64) types.Set {
-		elems := make([]attr.Value, len(vals))
-		for i, v := range vals {
-			elems[i] = types.Int64Value(v)
-		}
-		s, diags := types.SetValue(types.Int64Type, elems)
-		if diags.HasError() {
-			t.Fatalf("SetValue: %v", diags)
-		}
-		return s
-	}
-
 	tests := []struct {
 		name         string
 		entry        models.ScheduledScalingEntryModel
@@ -238,7 +226,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "valid entry",
 			entry: models.ScheduledScalingEntryModel{
 				Name:         types.StringValue("ok"),
-				Weekdays:     mustSet(1),
+				Weekdays:     weekdaySetOf(t, 1),
 				StartHourUtc: types.Int64Value(8),
 				EndHourUtc:   types.Int64Value(18),
 				MinReplicas:  types.Int64Value(2),
@@ -250,7 +238,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "start equals end",
 			entry: models.ScheduledScalingEntryModel{
 				Name:         types.StringValue("bad-window"),
-				Weekdays:     mustSet(1),
+				Weekdays:     weekdaySetOf(t, 1),
 				StartHourUtc: types.Int64Value(10),
 				EndHourUtc:   types.Int64Value(10),
 			},
@@ -262,7 +250,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "memory min > max",
 			entry: models.ScheduledScalingEntryModel{
 				Name:               types.StringValue("inverted-memory"),
-				Weekdays:           mustSet(1),
+				Weekdays:           weekdaySetOf(t, 1),
 				StartHourUtc:       types.Int64Value(0),
 				EndHourUtc:         types.Int64Value(24),
 				MinReplicaMemoryGb: types.Int64Value(64),
@@ -274,7 +262,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "min != max",
 			entry: models.ScheduledScalingEntryModel{
 				Name:         types.StringValue("uneven"),
-				Weekdays:     mustSet(1),
+				Weekdays:     weekdaySetOf(t, 1),
 				StartHourUtc: types.Int64Value(0),
 				EndHourUtc:   types.Int64Value(24),
 				MinReplicas:  types.Int64Value(2),
@@ -288,7 +276,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "idle: both set, idle_scaling=true",
 			entry: models.ScheduledScalingEntryModel{
 				Name:               types.StringValue("both-true"),
-				Weekdays:           mustSet(1),
+				Weekdays:           weekdaySetOf(t, 1),
 				StartHourUtc:       types.Int64Value(0),
 				EndHourUtc:         types.Int64Value(24),
 				IdleScaling:        types.BoolValue(true),
@@ -301,7 +289,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "idle: both set, idle_scaling=false",
 			entry: models.ScheduledScalingEntryModel{
 				Name:               types.StringValue("ui-persisted"),
-				Weekdays:           mustSet(1),
+				Weekdays:           weekdaySetOf(t, 1),
 				StartHourUtc:       types.Int64Value(0),
 				EndHourUtc:         types.Int64Value(24),
 				IdleScaling:        types.BoolValue(false),
@@ -313,7 +301,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "idle: only idle_timeout set",
 			entry: models.ScheduledScalingEntryModel{
 				Name:               types.StringValue("lone-timeout"),
-				Weekdays:           mustSet(1),
+				Weekdays:           weekdaySetOf(t, 1),
 				StartHourUtc:       types.Int64Value(0),
 				EndHourUtc:         types.Int64Value(24),
 				IdleTimeoutMinutes: types.Int64Value(10),
@@ -324,7 +312,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "idle: only idle_scaling set",
 			entry: models.ScheduledScalingEntryModel{
 				Name:         types.StringValue("lone-scaling"),
-				Weekdays:     mustSet(1),
+				Weekdays:     weekdaySetOf(t, 1),
 				StartHourUtc: types.Int64Value(0),
 				EndHourUtc:   types.Int64Value(24),
 				IdleScaling:  types.BoolValue(true),
@@ -335,7 +323,7 @@ func TestValidateScheduledScalingEntries(t *testing.T) {
 			name: "idle: both unset",
 			entry: models.ScheduledScalingEntryModel{
 				Name:         types.StringValue("no-idle"),
-				Weekdays:     mustSet(1),
+				Weekdays:     weekdaySetOf(t, 1),
 				StartHourUtc: types.Int64Value(0),
 				EndHourUtc:   types.Int64Value(24),
 			},
@@ -372,7 +360,7 @@ func TestPlanEntriesToAPI_OmitsNullOptionalFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Null(),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
+	got, _, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -454,7 +442,7 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 	}
 	planList := buildEntryList(t, planEntry)
 
-	apiEntries, d := planEntriesToAPI(ctx, planList)
+	apiEntries, _, d := planEntriesToAPI(ctx, planList)
 	if d.HasError() {
 		t.Fatalf("planEntriesToAPI: %v", d)
 	}
@@ -511,7 +499,7 @@ func reconcileSingleEntry(t *testing.T, planEntry models.ScheduledScalingEntryMo
 
 	state := &models.ServiceScheduledScalingResourceModel{}
 	schedule := &api.AutoScalingSchedule{Entries: []api.AutoScalingScheduleEntry{serverEntry}}
-	if d := applyScheduleToStateWithPlan(ctx, schedule, buildEntryList(t, planEntry), state); d.HasError() {
+	if d := applyScheduleToStateWithPlan(schedule, []models.ScheduledScalingEntryModel{planEntry}, state); d.HasError() {
 		t.Fatalf("applyScheduleToStateWithPlan: %v", d)
 	}
 

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -655,6 +655,115 @@ func TestApplyScheduleToStateWithPlan_FillsUnknownFromServer(t *testing.T) {
 	}
 }
 
+// TestApplyScheduleToStateWithPlan_ReorderedResponse exercises the reconcile on
+// a multi-entry plan whose server response is returned in a different order.
+// The index+identity-key correlation means a reordered element fails to match,
+// so known plan fields must survive while unset (unknown) fields resolve to
+// null — without error and preserving plan order.
+func TestApplyScheduleToStateWithPlan_ReorderedResponse(t *testing.T) {
+	ctx := context.Background()
+
+	planA := models.ScheduledScalingEntryModel{
+		Name: types.StringValue("A"), Weekdays: weekdaySetOf(t, 1),
+		StartHourUtc: types.Int64Value(8), EndHourUtc: types.Int64Value(12),
+		MinReplicas: types.Int64Value(3), MaxReplicas: types.Int64Value(3),
+		MinReplicaMemoryGb: types.Int64Null(), MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling: types.BoolValue(false), IdleTimeoutMinutes: types.Int64Unknown(),
+	}
+	planB := models.ScheduledScalingEntryModel{
+		Name: types.StringValue("B"), Weekdays: weekdaySetOf(t, 2),
+		StartHourUtc: types.Int64Value(12), EndHourUtc: types.Int64Value(16),
+		MinReplicas: types.Int64Value(5), MaxReplicas: types.Int64Value(5),
+		MinReplicaMemoryGb: types.Int64Null(), MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling: types.BoolValue(false), IdleTimeoutMinutes: types.Int64Unknown(),
+	}
+
+	// Server echoes the entries in reversed order.
+	schedule := &api.AutoScalingSchedule{
+		Entries: []api.AutoScalingScheduleEntry{
+			{Name: "B", Weekdays: []int{2}, StartHourUtc: 12, EndHourUtc: 16, MinReplicas: intPtr(5), MaxReplicas: intPtr(5), IdleScaling: boolPtr(false), IdleTimeoutMinutes: intPtr(30)},
+			{Name: "A", Weekdays: []int{1}, StartHourUtc: 8, EndHourUtc: 12, MinReplicas: intPtr(3), MaxReplicas: intPtr(3), IdleScaling: boolPtr(false), IdleTimeoutMinutes: intPtr(30)},
+		},
+	}
+
+	state := &models.ServiceScheduledScalingResourceModel{}
+	if d := applyScheduleToStateWithPlan(schedule, []models.ScheduledScalingEntryModel{planA, planB}, state); d.HasError() {
+		t.Fatalf("applyScheduleToStateWithPlan: %v", d)
+	}
+
+	var got []models.ScheduledScalingEntryModel
+	if d := state.Entries.ElementsAs(ctx, &got, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2", len(got))
+	}
+	// Plan order is preserved.
+	if got[0].Name.ValueString() != "A" || got[1].Name.ValueString() != "B" {
+		t.Errorf("order = [%s %s]; want [A B]", got[0].Name.ValueString(), got[1].Name.ValueString())
+	}
+	// Known plan fields survive.
+	if got[0].MinReplicas.ValueInt64() != 3 || got[1].MinReplicas.ValueInt64() != 5 {
+		t.Errorf("replicas = (%d, %d); want (3, 5)", got[0].MinReplicas.ValueInt64(), got[1].MinReplicas.ValueInt64())
+	}
+	// Unset fields resolve to null rather than filling from the mis-indexed
+	// server entry (which reported idle_timeout_minutes=30).
+	for i, e := range got {
+		if !e.IdleTimeoutMinutes.IsNull() {
+			t.Errorf("entry %d idle_timeout_minutes = %v; want null (reordered response must not fill unknowns)", i, e.IdleTimeoutMinutes)
+		}
+	}
+}
+
+// TestApplyScheduleToStateWithPlan_FewerServerEntries verifies that when the
+// server returns fewer entries than planned, state still has one entry per
+// planned entry (the plan drives length); the missing entry's unset fields
+// resolve to null.
+func TestApplyScheduleToStateWithPlan_FewerServerEntries(t *testing.T) {
+	ctx := context.Background()
+
+	planA := models.ScheduledScalingEntryModel{
+		Name: types.StringValue("A"), Weekdays: weekdaySetOf(t, 1),
+		StartHourUtc: types.Int64Value(8), EndHourUtc: types.Int64Value(12),
+		MinReplicas: types.Int64Value(3), MaxReplicas: types.Int64Value(3),
+		MinReplicaMemoryGb: types.Int64Null(), MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling: types.BoolValue(false), IdleTimeoutMinutes: types.Int64Unknown(),
+	}
+	planB := models.ScheduledScalingEntryModel{
+		Name: types.StringValue("B"), Weekdays: weekdaySetOf(t, 2),
+		StartHourUtc: types.Int64Value(12), EndHourUtc: types.Int64Value(16),
+		MinReplicas: types.Int64Value(5), MaxReplicas: types.Int64Value(5),
+		MinReplicaMemoryGb: types.Int64Null(), MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling: types.BoolValue(false), IdleTimeoutMinutes: types.Int64Unknown(),
+	}
+
+	// Server returns only the first entry.
+	schedule := &api.AutoScalingSchedule{
+		Entries: []api.AutoScalingScheduleEntry{
+			{Name: "A", Weekdays: []int{1}, StartHourUtc: 8, EndHourUtc: 12, MinReplicas: intPtr(3), MaxReplicas: intPtr(3), IdleScaling: boolPtr(false)},
+		},
+	}
+
+	state := &models.ServiceScheduledScalingResourceModel{}
+	if d := applyScheduleToStateWithPlan(schedule, []models.ScheduledScalingEntryModel{planA, planB}, state); d.HasError() {
+		t.Fatalf("applyScheduleToStateWithPlan: %v", d)
+	}
+
+	var got []models.ScheduledScalingEntryModel
+	if d := state.Entries.ElementsAs(ctx, &got, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2 (plan drives length)", len(got))
+	}
+	if got[1].Name.ValueString() != "B" {
+		t.Errorf("entry[1] name = %q; want B", got[1].Name.ValueString())
+	}
+	if !got[1].IdleTimeoutMinutes.IsNull() {
+		t.Errorf("entry[1] idle_timeout_minutes = %v; want null (no server entry to fill from)", got[1].IdleTimeoutMinutes)
+	}
+}
+
 // TestServiceScheduledScalingResource_UpgradeStateV0ToV1 verifies that state
 // written by an older provider (entries as a set) upgrades cleanly to the v1
 // layout (entries as a list) without losing entry content.

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -42,7 +42,7 @@ func TestApplyScheduleToState_PopulatesEntriesAndBaseConfig(t *testing.T) {
 		ServiceID: types.StringValue("svc-1"),
 	}
 
-	diags := applyScheduleToState(schedule, state)
+	diags := applyScheduleToState(context.Background(), schedule, state)
 	if diags.HasError() {
 		t.Fatalf("unexpected diags: %v", diags)
 	}
@@ -94,7 +94,7 @@ func TestApplyScheduleToState_NullBaseConfigWhenAbsent(t *testing.T) {
 		ServiceID: types.StringValue("svc-1"),
 	}
 
-	diags := applyScheduleToState(&api.AutoScalingSchedule{
+	diags := applyScheduleToState(context.Background(), &api.AutoScalingSchedule{
 		Entries:    []api.AutoScalingScheduleEntry{},
 		BaseConfig: nil,
 	}, state)
@@ -116,7 +116,7 @@ func TestApplyScheduleToState_CapturesAllEntries(t *testing.T) {
 	}
 
 	state := &models.ServiceScheduledScalingResourceModel{ServiceID: types.StringValue("svc-1")}
-	diags := applyScheduleToState(schedule, state)
+	diags := applyScheduleToState(context.Background(), schedule, state)
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -451,7 +451,7 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 	serverResponse := &api.AutoScalingSchedule{Entries: apiEntries}
 
 	state := &models.ServiceScheduledScalingResourceModel{}
-	if d := applyScheduleToState(serverResponse, state); d.HasError() {
+	if d := applyScheduleToState(context.Background(), serverResponse, state); d.HasError() {
 		t.Fatalf("applyScheduleToState: %v", d)
 	}
 
@@ -738,6 +738,65 @@ func TestServiceScheduledScalingResource_UpgradeStateV0ToV1(t *testing.T) {
 	}
 	if entries[0].MinReplicas.ValueInt64() != 3 || !entries[0].IdleScaling.ValueBool() {
 		t.Errorf("entry content not preserved: %+v", entries[0])
+	}
+}
+
+// TestApplyScheduleToState_PreservesPriorOrder guards the Read path against
+// server-side reordering: entries is a list (positional identity), so a
+// response returned in a different order than prior state must be reordered
+// back, or every refresh after a server sort would show a permanent reorder
+// diff. The two entries share a name deliberately — correlation must key on
+// the full identity (name + window), not the name alone.
+func TestApplyScheduleToState_PreservesPriorOrder(t *testing.T) {
+	ctx := context.Background()
+
+	morning := models.ScheduledScalingEntryModel{
+		Name:               types.StringValue("shift"),
+		Weekdays:           weekdaySetOf(t, 1),
+		StartHourUtc:       types.Int64Value(8),
+		EndHourUtc:         types.Int64Value(12),
+		MinReplicas:        types.Int64Value(2),
+		MaxReplicas:        types.Int64Value(2),
+		MinReplicaMemoryGb: types.Int64Null(),
+		MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling:        types.BoolValue(false),
+		IdleTimeoutMinutes: types.Int64Null(),
+	}
+	evening := morning
+	evening.StartHourUtc = types.Int64Value(12)
+	evening.EndHourUtc = types.Int64Value(18)
+	evening.MinReplicas = types.Int64Value(4)
+	evening.MaxReplicas = types.Int64Value(4)
+
+	// Prior state order: morning, evening. Server responds reversed.
+	state := &models.ServiceScheduledScalingResourceModel{
+		Entries: buildEntryList(t, morning, evening),
+	}
+	schedule := &api.AutoScalingSchedule{
+		Entries: []api.AutoScalingScheduleEntry{
+			{Name: "shift", Weekdays: []int{1}, StartHourUtc: 12, EndHourUtc: 18, MinReplicas: intPtr(4), MaxReplicas: intPtr(4), IdleScaling: boolPtr(false)},
+			{Name: "shift", Weekdays: []int{1}, StartHourUtc: 8, EndHourUtc: 12, MinReplicas: intPtr(2), MaxReplicas: intPtr(2), IdleScaling: boolPtr(false)},
+		},
+	}
+
+	if d := applyScheduleToState(ctx, schedule, state); d.HasError() {
+		t.Fatalf("applyScheduleToState: %v", d)
+	}
+
+	var got []models.ScheduledScalingEntryModel
+	if d := state.Entries.ElementsAs(ctx, &got, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d; want 2", len(got))
+	}
+	if got[0].StartHourUtc.ValueInt64() != 8 || got[1].StartHourUtc.ValueInt64() != 12 {
+		t.Errorf("order = (%d, %d); want prior-state order (8, 12)",
+			got[0].StartHourUtc.ValueInt64(), got[1].StartHourUtc.ValueInt64())
+	}
+	if got[0].MinReplicas.ValueInt64() != 2 || got[1].MinReplicas.ValueInt64() != 4 {
+		t.Errorf("replicas = (%d, %d); want (2, 4) — content must follow the matched entry",
+			got[0].MinReplicas.ValueInt64(), got[1].MinReplicas.ValueInt64())
 	}
 }
 

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -135,25 +135,25 @@ func TestApplyScheduleToState_CapturesAllEntries(t *testing.T) {
 	}
 }
 
-// buildEntrySet constructs a types.Set of ScheduledScalingEntryModel for
+// buildEntryList constructs a types.List of ScheduledScalingEntryModel for
 // driving planEntriesToAPI in tests.
-func buildEntrySet(t *testing.T, entries ...models.ScheduledScalingEntryModel) types.Set {
+func buildEntryList(t *testing.T, entries ...models.ScheduledScalingEntryModel) types.List {
 	t.Helper()
 	values := make([]attr.Value, len(entries))
 	for i, e := range entries {
 		values[i] = e.ObjectValue()
 	}
-	set, diags := types.SetValue(models.ScheduledScalingEntryModel{}.ObjectType(), values)
+	list, diags := types.ListValue(models.ScheduledScalingEntryModel{}.ObjectType(), values)
 	if diags.HasError() {
-		t.Fatalf("SetValue: %v", diags)
+		t.Fatalf("ListValue: %v", diags)
 	}
-	return set
+	return list
 }
 
 func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 	ctx := context.Background()
 
-	got, diags := planEntriesToAPI(ctx, types.SetNull(models.ScheduledScalingEntryModel{}.ObjectType()))
+	got, diags := planEntriesToAPI(ctx, types.ListNull(models.ScheduledScalingEntryModel{}.ObjectType()))
 	if diags.HasError() {
 		t.Fatalf("null input diags: %v", diags)
 	}
@@ -161,7 +161,7 @@ func TestPlanEntriesToAPI_EmptyAndNullInputs(t *testing.T) {
 		t.Errorf("null input: len = %d; want 0", len(got))
 	}
 
-	got, diags = planEntriesToAPI(ctx, buildEntrySet(t))
+	got, diags = planEntriesToAPI(ctx, buildEntryList(t))
 	if diags.HasError() {
 		t.Fatalf("empty input diags: %v", diags)
 	}
@@ -191,7 +191,7 @@ func TestPlanEntriesToAPI_ConvertsAllFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Value(15),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntrySet(t, entry))
+	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -372,7 +372,7 @@ func TestPlanEntriesToAPI_OmitsNullOptionalFields(t *testing.T) {
 		IdleTimeoutMinutes: types.Int64Null(),
 	}
 
-	got, diags := planEntriesToAPI(context.Background(), buildEntrySet(t, entry))
+	got, diags := planEntriesToAPI(context.Background(), buildEntryList(t, entry))
 	if diags.HasError() {
 		t.Fatalf("diags: %v", diags)
 	}
@@ -452,7 +452,7 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 		IdleScaling:        types.BoolValue(true),
 		IdleTimeoutMinutes: types.Int64Value(15),
 	}
-	planList := buildEntrySet(t, planEntry)
+	planList := buildEntryList(t, planEntry)
 
 	apiEntries, d := planEntriesToAPI(ctx, planList)
 	if d.HasError() {
@@ -500,5 +500,272 @@ func TestRoundTrip_NoServerNormalization(t *testing.T) {
 	sort.Ints(got)
 	if !reflect.DeepEqual(got, []int{1, 2, 3}) {
 		t.Errorf("weekdays = %v; want [1 2 3]", got)
+	}
+}
+
+// reconcileSingleEntry drives applyScheduleToStateWithPlan for one plan entry
+// against one server-returned entry and returns the resulting state entry.
+func reconcileSingleEntry(t *testing.T, planEntry models.ScheduledScalingEntryModel, serverEntry api.AutoScalingScheduleEntry) models.ScheduledScalingEntryModel {
+	t.Helper()
+	ctx := context.Background()
+
+	state := &models.ServiceScheduledScalingResourceModel{}
+	schedule := &api.AutoScalingSchedule{Entries: []api.AutoScalingScheduleEntry{serverEntry}}
+	if d := applyScheduleToStateWithPlan(ctx, schedule, buildEntryList(t, planEntry), state); d.HasError() {
+		t.Fatalf("applyScheduleToStateWithPlan: %v", d)
+	}
+
+	var entries []models.ScheduledScalingEntryModel
+	if d := state.Entries.ElementsAs(ctx, &entries, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d; want 1", len(entries))
+	}
+	return entries[0]
+}
+
+func weekdaySetOf(t *testing.T, days ...int64) types.Set {
+	t.Helper()
+	elems := make([]attr.Value, len(days))
+	for i, d := range days {
+		elems[i] = types.Int64Value(d)
+	}
+	s, diags := types.SetValue(types.Int64Type, elems)
+	if diags.HasError() {
+		t.Fatalf("SetValue: %v", diags)
+	}
+	return s
+}
+
+// TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse reproduces issue
+// #611: a non-idle entry (idle_scaling=false) whose idle fields the server
+// drops from its response. Without reconciliation the planned false becomes
+// null and Terraform aborts with "inconsistent result after apply".
+func TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse(t *testing.T) {
+	plan := models.ScheduledScalingEntryModel{
+		Name:               types.StringValue("Business Hours"),
+		Weekdays:           weekdaySetOf(t, 1, 2, 3, 4, 5),
+		StartHourUtc:       types.Int64Value(5),
+		EndHourUtc:         types.Int64Value(19),
+		MinReplicaMemoryGb: types.Int64Value(236),
+		MaxReplicaMemoryGb: types.Int64Value(236),
+		MinReplicas:        types.Int64Value(10),
+		MaxReplicas:        types.Int64Value(10),
+		IdleScaling:        types.BoolValue(false),
+		// Left unset by the user: unknown at plan time.
+		IdleTimeoutMinutes: types.Int64Unknown(),
+	}
+	// Server echoes the sizing but drops the idle fields for a non-idle entry.
+	server := api.AutoScalingScheduleEntry{
+		Name:               "Business Hours",
+		Weekdays:           []int{1, 2, 3, 4, 5},
+		StartHourUtc:       5,
+		EndHourUtc:         19,
+		MinReplicaMemoryGb: intPtr(236),
+		MaxReplicaMemoryGb: intPtr(236),
+		MinReplicas:        intPtr(10),
+		MaxReplicas:        intPtr(10),
+	}
+
+	got := reconcileSingleEntry(t, plan, server)
+
+	if got.IdleScaling.IsNull() || got.IdleScaling.IsUnknown() {
+		t.Fatalf("idle_scaling should be a known value, got %v", got.IdleScaling)
+	}
+	if got.IdleScaling.ValueBool() {
+		t.Errorf("idle_scaling = true; want false (planned value must survive)")
+	}
+	if !got.IdleTimeoutMinutes.IsNull() {
+		t.Errorf("idle_timeout_minutes = %v; want null (unset in plan, dropped by server)", got.IdleTimeoutMinutes)
+	}
+	if got.MinReplicas.ValueInt64() != 10 || got.MaxReplicas.ValueInt64() != 10 {
+		t.Errorf("replicas = (%d, %d); want (10, 10)", got.MinReplicas.ValueInt64(), got.MaxReplicas.ValueInt64())
+	}
+}
+
+// TestApplyScheduleToStateWithPlan_PreservesExplicitIdleTimeout covers the
+// issue's "same happens whether idle_timeout_minutes is set or omitted": an
+// explicit idle_timeout_minutes must also survive the server dropping it.
+func TestApplyScheduleToStateWithPlan_PreservesExplicitIdleTimeout(t *testing.T) {
+	plan := models.ScheduledScalingEntryModel{
+		Name:               types.StringValue("Business Hours"),
+		Weekdays:           weekdaySetOf(t, 1),
+		StartHourUtc:       types.Int64Value(5),
+		EndHourUtc:         types.Int64Value(19),
+		MinReplicas:        types.Int64Value(10),
+		MaxReplicas:        types.Int64Value(10),
+		MinReplicaMemoryGb: types.Int64Null(),
+		MaxReplicaMemoryGb: types.Int64Null(),
+		IdleScaling:        types.BoolValue(false),
+		IdleTimeoutMinutes: types.Int64Value(5),
+	}
+	server := api.AutoScalingScheduleEntry{
+		Name:         "Business Hours",
+		Weekdays:     []int{1},
+		StartHourUtc: 5,
+		EndHourUtc:   19,
+		MinReplicas:  intPtr(10),
+		MaxReplicas:  intPtr(10),
+	}
+
+	got := reconcileSingleEntry(t, plan, server)
+
+	if got.IdleScaling.ValueBool() {
+		t.Errorf("idle_scaling = true; want false")
+	}
+	if got.IdleTimeoutMinutes.IsNull() || got.IdleTimeoutMinutes.ValueInt64() != 5 {
+		t.Errorf("idle_timeout_minutes = %v; want 5 (planned value must survive)", got.IdleTimeoutMinutes)
+	}
+}
+
+// TestApplyScheduleToStateWithPlan_FillsUnknownFromServer verifies the other
+// direction: a field the user left unset (unknown at plan) is resolved from the
+// server's echoed value.
+func TestApplyScheduleToStateWithPlan_FillsUnknownFromServer(t *testing.T) {
+	plan := models.ScheduledScalingEntryModel{
+		Name:               types.StringValue("Overnight"),
+		Weekdays:           weekdaySetOf(t, 0, 6),
+		StartHourUtc:       types.Int64Value(22),
+		EndHourUtc:         types.Int64Value(6),
+		MinReplicaMemoryGb: types.Int64Unknown(),
+		MaxReplicaMemoryGb: types.Int64Unknown(),
+		MinReplicas:        types.Int64Unknown(),
+		MaxReplicas:        types.Int64Unknown(),
+		IdleScaling:        types.BoolValue(true),
+		IdleTimeoutMinutes: types.Int64Value(5),
+	}
+	server := api.AutoScalingScheduleEntry{
+		Name:               "Overnight",
+		Weekdays:           []int{0, 6},
+		StartHourUtc:       22,
+		EndHourUtc:         6,
+		MinReplicaMemoryGb: intPtr(16),
+		MaxReplicaMemoryGb: intPtr(16),
+		MinReplicas:        intPtr(1),
+		MaxReplicas:        intPtr(1),
+		IdleScaling:        boolPtr(true),
+		IdleTimeoutMinutes: intPtr(5),
+	}
+
+	got := reconcileSingleEntry(t, plan, server)
+
+	if got.MinReplicas.ValueInt64() != 1 || got.MaxReplicas.ValueInt64() != 1 {
+		t.Errorf("replicas = (%d, %d); want (1, 1) from server", got.MinReplicas.ValueInt64(), got.MaxReplicas.ValueInt64())
+	}
+	if got.MinReplicaMemoryGb.ValueInt64() != 16 || got.MaxReplicaMemoryGb.ValueInt64() != 16 {
+		t.Errorf("memory = (%d, %d); want (16, 16) from server", got.MinReplicaMemoryGb.ValueInt64(), got.MaxReplicaMemoryGb.ValueInt64())
+	}
+	if !got.IdleScaling.ValueBool() {
+		t.Errorf("idle_scaling = false; want true")
+	}
+}
+
+// TestServiceScheduledScalingResource_UpgradeStateV0ToV1 verifies that state
+// written by an older provider (entries as a set) upgrades cleanly to the v1
+// layout (entries as a list) without losing entry content.
+func TestServiceScheduledScalingResource_UpgradeStateV0ToV1(t *testing.T) {
+	ctx := context.Background()
+	r := NewServiceScheduledScalingResource().(*ServiceScheduledScalingResource)
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("Schema: %v", schemaResp.Diagnostics)
+	}
+	currentSchema := schemaResp.Schema
+
+	upgrader, ok := r.UpgradeState(ctx)[0]
+	if !ok {
+		t.Fatalf("no upgrader registered for schema version 0")
+	}
+	if upgrader.PriorSchema == nil {
+		t.Fatalf("upgrader is missing a PriorSchema")
+	}
+	priorSchema := *upgrader.PriorSchema
+
+	entry := models.ScheduledScalingEntryModel{
+		Name:               types.StringValue("business"),
+		Weekdays:           weekdaySetOf(t, 1, 2),
+		StartHourUtc:       types.Int64Value(8),
+		EndHourUtc:         types.Int64Value(18),
+		MinReplicaMemoryGb: types.Int64Null(),
+		MaxReplicaMemoryGb: types.Int64Null(),
+		MinReplicas:        types.Int64Value(3),
+		MaxReplicas:        types.Int64Value(3),
+		IdleScaling:        types.BoolValue(true),
+		IdleTimeoutMinutes: types.Int64Value(5),
+	}
+	entrySet, d := types.SetValue(models.ScheduledScalingEntryModel{}.ObjectType(), []attr.Value{entry.ObjectValue()})
+	if d.HasError() {
+		t.Fatalf("SetValue: %v", d)
+	}
+
+	priorState := tfsdk.State{
+		Schema: priorSchema,
+		Raw:    tftypes.NewValue(priorSchema.Type().TerraformType(ctx), nil),
+	}
+	if d := priorState.Set(ctx, scheduledScalingModelV0{
+		ID:         types.StringValue("svc-1"),
+		ServiceID:  types.StringValue("svc-1"),
+		Entries:    entrySet,
+		BaseConfig: types.ObjectNull(models.ScheduledScalingBaseConfigModel{}.ObjectType().AttrTypes),
+	}); d.HasError() {
+		t.Fatalf("prior state Set: %v", d)
+	}
+
+	resp := &resource.UpgradeStateResponse{
+		State: tfsdk.State{
+			Schema: currentSchema,
+			Raw:    tftypes.NewValue(currentSchema.Type().TerraformType(ctx), nil),
+		},
+	}
+	upgrader.StateUpgrader(ctx, resource.UpgradeStateRequest{State: &priorState}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("upgrade diags: %v", resp.Diagnostics)
+	}
+
+	var upgraded models.ServiceScheduledScalingResourceModel
+	if d := resp.State.Get(ctx, &upgraded); d.HasError() {
+		t.Fatalf("Get upgraded (entries must decode as a list): %v", d)
+	}
+	if upgraded.ServiceID.ValueString() != "svc-1" {
+		t.Errorf("service_id = %q; want svc-1", upgraded.ServiceID.ValueString())
+	}
+	var entries []models.ScheduledScalingEntryModel
+	if d := upgraded.Entries.ElementsAs(ctx, &entries, false); d.HasError() {
+		t.Fatalf("ElementsAs: %v", d)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len(entries) = %d; want 1", len(entries))
+	}
+	if entries[0].Name.ValueString() != "business" {
+		t.Errorf("name = %q; want business", entries[0].Name.ValueString())
+	}
+	if entries[0].MinReplicas.ValueInt64() != 3 || !entries[0].IdleScaling.ValueBool() {
+		t.Errorf("entry content not preserved: %+v", entries[0])
+	}
+}
+
+// TestApiEntryToModel_DefaultsIdleScalingFalse guards the Read path: a server
+// entry that omits idle_scaling maps to an explicit false so a refresh of a
+// non-idle entry does not report perpetual drift.
+func TestApiEntryToModel_DefaultsIdleScalingFalse(t *testing.T) {
+	got, diags := apiEntryToModel(api.AutoScalingScheduleEntry{
+		Name:         "no-idle",
+		Weekdays:     []int{1},
+		StartHourUtc: 0,
+		EndHourUtc:   24,
+		MinReplicas:  intPtr(2),
+		MaxReplicas:  intPtr(2),
+	})
+	if diags.HasError() {
+		t.Fatalf("apiEntryToModel: %v", diags)
+	}
+	if got.IdleScaling.IsNull() || got.IdleScaling.IsUnknown() {
+		t.Fatalf("idle_scaling should default to a known value, got %v", got.IdleScaling)
+	}
+	if got.IdleScaling.ValueBool() {
+		t.Errorf("idle_scaling = true; want false")
 	}
 }

--- a/pkg/resource/service_scheduled_scaling_test.go
+++ b/pkg/resource/service_scheduled_scaling_test.go
@@ -538,11 +538,15 @@ func weekdaySetOf(t *testing.T, days ...int64) types.Set {
 	return s
 }
 
-// TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse reproduces issue
-// #611: a non-idle entry (idle_scaling=false) whose idle fields the server
-// drops from its response. Without reconciliation the planned false becomes
-// null and Terraform aborts with "inconsistent result after apply".
-func TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse(t *testing.T) {
+// TestApplyScheduleToStateWithPlan_PreservesReplicaBand reproduces the actual
+// issue #611 normalization (UC-1252): the server collapsed a vertical entry's
+// equal min/max replica band to numReplicas (a field the provider does not
+// model) and omitted minReplicas/maxReplicas from the response, while echoing
+// the idle fields. Without reconciliation the planned 10/10 becomes null/null
+// and Terraform aborts with "inconsistent result after apply". Fixed
+// server-side in control-plane#35956; kept here so the provider stays correct
+// against any server version.
+func TestApplyScheduleToStateWithPlan_PreservesReplicaBand(t *testing.T) {
 	plan := models.ScheduledScalingEntryModel{
 		Name:               types.StringValue("Business Hours"),
 		Weekdays:           weekdaySetOf(t, 1, 2, 3, 4, 5),
@@ -556,7 +560,8 @@ func TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse(t *testing.T) {
 		// Left unset by the user: unknown at plan time.
 		IdleTimeoutMinutes: types.Int64Unknown(),
 	}
-	// Server echoes the sizing but drops the idle fields for a non-idle entry.
+	// Pre-#35956 server response: memory and idle fields echoed, replica band
+	// omitted (returned as numReplicas, which the provider does not decode).
 	server := api.AutoScalingScheduleEntry{
 		Name:               "Business Hours",
 		Weekdays:           []int{1, 2, 3, 4, 5},
@@ -564,29 +569,30 @@ func TestApplyScheduleToStateWithPlan_PreservesIdleScalingFalse(t *testing.T) {
 		EndHourUtc:         19,
 		MinReplicaMemoryGb: intPtr(236),
 		MaxReplicaMemoryGb: intPtr(236),
-		MinReplicas:        intPtr(10),
-		MaxReplicas:        intPtr(10),
+		IdleScaling:        boolPtr(false),
 	}
 
 	got := reconcileSingleEntry(t, plan, server)
 
+	if got.MinReplicas.ValueInt64() != 10 || got.MaxReplicas.ValueInt64() != 10 {
+		t.Errorf("replicas = (%d, %d); want (10, 10) (planned values must survive)", got.MinReplicas.ValueInt64(), got.MaxReplicas.ValueInt64())
+	}
 	if got.IdleScaling.IsNull() || got.IdleScaling.IsUnknown() {
 		t.Fatalf("idle_scaling should be a known value, got %v", got.IdleScaling)
 	}
 	if got.IdleScaling.ValueBool() {
-		t.Errorf("idle_scaling = true; want false (planned value must survive)")
+		t.Errorf("idle_scaling = true; want false")
 	}
 	if !got.IdleTimeoutMinutes.IsNull() {
-		t.Errorf("idle_timeout_minutes = %v; want null (unset in plan, dropped by server)", got.IdleTimeoutMinutes)
-	}
-	if got.MinReplicas.ValueInt64() != 10 || got.MaxReplicas.ValueInt64() != 10 {
-		t.Errorf("replicas = (%d, %d); want (10, 10)", got.MinReplicas.ValueInt64(), got.MaxReplicas.ValueInt64())
+		t.Errorf("idle_timeout_minutes = %v; want null (unset in plan, not echoed by server)", got.IdleTimeoutMinutes)
 	}
 }
 
-// TestApplyScheduleToStateWithPlan_PreservesExplicitIdleTimeout covers the
-// issue's "same happens whether idle_timeout_minutes is set or omitted": an
-// explicit idle_timeout_minutes must also survive the server dropping it.
+// TestApplyScheduleToStateWithPlan_PreservesExplicitIdleTimeout guards the
+// general property behind the fix: any value the user set explicitly survives
+// a server response that does not echo it. The fixture drops the idle fields —
+// a normalization no current server version performs — precisely to prove the
+// reconcile holds for fields beyond the replica band.
 func TestApplyScheduleToStateWithPlan_PreservesExplicitIdleTimeout(t *testing.T) {
 	plan := models.ScheduledScalingEntryModel{
 		Name:               types.StringValue("Business Hours"),
@@ -748,8 +754,9 @@ func TestServiceScheduledScalingResource_UpgradeStateV0ToV1(t *testing.T) {
 }
 
 // TestApiEntryToModel_DefaultsIdleScalingFalse guards the Read path: a server
-// entry that omits idle_scaling maps to an explicit false so a refresh of a
-// non-idle entry does not report perpetual drift.
+// entry that omits idle_scaling maps to its effective default, false, so a
+// refresh can never report perpetual drift on it. Current server versions echo
+// idle_scaling; this pins the defensive default.
 func TestApiEntryToModel_DefaultsIdleScalingFalse(t *testing.T) {
 	got, diags := apiEntryToModel(api.AutoScalingScheduleEntry{
 		Name:         "no-idle",


### PR DESCRIPTION
Fixes #611.

## Problem

`clickhouse_service_scheduled_scaling` could not be applied for entries with a fixed replica count (`min_replicas == max_replicas`, the only shape the resource supports). `terraform apply` aborted with:

> Provider produced inconsistent result after apply … `.entries`: planned set element … does not correlate with any element in actual.

## Root cause

The primary cause is **API-side** (UC-1252, fixed in ClickHouse/control-plane#35956): after UC-1173, the schedule API stopped echoing `minReplicas`/`maxReplicas` for vertical entries, returning the fixed count as `numReplicas` — a field the provider does not model. The provider therefore read the replica bounds back as `null`, which cannot correlate with the planned `min/max` values.

The provider-side amplifier is that `entries` was a `SetNestedAttribute`: Terraform correlates set elements by value, so *any* server-side normalization of *any* field in an element (or an `Optional + Computed` field left unset and planned as unknown) risks a fatal "does not correlate" instead of a benign in-place update.

An earlier revision of this PR attributed the mismatch to the server dropping `idleScaling`/`idleTimeoutMinutes` for non-idle entries. Verified against the live API: it does not — those fields are echoed; the replica band was the culprit.

## What this PR changes

With the API fix in control-plane#35956, the released provider round-trips correctly again with no changes (verified). This PR is hardening so the resource cannot fail this way again for other/future response normalizations:

- **Model `entries` as a `ListNestedAttribute`.** Lists correlate by index, so a normalized or late-resolving field produces an in-place diff at worst, never an "inconsistent result after apply" error.
- **Reconcile the server response against the plan in Create/Update** (`applyScheduleToStateWithPlan` / `reconcileEntriesWithPlan`): values the user set explicitly are kept from the plan; fields left unset are resolved from the server response. This holds regardless of which fields the server echoes.
- **On Read, map a missing `idle_scaling` to its effective value `false`** so a refresh never reports drift on it.
- **Add a v0 → v1 state upgrader** (set → list layout) so existing state migrates cleanly; schema version bumped to 1.
- Update the resource description and generated docs (set → list).

## Testing

Unit tests cover the reconcile logic in both directions (explicit plan values survive normalization; unset fields resolve from the server), the Read-path `idle_scaling` default, and the v0 → v1 upgrader.

Verified end-to-end with real `terraform` runs:

- **Against the live staging API (current, pre-#35956 behavior):** the #611 config fails on `main` with the exact reported error and applies cleanly with this PR; v0 state written by `main` upgrades in place; import works. (Note: against the pre-#35956 API, a refresh still nulls `min_replicas`/`max_replicas` — resolved by the API-side fix rather than provider-side mapping.)
- **Against a mock implementing the post-#35956 response shape:** both `main` and this PR apply cleanly and plans converge, including `idle_scaling = false` with an explicit `idle_timeout_minutes`, and the v0 → v1 upgrade path.

`go build ./...`, `go test ./...`, `go vet ./...`, and `golangci-lint run` all pass.

## Rollout note

This PR is independent of control-plane#35956 in either order, but the provider release fully converges (no refresh diff on `min_replicas`/`max_replicas`) only once #35956 is deployed to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012fxjy91WrDMdDCnDmSBSXf)_
