### PR TITLE
fix(clickpipes): correct IAM role casing so payload matches API contract

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -496,7 +496,7 @@ Optional:
 
 Required:
 
-- `credentials` (Attributes, Sensitive) The credentials for the Postgres instance. Username is always required. For `basic` authentication, supply either `password` or `password_wo`. For `iam_role` authentication, password is optional. (see [below for nested schema](#nestedatt--source--postgres--credentials))
+- `credentials` (Attributes, Sensitive) The credentials for the Postgres instance. Username is always required. For `basic` authentication, supply either `password` or `password_wo`. For `IAM_ROLE` authentication, password is optional. (see [below for nested schema](#nestedatt--source--postgres--credentials))
 - `database` (String) The database name of the Postgres instance.
 - `host` (String) The hostname of the Postgres instance.
 - `settings` (Attributes) Settings for the Postgres CDC pipe. (see [below for nested schema](#nestedatt--source--postgres--settings))
@@ -504,9 +504,9 @@ Required:
 
 Optional:
 
-- `authentication` (String) Authentication method for Postgres connection. Supported values: `basic`, `iam_role`. Default is `basic`.
+- `authentication` (String) Authentication method for Postgres connection. Supported values: `basic`, `IAM_ROLE`. Default is `basic`.
 - `ca_certificate` (String) PEM encoded CA certificate to validate the Postgres server certificate.
-- `iam_role` (String) IAM role ARN for IAM authentication. Required when authentication is set to `iam_role`.
+- `iam_role` (String) IAM role ARN for IAM authentication. Required when authentication is set to `IAM_ROLE`.
 - `port` (Number) The port of the Postgres instance. Default is 5432.
 - `tls_host` (String) TLS/SSL host for secure connections. Used to verify the server certificate.
 - `type` (String) The type of the Postgres source. (`postgres`, `supabase`, `neon`, `alloydb`, `planetscale`, `rdspostgres`, `aurorapostgres`, `cloudsqlpostgres`, `azurepostgres`, `crunchybridge`, `tigerdata`). Default is `postgres`.

--- a/internal/api/clickpipe.go
+++ b/internal/api/clickpipe.go
@@ -248,6 +248,14 @@ var ClickPipePostgresTableEngines = []string{
 	ClickPipeTableEngineNull,
 }
 
+// ClickPipePostgresAuthenticationMethods lists the values accepted by the API for
+// source.postgres.authentication. The API's `basic` value stays lowercase, but `IAM_ROLE`
+// must be uppercase like every other ClickPipe authentication enum (see #639).
+var ClickPipePostgresAuthenticationMethods = []string{
+	"basic",
+	ClickPipeAuthenticationIAMRole,
+}
+
 var ClickPipeBigQueryTableEngines = []string{
 	ClickPipeTableEngineMergeTree,
 	ClickPipeTableEngineReplacingMergeTree,

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -886,16 +886,19 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Required:    true,
 							},
 							"authentication": schema.StringAttribute{
-								MarkdownDescription: "Authentication method for Postgres connection. Supported values: `basic`, `iam_role`. Default is `basic`.",
-								Optional:            true,
-								Computed:            true,
-								Default:             stringdefault.StaticString(clickPipeAuthBasic),
+								MarkdownDescription: fmt.Sprintf(
+									"Authentication method for Postgres connection. Supported values: %s. Default is `basic`.",
+									wrapStringsWithBackticksAndJoinCommaSeparated(api.ClickPipePostgresAuthenticationMethods),
+								),
+								Optional: true,
+								Computed: true,
+								Default:  stringdefault.StaticString(clickPipeAuthBasic),
 								Validators: []validator.String{
-									stringvalidator.OneOf(clickPipeAuthBasic, "iam_role"),
+									stringvalidator.OneOf(api.ClickPipePostgresAuthenticationMethods...),
 								},
 							},
 							"iam_role": schema.StringAttribute{
-								Description: "IAM role ARN for IAM authentication. Required when authentication is set to `iam_role`.",
+								Description: "IAM role ARN for IAM authentication. Required when authentication is set to `IAM_ROLE`.",
 								Optional:    true,
 							},
 							"tls_host": schema.StringAttribute{
@@ -907,7 +910,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 							},
 							"credentials": schema.SingleNestedAttribute{
-								MarkdownDescription: "The credentials for the Postgres instance. Username is always required. For `basic` authentication, supply either `password` or `password_wo`. For `iam_role` authentication, password is optional.",
+								MarkdownDescription: "The credentials for the Postgres instance. Username is always required. For `basic` authentication, supply either `password` or `password_wo`. For `IAM_ROLE` authentication, password is optional.",
 								Required:            true,
 								Sensitive:           true,
 								Attributes: map[string]schema.Attribute{
@@ -3318,17 +3321,17 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			}
 		}
 
-		if authentication == "iam_role" {
+		if authentication == api.ClickPipeAuthenticationIAMRole {
 			if postgresModel.IAMRole.IsNull() {
 				diagnostics.AddError(
 					"Missing required attribute",
-					"IAM role is required when authentication is set to 'iam_role'.",
+					"IAM role is required when authentication is set to 'IAM_ROLE'.",
 				)
 			}
 			if credentialsKnown && !credentialsModel.Password.IsNull() && !credentialsModel.Password.IsUnknown() {
 				diagnostics.AddError(
 					"Invalid attribute combination",
-					"Password (or `password_wo`) should not be set when authentication is set to 'iam_role'.",
+					"Password (or `password_wo`) should not be set when authentication is set to 'IAM_ROLE'.",
 				)
 			}
 		}

--- a/internal/service/clickhouse/resource/clickpipe_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_test.go
@@ -935,7 +935,7 @@ func TestExtractSourceFromPlan_PostgresIAMRoleAuthentication(t *testing.T) {
 	resource := &ClickPipeResource{}
 
 	t.Run("IAM_ROLE authentication with iam_role set succeeds and is passed through verbatim", func(t *testing.T) {
-		plan, config := buildPostgresIAMRolePlan(types.StringValue("IAM_ROLE"), types.StringValue("arn:aws:iam::123456789012:role/MyRole"))
+		plan, config := buildPostgresIAMRolePlan(types.StringValue(api.ClickPipeAuthenticationIAMRole), types.StringValue("arn:aws:iam::123456789012:role/MyRole"))
 		diagnostics := diag.Diagnostics{}
 		source := resource.extractSourceFromPlan(ctx, &diagnostics, plan, &config, false)
 
@@ -943,20 +943,20 @@ func TestExtractSourceFromPlan_PostgresIAMRoleAuthentication(t *testing.T) {
 		assert.NotNil(t, source)
 		assert.NotNil(t, source.Postgres)
 		assert.NotNil(t, source.Postgres.Authentication)
-		assert.Equal(t, "IAM_ROLE", *source.Postgres.Authentication)
+		assert.Equal(t, api.ClickPipeAuthenticationIAMRole, *source.Postgres.Authentication)
 		assert.NotNil(t, source.Postgres.IAMRole)
 		assert.Equal(t, "arn:aws:iam::123456789012:role/MyRole", *source.Postgres.IAMRole)
 	})
 
 	t.Run("IAM_ROLE authentication without iam_role errors", func(t *testing.T) {
-		plan, config := buildPostgresIAMRolePlan(types.StringValue("IAM_ROLE"), types.StringNull())
+		plan, config := buildPostgresIAMRolePlan(types.StringValue(api.ClickPipeAuthenticationIAMRole), types.StringNull())
 		diagnostics := diag.Diagnostics{}
 		resource.extractSourceFromPlan(ctx, &diagnostics, plan, &config, false)
 
 		assert.True(t, diagnostics.HasError(), "expected error when iam_role is unset for IAM_ROLE auth")
 	})
 
-	assert.Equal(t, []string{"basic", "IAM_ROLE"}, api.ClickPipePostgresAuthenticationMethods,
+	assert.Equal(t, []string{clickPipeAuthBasic, api.ClickPipeAuthenticationIAMRole}, api.ClickPipePostgresAuthenticationMethods,
 		"Postgres authentication enum must match the ClickPipes API contract, not the schema's old lowercase iam_role")
 }
 

--- a/internal/service/clickhouse/resource/clickpipe_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_test.go
@@ -873,6 +873,93 @@ func TestExtractSourceFromPlan_PostgresWriteOnlyPassword(t *testing.T) {
 	})
 }
 
+// buildPostgresIAMRolePlan returns plan/config models for Postgres with the given authentication
+// and iam_role values, and a null password (IAM_ROLE authentication doesn't require one).
+func buildPostgresIAMRolePlan(authentication, iamRole types.String) (plan, config models.ClickPipeResourceModel) {
+	credAttrs := map[string]attr.Value{
+		"username":            types.StringValue("user"),
+		"password":            types.StringNull(),
+		"password_wo":         types.StringNull(),
+		"password_wo_version": types.Int64Null(),
+	}
+	settingsAttrs := map[string]attr.Value{
+		"replication_mode":                   types.StringValue("cdc"),
+		"sync_interval_seconds":              types.Int64Null(),
+		"pull_batch_size":                    types.Int64Null(),
+		"publication_name":                   types.StringNull(),
+		"replication_slot_name":              types.StringNull(),
+		"allow_nullable_columns":             types.BoolNull(),
+		"initial_load_parallelism":           types.Int64Null(),
+		"snapshot_num_rows_per_partition":    types.Int64Null(),
+		"snapshot_number_of_parallel_tables": types.Int64Null(),
+		"enable_failover_slots":              types.BoolNull(),
+		"delete_on_merge":                    types.BoolNull(),
+	}
+	pgAttrs := map[string]attr.Value{
+		"type":           types.StringValue("aurorapostgres"),
+		"host":           types.StringValue("postgres.example.com"),
+		"port":           types.Int64Value(5432),
+		"database":       types.StringValue("mydb"),
+		"authentication": authentication,
+		"iam_role":       iamRole,
+		"tls_host":       types.StringNull(),
+		"ca_certificate": types.StringNull(),
+		"credentials":    types.ObjectValueMust(models.ClickPipeSourceCredentialsModel{}.ObjectType().AttrTypes, credAttrs),
+		"settings":       types.ObjectValueMust(models.ClickPipePostgresSettingsModel{}.ObjectType().AttrTypes, settingsAttrs),
+		"table_mappings": types.SetValueMust(models.ClickPipePostgresTableMappingModel{}.ObjectType(), []attr.Value{}),
+	}
+	sourceModel := models.ClickPipeSourceModel{
+		Kafka:         types.ObjectNull(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes),
+		ObjectStorage: types.ObjectNull(models.ClickPipeObjectStorageSourceModel{}.ObjectType().AttrTypes),
+		Kinesis:       types.ObjectNull(models.ClickPipeKinesisSourceModel{}.ObjectType().AttrTypes),
+		PubSub:        types.ObjectNull(models.ClickPipePubSubSourceModel{}.ObjectType().AttrTypes),
+		Postgres:      types.ObjectValueMust(models.ClickPipePostgresSourceModel{}.ObjectType().AttrTypes, pgAttrs),
+		MySQL:         types.ObjectNull(models.ClickPipeMySQLSourceModel{}.ObjectType().AttrTypes),
+		BigQuery:      types.ObjectNull(models.ClickPipeBigQuerySourceModel{}.ObjectType().AttrTypes),
+		MongoDB:       types.ObjectNull(models.ClickPipeMongoDBSourceModel{}.ObjectType().AttrTypes),
+	}
+	model := models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("service-123"),
+		Name:      types.StringValue("test-pg-pipe"),
+		Source:    sourceModel.ObjectValue(),
+	}
+	return model, model
+}
+
+// TestExtractSourceFromPlan_PostgresIAMRoleAuthentication guards against regressing issue #639,
+// where the provider sent the API the lowercase "iam_role" it validated instead of the
+// uppercase "IAM_ROLE" the ClickPipes API actually accepts for Postgres sources.
+func TestExtractSourceFromPlan_PostgresIAMRoleAuthentication(t *testing.T) {
+	ctx := context.Background()
+	resource := &ClickPipeResource{}
+
+	t.Run("IAM_ROLE authentication with iam_role set succeeds and is passed through verbatim", func(t *testing.T) {
+		plan, config := buildPostgresIAMRolePlan(types.StringValue("IAM_ROLE"), types.StringValue("arn:aws:iam::123456789012:role/MyRole"))
+		diagnostics := diag.Diagnostics{}
+		source := resource.extractSourceFromPlan(ctx, &diagnostics, plan, &config, false)
+
+		assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+		assert.NotNil(t, source)
+		assert.NotNil(t, source.Postgres)
+		assert.NotNil(t, source.Postgres.Authentication)
+		assert.Equal(t, "IAM_ROLE", *source.Postgres.Authentication)
+		assert.NotNil(t, source.Postgres.IAMRole)
+		assert.Equal(t, "arn:aws:iam::123456789012:role/MyRole", *source.Postgres.IAMRole)
+	})
+
+	t.Run("IAM_ROLE authentication without iam_role errors", func(t *testing.T) {
+		plan, config := buildPostgresIAMRolePlan(types.StringValue("IAM_ROLE"), types.StringNull())
+		diagnostics := diag.Diagnostics{}
+		resource.extractSourceFromPlan(ctx, &diagnostics, plan, &config, false)
+
+		assert.True(t, diagnostics.HasError(), "expected error when iam_role is unset for IAM_ROLE auth")
+	})
+
+	assert.Equal(t, []string{"basic", "IAM_ROLE"}, api.ClickPipePostgresAuthenticationMethods,
+		"Postgres authentication enum must match the ClickPipes API contract, not the schema's old lowercase iam_role")
+}
+
 // buildKafkaCredentialsPlan returns plan/config models for PLAIN-authenticated Kafka; see buildPostgresCredentialsPlan for the plan-vs-config asymmetry.
 func buildKafkaCredentialsPlan(password, passwordWO types.String, passwordWOVersion types.Int64) (plan, config models.ClickPipeResourceModel) {
 	build := func(pw, pwWO types.String) models.ClickPipeResourceModel {


### PR DESCRIPTION
# Summary
This fixes an issue where the payload to create an Postgres CDC ClickPipes sent `iam_role` instead of the correct `IAM_ROLE` required on the api contract. This fixes the issue and adds a few tests.
This closes #639 