### PR TITLE
docs(clickpipe): add example to object storage start_after

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -477,7 +477,7 @@ Optional:
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
 - `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.
-- `start_after` (String) Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Keys are compared in lexicographical order. Cannot be provided when `skip_initial_load` is true.
+- `start_after` (String) Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -477,7 +477,7 @@ Optional:
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
 - `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.
-- `start_after` (String) Start continuous ingestion after this object key. Cannot be provided when `skip_initial_load` is true.
+- `start_after` (String) Start continuous ingestion after this object key (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -477,7 +477,7 @@ Optional:
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
 - `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.
-- `start_after` (String) Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.
+- `start_after` (String) Skip all files up to and including this object key during the initial load (e.g. `events/2026-06-01/`). Cannot be provided when `skip_initial_load` is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -477,7 +477,7 @@ Optional:
 - `queue_url` (String) Queue URL for event-based continuous ingestion. When provided, files are ingested based on event notifications rather than lexicographical order. Only applicable when `is_continuous` is `true` and authentication is provided. For S3: SQS URL in the format `https://sqs.{region}.amazonaws.com/{account-id}/{queue-name}`. For GCS: Pub/Sub subscription in the format `projects/{project}/subscriptions/{subscription}`.
 - `service_account_key` (String, Sensitive) Base64-encoded GCP service account JSON key for GCS authentication. Required when authentication is `SERVICE_ACCOUNT`.
 - `skip_initial_load` (Boolean) If set to true, skips the initial load and only ingests files delivered by queue notifications. Only applicable when `queue_url` is provided.
-- `start_after` (String) Start continuous ingestion after this object key (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.
+- `start_after` (String) Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Keys are compared in lexicographical order. Cannot be provided when `skip_initial_load` is true.
 - `type` (String) The type of the S3-compatible source (`s3`, `gcs`, `azureblobstorage`). Default is `s3`.
 - `url` (String) The URL of the S3/GCS bucket. Required for S3 and GCS types. Not used for Azure Blob Storage (use path and azure_container_name instead). You can specify multiple files using bash-like wildcards. For more information, see the documentation on using wildcards in path: https://clickhouse.com/docs/en/integrations/clickpipes/object-storage#limitations
 

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -543,7 +543,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"start_after": schema.StringAttribute{
-								MarkdownDescription: "Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.",
+								MarkdownDescription: "Skip all files up to and including this object key during the initial load (e.g. `events/2026-06-01/`). Cannot be provided when `skip_initial_load` is true.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -543,7 +543,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"start_after": schema.StringAttribute{
-								MarkdownDescription: "Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Keys are compared in lexicographical order. Cannot be provided when `skip_initial_load` is true.",
+								MarkdownDescription: "Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -543,7 +543,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"start_after": schema.StringAttribute{
-								MarkdownDescription: "Start continuous ingestion after this object key. Cannot be provided when `skip_initial_load` is true.",
+								MarkdownDescription: "Start continuous ingestion after this object key (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),

--- a/pkg/resource/clickpipe.go
+++ b/pkg/resource/clickpipe.go
@@ -543,7 +543,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"start_after": schema.StringAttribute{
-								MarkdownDescription: "Start continuous ingestion after this object key (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.",
+								MarkdownDescription: "Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Keys are compared in lexicographical order. Cannot be provided when `skip_initial_load` is true.",
 								Optional:            true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),


### PR DESCRIPTION
## What

The `start_after` attribute on the object storage ClickPipe source (1) had no example of what an object key looks like, and (2) was framed around continuous ingestion, whereas the ClickHouse Cloud console describes the same field in terms of the initial load. This adds an example and aligns the two surfaces so they read consistently.

The field controls where the **initial load** listing begins — it skips object keys lexicographically up to and including the given key. It is incompatible with `skip_initial_load` (if you skip the initial load, there's nothing for it to affect), which is why the initial-load framing is the accurate one.

## Changes

- `pkg/resource/clickpipe.go` — update the `start_after` attribute `MarkdownDescription`.
- `docs/resources/clickpipe.md` — regenerated line (deterministic `tfplugindocs` transform of the description; updated by hand to match).

Before:
> Start continuous ingestion after this object key. Cannot be provided when `skip_initial_load` is true.

After:
> Skip all files up to and including this object key during the initial load (e.g. `logs/2024-01-01/events-000042.json`). Cannot be provided when `skip_initial_load` is true.

This matches the console object-storage form helper text (control-plane #35976) and reuses the same example key.

## Notes

- Docs-only content change; no schema/behavior change. `gofmt` clean.
- The generated doc line was edited by hand rather than running the patched `tfplugindocs` fork locally; the docs CI check will confirm it matches generator output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
