### PR TITLE
fix(clickpipes): don't re-send source connection on a table_mappings-only edit

### DIFF
--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -5262,11 +5262,22 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 						}
 					}
 
-					if len(tableMappingsToAdd) > 0 {
-						source.Postgres.TableMappingsToAdd = tableMappingsToAdd
-					}
-					if len(tableMappingsToRemove) > 0 {
-						source.Postgres.TableMappingsToRemove = tableMappingsToRemove
+					if otherFieldsChanged {
+						if len(tableMappingsToAdd) > 0 {
+							source.Postgres.TableMappingsToAdd = tableMappingsToAdd
+						}
+						if len(tableMappingsToRemove) > 0 {
+							source.Postgres.TableMappingsToRemove = tableMappingsToRemove
+						}
+					} else {
+						// Only table_mappings changed: PATCH just the mapping deltas.
+						// Re-sending the connection (host/port/settings) makes the
+						// control plane re-validate the source connection, which fails
+						// because the unchanged credentials are omitted (#617).
+						source.Postgres = &api.ClickPipePostgresSource{
+							TableMappingsToAdd:    tableMappingsToAdd,
+							TableMappingsToRemove: tableMappingsToRemove,
+						}
 					}
 				}
 
@@ -5332,11 +5343,22 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 						}
 					}
 
-					if len(tableMappingsToAdd) > 0 {
-						source.MySQL.TableMappingsToAdd = tableMappingsToAdd
-					}
-					if len(tableMappingsToRemove) > 0 {
-						source.MySQL.TableMappingsToRemove = tableMappingsToRemove
+					if otherFieldsChanged {
+						if len(tableMappingsToAdd) > 0 {
+							source.MySQL.TableMappingsToAdd = tableMappingsToAdd
+						}
+						if len(tableMappingsToRemove) > 0 {
+							source.MySQL.TableMappingsToRemove = tableMappingsToRemove
+						}
+					} else {
+						// Only table_mappings changed: PATCH just the mapping deltas.
+						// Re-sending the connection (host/port/settings) makes the
+						// control plane re-validate the source connection, which fails
+						// because the unchanged credentials are omitted (#617).
+						source.MySQL = &api.ClickPipeMySQLSource{
+							TableMappingsToAdd:    tableMappingsToAdd,
+							TableMappingsToRemove: tableMappingsToRemove,
+						}
 					}
 				}
 
@@ -5402,11 +5424,22 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 						}
 					}
 
-					if len(tableMappingsToAdd) > 0 {
-						source.MongoDB.TableMappingsToAdd = tableMappingsToAdd
-					}
-					if len(tableMappingsToRemove) > 0 {
-						source.MongoDB.TableMappingsToRemove = tableMappingsToRemove
+					if otherFieldsChanged {
+						if len(tableMappingsToAdd) > 0 {
+							source.MongoDB.TableMappingsToAdd = tableMappingsToAdd
+						}
+						if len(tableMappingsToRemove) > 0 {
+							source.MongoDB.TableMappingsToRemove = tableMappingsToRemove
+						}
+					} else {
+						// Only table_mappings changed: PATCH just the mapping deltas.
+						// Re-sending the connection (uri/settings) makes the control
+						// plane re-validate the source connection, which fails because
+						// the unchanged credentials are omitted from the payload (#617).
+						source.MongoDB = &api.ClickPipeMongoDBSource{
+							TableMappingsToAdd:    tableMappingsToAdd,
+							TableMappingsToRemove: tableMappingsToRemove,
+						}
 					}
 				}
 			}

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -2879,16 +2879,22 @@ func credentialsObjectChanged(planCredentials, stateCredentials types.Object) bo
 }
 
 // sourceFieldsChangedIgnoringMappings reports whether any source attribute other
-// than table_mappings differs between plan and state. It backs the mappings-only
-// PATCH shortcut (issue #617): that shortcut may drop the connection from the
-// payload only when nothing but table_mappings changed, so comparing every other
-// attribute (rather than an enumerated subset) keeps a connection/settings/
-// credential change made in the same apply from being silently dropped.
+// than table_mappings or credentials differs between plan and state. It backs the
+// mappings-only PATCH shortcut (issue #617): that shortcut may drop the connection
+// from the payload only when nothing but table_mappings changed, so comparing
+// every other attribute (rather than an enumerated subset) keeps a
+// connection/settings change made in the same apply from being silently dropped.
+//
+// credentials is excluded and must be checked separately via
+// credentialsObjectChanged: password_wo is write-only, so plan always carries the
+// configured value while state always has it nulled out, which would make a
+// plain Equal() report "changed" on every single apply for write-only-credential
+// pipes and permanently disable this shortcut for them.
 func sourceFieldsChangedIgnoringMappings(planObj, stateObj types.Object) bool {
 	planAttrs := planObj.Attributes()
 	stateAttrs := stateObj.Attributes()
 	for name, planVal := range planAttrs {
-		if name == "table_mappings" {
+		if name == "table_mappings" || name == "credentials" {
 			continue
 		}
 		stateVal, ok := stateAttrs[name]
@@ -5223,11 +5229,13 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 			// Check if table_mappings or other Postgres fields changed
 			tableMappingsChanged := !planPostgresModel.TableMappings.Equal(statePostgresModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planPostgresModel.Credentials, statePostgresModel.Credentials)
-			// Any non-mapping source change (host/port/database/credentials/settings
-			// and less-common fields like authentication/tls_host/ca_certificate)
+			// Any non-mapping source change (host/port/database/settings and
+			// less-common fields like authentication/tls_host/ca_certificate)
 			// disqualifies the mappings-only shortcut, so compare every attribute
-			// except table_mappings rather than an enumerated subset.
-			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.Postgres, stateSourceModel.Postgres)
+			// except table_mappings rather than an enumerated subset. credentials
+			// is compared separately via credentialsChanged (see
+			// sourceFieldsChangedIgnoringMappings for why).
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.Postgres, stateSourceModel.Postgres) || credentialsChanged
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true
@@ -5314,7 +5322,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 
 			tableMappingsChanged := !planMySQLModel.TableMappings.Equal(stateMySQLModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planMySQLModel.Credentials, stateMySQLModel.Credentials)
-			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MySQL, stateSourceModel.MySQL)
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MySQL, stateSourceModel.MySQL) || credentialsChanged
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true
@@ -5391,7 +5399,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 
 			tableMappingsChanged := !planMongoDBModel.TableMappings.Equal(stateMongoDBModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planMongoDBModel.Credentials, stateMongoDBModel.Credentials)
-			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MongoDB, stateSourceModel.MongoDB)
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MongoDB, stateSourceModel.MongoDB) || credentialsChanged
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -2878,6 +2878,27 @@ func credentialsObjectChanged(planCredentials, stateCredentials types.Object) bo
 	return false
 }
 
+// sourceFieldsChangedIgnoringMappings reports whether any source attribute other
+// than table_mappings differs between plan and state. It backs the mappings-only
+// PATCH shortcut (issue #617): that shortcut may drop the connection from the
+// payload only when nothing but table_mappings changed, so comparing every other
+// attribute (rather than an enumerated subset) keeps a connection/settings/
+// credential change made in the same apply from being silently dropped.
+func sourceFieldsChangedIgnoringMappings(planObj, stateObj types.Object) bool {
+	planAttrs := planObj.Attributes()
+	stateAttrs := stateObj.Attributes()
+	for name, planVal := range planAttrs {
+		if name == "table_mappings" {
+			continue
+		}
+		stateVal, ok := stateAttrs[name]
+		if !ok || !planVal.Equal(stateVal) {
+			return true
+		}
+	}
+	return false
+}
+
 // extractSourceFromPlan builds the API source from plan. config supplies write-only credentials stripped from plan; pass nil in unit tests not exercising write-only behavior.
 func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnostics *diag.Diagnostics, plan models.ClickPipeResourceModel, config *models.ClickPipeResourceModel, isUpdate bool) *api.ClickPipeSource {
 	source := &api.ClickPipeSource{}
@@ -5202,11 +5223,11 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 			// Check if table_mappings or other Postgres fields changed
 			tableMappingsChanged := !planPostgresModel.TableMappings.Equal(statePostgresModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planPostgresModel.Credentials, statePostgresModel.Credentials)
-			otherFieldsChanged := !planPostgresModel.Host.Equal(statePostgresModel.Host) ||
-				!planPostgresModel.Port.Equal(statePostgresModel.Port) ||
-				!planPostgresModel.Database.Equal(statePostgresModel.Database) ||
-				credentialsChanged ||
-				!planPostgresModel.Settings.Equal(statePostgresModel.Settings)
+			// Any non-mapping source change (host/port/database/credentials/settings
+			// and less-common fields like authentication/tls_host/ca_certificate)
+			// disqualifies the mappings-only shortcut, so compare every attribute
+			// except table_mappings rather than an enumerated subset.
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.Postgres, stateSourceModel.Postgres)
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true
@@ -5293,10 +5314,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 
 			tableMappingsChanged := !planMySQLModel.TableMappings.Equal(stateMySQLModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planMySQLModel.Credentials, stateMySQLModel.Credentials)
-			otherFieldsChanged := !planMySQLModel.Host.Equal(stateMySQLModel.Host) ||
-				!planMySQLModel.Port.Equal(stateMySQLModel.Port) ||
-				credentialsChanged ||
-				!planMySQLModel.Settings.Equal(stateMySQLModel.Settings)
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MySQL, stateSourceModel.MySQL)
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true
@@ -5373,13 +5391,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 
 			tableMappingsChanged := !planMongoDBModel.TableMappings.Equal(stateMongoDBModel.TableMappings)
 			credentialsChanged := credentialsObjectChanged(planMongoDBModel.Credentials, stateMongoDBModel.Credentials)
-			otherFieldsChanged := !planMongoDBModel.URI.Equal(stateMongoDBModel.URI) ||
-				!planMongoDBModel.ReadPreference.Equal(stateMongoDBModel.ReadPreference) ||
-				!planMongoDBModel.TLSHost.Equal(stateMongoDBModel.TLSHost) ||
-				!planMongoDBModel.CACertificate.Equal(stateMongoDBModel.CACertificate) ||
-				!planMongoDBModel.DisableTLS.Equal(stateMongoDBModel.DisableTLS) ||
-				credentialsChanged ||
-				!planMongoDBModel.Settings.Equal(stateMongoDBModel.Settings)
+			otherFieldsChanged := sourceFieldsChangedIgnoringMappings(planSourceModel.MongoDB, stateSourceModel.MongoDB)
 
 			if tableMappingsChanged || otherFieldsChanged {
 				pipeChanged = true

--- a/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
@@ -1,0 +1,58 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+)
+
+// A table_mappings-only edit must PATCH just the mapping deltas, not re-send the
+// connection. Re-sending the uri/host while omitting unchanged credentials makes
+// the control plane re-validate the source connection with no auth, which fails
+// with AuthenticationFailed (issue #617).
+func TestClickPipeResource_Update_MappingsOnlyOmitsConnection_Issue617(t *testing.T) {
+	ctx := context.Background()
+	// Only table_mappings differ (remove "orders"); host/port/database/credentials
+	// /settings are identical in state and plan, so otherFieldsChanged is false.
+	state := postgresUpdateModel(ctx, t, "users", "orders")
+	plan := postgresUpdateModel(ctx, t, "users")
+
+	mc := minimock.NewController(t)
+	syncPipe := postgresAPIPipe(api.ClickPipeRunningState, "users")
+	mock, calls := pauseEditClientMock(mc, syncPipe, func(int) (*api.ClickPipe, error) {
+		return postgresAPIPipe(api.ClickPipePausedState, "users"), nil
+	})
+
+	// Capture the PATCH payload the provider builds.
+	var captured api.ClickPipeUpdate
+	mock.UpdateClickPipeMock.Set(func(_ context.Context, _, _ string, update api.ClickPipeUpdate) (*api.ClickPipe, error) {
+		*calls = append(*calls, "update")
+		captured = update
+		return postgresAPIPipe(api.ClickPipePausedState, "users"), nil
+	})
+	expectSyncRead(mock, calls, syncPipe)
+
+	resp := driveClickPipeUpdate(ctx, t, &ClickPipeResource{client: mock}, state, plan)
+	require.False(t, resp.Diagnostics.HasError(), "update must succeed: %v", resp.Diagnostics.Errors())
+
+	require.NotNil(t, captured.Source)
+	require.NotNil(t, captured.Source.Postgres)
+	pg := captured.Source.Postgres
+
+	// Connection fields must be omitted so no re-validation is triggered.
+	assert.Empty(t, pg.Host, "host must not be re-sent on a mappings-only edit")
+	assert.Zero(t, pg.Port, "port must not be re-sent on a mappings-only edit")
+	assert.Empty(t, pg.Database, "database must not be re-sent on a mappings-only edit")
+	assert.Nil(t, pg.Credentials, "credentials must not be re-sent on a mappings-only edit")
+	assert.Nil(t, pg.Settings, "settings must not be re-sent on a mappings-only edit")
+
+	// The mapping delta itself must still be carried.
+	require.Len(t, pg.TableMappingsToRemove, 1, "the removed mapping must be sent")
+	assert.Equal(t, "orders", pg.TableMappingsToRemove[0].SourceTable)
+	assert.Empty(t, pg.TableMappingsToAdd)
+}

--- a/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickhouse/resource/models"
 )
 
 // A table_mappings-only edit must PATCH just the mapping deltas, not re-send the
@@ -55,4 +58,49 @@ func TestClickPipeResource_Update_MappingsOnlyOmitsConnection_Issue617(t *testin
 	require.Len(t, pg.TableMappingsToRemove, 1, "the removed mapping must be sent")
 	assert.Equal(t, "orders", pg.TableMappingsToRemove[0].SourceTable)
 	assert.Empty(t, pg.TableMappingsToAdd)
+}
+
+// A connection change made in the same apply as a table_mappings change must NOT
+// be dropped. The mappings-only shortcut applies only when nothing else changed;
+// otherFieldsChanged now compares every non-mapping attribute (rather than an
+// enumerated subset), so fields like host/authentication/tls_host can't slip
+// through and get overwritten by a minimal payload (Copilot review on #618).
+func TestClickPipeResource_Update_ConnectionChangeAlongsideMappingsNotDropped(t *testing.T) {
+	ctx := context.Background()
+	state := postgresUpdateModel(ctx, t, "users")
+	plan := postgresUpdateModel(ctx, t, "users", "orders") // adds "orders"
+
+	// Change a connection field in the same apply as the mapping add.
+	var src models.ClickPipeSourceModel
+	require.False(t, plan.Source.As(ctx, &src, basetypes.ObjectAsOptions{}).HasError())
+	var pg models.ClickPipePostgresSourceModel
+	require.False(t, src.Postgres.As(ctx, &pg, basetypes.ObjectAsOptions{}).HasError())
+	pg.Host = types.StringValue("new-host.example.com")
+	src.Postgres = pg.ObjectValue()
+	plan.Source = src.ObjectValue()
+
+	mc := minimock.NewController(t)
+	syncPipe := postgresAPIPipe(api.ClickPipeRunningState, "users", "orders")
+	mock, calls := pauseEditClientMock(mc, syncPipe, func(int) (*api.ClickPipe, error) {
+		return postgresAPIPipe(api.ClickPipePausedState, "users", "orders"), nil
+	})
+
+	var captured api.ClickPipeUpdate
+	mock.UpdateClickPipeMock.Set(func(_ context.Context, _, _ string, update api.ClickPipeUpdate) (*api.ClickPipe, error) {
+		*calls = append(*calls, "update")
+		captured = update
+		return postgresAPIPipe(api.ClickPipePausedState, "users", "orders"), nil
+	})
+	expectSyncRead(mock, calls, syncPipe)
+
+	resp := driveClickPipeUpdate(ctx, t, &ClickPipeResource{client: mock}, state, plan)
+	require.False(t, resp.Diagnostics.HasError(), "update must succeed: %v", resp.Diagnostics.Errors())
+
+	require.NotNil(t, captured.Source)
+	require.NotNil(t, captured.Source.Postgres)
+	// The connection change must be carried, not dropped by the mappings-only shortcut.
+	assert.Equal(t, "new-host.example.com", captured.Source.Postgres.Host)
+	// And the mapping delta is still present.
+	require.Len(t, captured.Source.Postgres.TableMappingsToAdd, 1)
+	assert.Equal(t, "orders", captured.Source.Postgres.TableMappingsToAdd[0].SourceTable)
 }

--- a/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_mappings_only_update_test.go
@@ -104,3 +104,69 @@ func TestClickPipeResource_Update_ConnectionChangeAlongsideMappingsNotDropped(t 
 	require.Len(t, captured.Source.Postgres.TableMappingsToAdd, 1)
 	assert.Equal(t, "orders", captured.Source.Postgres.TableMappingsToAdd[0].SourceTable)
 }
+
+// A table_mappings-only edit on a pipe using write-only credentials
+// (password_wo/password_wo_version) must still take the mappings-only shortcut.
+// password_wo is always populated in plan (from config) and always null in state
+// (per the write-only contract), even when nothing about the credentials actually
+// changed. sourceFieldsChangedIgnoringMappings must not treat that expected
+// divergence as a "connection changed" signal, or it permanently disables the
+// shortcut for every write-only-credential pipe and reopens #617 for them.
+func TestClickPipeResource_Update_MappingsOnlyWithWriteOnlyCredentials(t *testing.T) {
+	ctx := context.Background()
+	state := postgresUpdateModel(ctx, t, "users")
+	plan := postgresUpdateModel(ctx, t, "users", "orders") // adds "orders" only
+
+	setSteadyStateWriteOnlyCreds := func(m *models.ClickPipeResourceModel, passwordWOInPlan bool) {
+		var src models.ClickPipeSourceModel
+		require.False(t, m.Source.As(ctx, &src, basetypes.ObjectAsOptions{}).HasError())
+		var pg models.ClickPipePostgresSourceModel
+		require.False(t, src.Postgres.As(ctx, &pg, basetypes.ObjectAsOptions{}).HasError())
+		var cred models.ClickPipeSourceCredentialsModel
+		require.False(t, pg.Credentials.As(ctx, &cred, basetypes.ObjectAsOptions{}).HasError())
+		cred.Password = types.StringNull()
+		if passwordWOInPlan {
+			cred.PasswordWO = types.StringValue("supersecret")
+		} else {
+			cred.PasswordWO = types.StringNull()
+		}
+		// password_wo_version is not write-only; it stays the same in plan and
+		// state when there is no rotation, exactly like this mappings-only edit.
+		cred.PasswordWOVersion = types.Int64Value(1)
+		pg.Credentials = cred.ObjectValue()
+		src.Postgres = pg.ObjectValue()
+		m.Source = src.ObjectValue()
+	}
+	setSteadyStateWriteOnlyCreds(&state, false) // state: password_wo always nulled out
+	setSteadyStateWriteOnlyCreds(&plan, true)   // plan: password_wo always carries the config value
+
+	mc := minimock.NewController(t)
+	syncPipe := postgresAPIPipe(api.ClickPipeRunningState, "users", "orders")
+	mock, calls := pauseEditClientMock(mc, syncPipe, func(int) (*api.ClickPipe, error) {
+		return postgresAPIPipe(api.ClickPipePausedState, "users", "orders"), nil
+	})
+
+	var captured api.ClickPipeUpdate
+	mock.UpdateClickPipeMock.Set(func(_ context.Context, _, _ string, update api.ClickPipeUpdate) (*api.ClickPipe, error) {
+		*calls = append(*calls, "update")
+		captured = update
+		return postgresAPIPipe(api.ClickPipePausedState, "users", "orders"), nil
+	})
+	expectSyncRead(mock, calls, syncPipe)
+
+	resp := driveClickPipeUpdate(ctx, t, &ClickPipeResource{client: mock}, state, plan)
+	require.False(t, resp.Diagnostics.HasError(), "update must succeed: %v", resp.Diagnostics.Errors())
+
+	require.NotNil(t, captured.Source)
+	require.NotNil(t, captured.Source.Postgres)
+	pg := captured.Source.Postgres
+
+	// The write-only credentials divergence must not defeat the shortcut: the
+	// connection must still be omitted, exactly as in the stateful-password case.
+	assert.Empty(t, pg.Host, "host must not be re-sent on a mappings-only edit, even with write-only credentials")
+	assert.Nil(t, pg.Credentials, "credentials must not be re-sent on a mappings-only edit")
+	assert.Nil(t, pg.Settings, "settings must not be re-sent on a mappings-only edit")
+
+	require.Len(t, pg.TableMappingsToAdd, 1, "the added mapping must be sent")
+	assert.Equal(t, "orders", pg.TableMappingsToAdd[0].SourceTable)
+}


### PR DESCRIPTION
## Problem

Editing only `table_mappings` on a running CDC ClickPipe (Postgres, MySQL, or MongoDB) fails with a source-connection authentication error, even when the pipe is replicating fine on valid stored credentials:

```
Error Updating ClickPipe ... status: 400 ... 'connectionStatus' failed:
... (AuthenticationFailed) Authentication failed.
```

`Update()` builds the source via `extractSourceFromPlan` (which always populates the `uri`) and then nils the credentials when they are unchanged. The resulting PATCH carries the connection `uri` but no `credentials`, so the control plane re-validates the source connection with nothing to authenticate with, and fails. The pipe's stored credentials are never consulted. This affects all three CDC source types, and `credentialsObjectChanged` skips `password_wo`, so write-only configs hit it too. See #617 for the full analysis.

It surfaces now because the pause-before-edit change lets the update reach connection validation; previously the edit failed earlier with `must be paused to edit`.

## Fix

When an update changes **only** `table_mappings` (connection, settings, and credentials all unchanged), PATCH just the mapping deltas and omit the connection fields. Because `uri` / `credentials` / `settings` are `omitempty`, this produces `{"source":{"<db>":{"tableMappingsToAdd":[...]}}}`, which does not trigger connection re-validation. This mirrors editing `table_mappings` directly via the API with only `tableMappingsToAdd`/`tableMappingsToRemove`, which works today.

Updates that also change the connection/settings/credentials are unchanged: they still send the full source (with credentials when those changed).

## Testing

- New unit test `TestClickPipeResource_Update_MappingsOnlyOmitsConnection_Issue617` drives `Update()` end to end through the minimock client and asserts the PATCH payload for a mappings-only edit omits `host`/`port`/`database`/`credentials`/`settings` and carries only the mapping delta.
- Existing pause-before-edit tests, the full `internal/service/clickhouse/resource` and `internal/api` unit suites, `go build ./...`, and `make fmt` (golangci-lint) all pass.

Fixes #617
