### PR TITLE
fix(clickpipes): treat Kafka schema registry and immutable source fields as immutable

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -235,7 +235,7 @@ Optional:
 - `iam_role` (String) The IAM role for the Kafka source. Use with `IAM_ROLE` authentication. It can be used with AWS ClickHouse service only. Read more at https://clickhouse.com/docs/en/integrations/clickpipes/kafka#iam
 - `offset` (Attributes) The Kafka offset. (see [below for nested schema](#nestedatt--source--kafka--offset))
 - `reverse_private_endpoint_ids` (List of String) The list of reverse private endpoint IDs for the Kafka source. (comma separated)
-- `schema_registry` (Attributes) The schema registry for the Kafka source. (see [below for nested schema](#nestedatt--source--kafka--schema_registry))
+- `schema_registry` (Attributes) The schema registry for the Kafka source. Immutable: any change forces pipe replacement. (see [below for nested schema](#nestedatt--source--kafka--schema_registry))
 - `type` (String) The type of the Kafka source. (`kafka`, `redpanda`, `confluent`, `msk`, `warpstream`, `azureeventhub`, `gcmk`). Default is `kafka`.
 
 <a id="nestedatt--source--kafka--credentials"></a>
@@ -272,7 +272,7 @@ Optional:
 Required:
 
 - `authentication` (String) The authentication method for the Schema Registry. Only supported is `PLAIN`.
-- `credentials` (Attributes, Sensitive) The credentials for the Schema Registry. (see [below for nested schema](#nestedatt--source--kafka--schema_registry--credentials))
+- `credentials` (Attributes, Sensitive) The credentials for the Schema Registry. Immutable: in-place credential rotation is not supported, so changing them forces pipe replacement. Changes are detected at plan time: values not known until apply (for example, generated in the same run) are recorded in state without forcing replacement. (see [below for nested schema](#nestedatt--source--kafka--schema_registry--credentials))
 - `url` (String) The URL of the schema registry.
 
 <a id="nestedatt--source--kafka--schema_registry--credentials"></a>
@@ -285,8 +285,8 @@ Required:
 Optional:
 
 - `password` (String, Sensitive) The password for the Schema Registry. Either `password` or `password_wo` must be provided.
-- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only password for the Schema Registry. Not persisted to state. Pair with `password_wo_version` to trigger updates.
-- `password_wo_version` (Number) Version trigger for `password_wo`. Increment to push a new password to the API.
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write-only password for the Schema Registry. Not persisted to state. Pair with `password_wo_version`; changing schema registry credentials forces pipe replacement.
+- `password_wo_version` (Number) Version trigger for `password_wo`. Incrementing signals a new password, which forces pipe replacement - schema registry credentials cannot be updated in place.
 
 
 

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -292,8 +292,11 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								},
 							},
 							"schema_registry": schema.SingleNestedAttribute{
-								MarkdownDescription: "The schema registry for the Kafka source.",
+								MarkdownDescription: "The schema registry for the Kafka source. Immutable: any change forces pipe replacement.",
 								Optional:            true,
+								PlanModifiers: []planmodifier.Object{
+									requiresReplaceIfSchemaRegistryChanges{},
+								},
 								Attributes: map[string]schema.Attribute{
 									"url": schema.StringAttribute{
 										Description: "The URL of the schema registry.",
@@ -311,7 +314,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									// Other sources (Kafka, Postgres, MySQL, MongoDB) defer this requirement to runtime
 									// validation in extractSourceFromPlan because it's conditional on the `authentication` field.
 									"credentials": schema.SingleNestedAttribute{
-										MarkdownDescription: "The credentials for the Schema Registry.",
+										MarkdownDescription: "The credentials for the Schema Registry. Immutable: in-place credential rotation is not supported, so changing them forces pipe replacement. Changes are detected at plan time: values not known until apply (for example, generated in the same run) are recorded in state without forcing replacement.",
 										Required:            true,
 										Sensitive:           true,
 										Attributes: map[string]schema.Attribute{
@@ -338,7 +341,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 												},
 											},
 											"password_wo": schema.StringAttribute{
-												Description: "Write-only password for the Schema Registry. Not persisted to state. Pair with `password_wo_version` to trigger updates.",
+												Description: "Write-only password for the Schema Registry. Not persisted to state. Pair with `password_wo_version`; changing schema registry credentials forces pipe replacement.",
 												Optional:    true,
 												Sensitive:   true,
 												WriteOnly:   true,
@@ -347,7 +350,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 												},
 											},
 											"password_wo_version": schema.Int64Attribute{
-												Description: "Version trigger for `password_wo`. Increment to push a new password to the API.",
+												Description: "Version trigger for `password_wo`. Incrementing signals a new password, which forces pipe replacement - schema registry credentials cannot be updated in place.",
 												Optional:    true,
 												Validators: []validator.Int64{
 													int64validator.AlsoRequires(path.MatchRelative().AtParent().AtName("password_wo")),
@@ -5479,9 +5482,7 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 				if !credentialsObjectChanged(planKafkaModel.Credentials, stateKafkaModel.Credentials) {
 					source.Kafka.Credentials = nil
 				}
-				if planKafkaModel.SchemaRegistry.Equal(stateKafkaModel.SchemaRegistry) && source.Kafka.SchemaRegistry != nil {
-					source.Kafka.SchemaRegistry.Credentials = nil
-				}
+				source.Kafka.SchemaRegistry = nil
 			}
 
 			// For Pub/Sub, only re-send the service_account_key when it changed
@@ -5817,7 +5818,7 @@ func (c *ClickPipeResource) Delete(ctx context.Context, request resource.DeleteR
 	}
 }
 
-// ImportState imports a ClickPipe reverse private endpoint into the state.
+// ImportState imports a ClickPipe into the state.
 // We don't have access to configuration/plan, so service id is required
 // to be provided as a part of the import id.
 func (r *ClickPipeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
@@ -5838,10 +5839,10 @@ func (r *ClickPipeResource) ImportState(ctx context.Context, req resource.Import
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), endpointID)...)
 
 	resp.Diagnostics.AddWarning(
-		"Credentials state diverge",
-		"Importing a ClickPipe will not persist credentials into your state.\n"+
-			"Sensitive values are only stored in your state and provider is not able to import them.\n"+
-			"Run a `terraform apply` to ensure sensitive values state is up to date with a ClickPipe.\n"+
-			"Important: your configuration (in *.tf files) has to provide valid credentials.",
+		"Credentials are not imported",
+		"The API never returns sensitive values, so importing a ClickPipe cannot persist credentials into your state.\n"+
+			"Your configuration (in *.tf files) must provide valid credentials.\n"+
+			"The first `terraform apply` after import sends the source credentials to the ClickPipe and records them in state.\n"+
+			"Schema registry credentials are immutable and never sent on update: the apply records your configured values in state without server-side verification, so ensure they match the registry credentials the pipe already uses.",
 	)
 }

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -5482,6 +5482,13 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 				if !credentialsObjectChanged(planKafkaModel.Credentials, stateKafkaModel.Credentials) {
 					source.Kafka.Credentials = nil
 				}
+				// Omit all immutable fields from update payload
+				source.Kafka.Type = ""
+				source.Kafka.Format = ""
+				source.Kafka.Brokers = ""
+				source.Kafka.Topics = ""
+				source.Kafka.ConsumerGroup = nil
+				source.Kafka.Offset = nil
 				source.Kafka.SchemaRegistry = nil
 			}
 

--- a/internal/service/clickhouse/resource/clickpipe_kafka_update_payload_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_kafka_update_payload_test.go
@@ -1,0 +1,207 @@
+package resource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickhouse/resource/models"
+)
+
+func kafkaUpdateModel(caCertificate types.String, kafkaPassword string) models.ClickPipeResourceModel {
+	mainCredAttrs := map[string]attr.Value{
+		"username":            types.StringValue("kuser"),
+		"password":            types.StringValue(kafkaPassword),
+		"password_wo":         types.StringNull(),
+		"password_wo_version": types.Int64Null(),
+		"access_key_id":       types.StringNull(),
+		"secret_key":          types.StringNull(),
+		"connection_string":   types.StringNull(),
+		"certificate":         types.StringNull(),
+		"private_key":         types.StringNull(),
+	}
+	srCredAttrs := map[string]attr.Value{
+		"username":            types.StringValue("sruser"),
+		"password":            types.StringValue("sr-pass"),
+		"password_wo":         types.StringNull(),
+		"password_wo_version": types.Int64Null(),
+	}
+	srAttrs := map[string]attr.Value{
+		"url":            types.StringValue("https://schema-registry.example.com"),
+		"authentication": types.StringValue("PLAIN"),
+		"credentials":    types.ObjectValueMust(models.ClickPipeSourceCredentialsModel{}.ObjectType().AttrTypes, srCredAttrs),
+	}
+	kafkaAttrs := map[string]attr.Value{
+		"type":                         types.StringValue("kafka"),
+		"format":                       types.StringValue("AvroConfluent"),
+		"brokers":                      types.StringValue("broker:9092"),
+		"topics":                       types.StringValue("test-topic"),
+		"consumer_group":               types.StringValue("clickpipes-test"),
+		"offset":                       types.ObjectNull(models.ClickPipeKafkaOffsetModel{}.ObjectType().AttrTypes),
+		"schema_registry":              types.ObjectValueMust(models.ClickPipeKafkaSchemaRegistryModel{}.ObjectType().AttrTypes, srAttrs),
+		"authentication":               types.StringValue("PLAIN"),
+		"credentials":                  types.ObjectValueMust(models.ClickPipeKafkaSourceCredentialsModel{}.ObjectType().AttrTypes, mainCredAttrs),
+		"iam_role":                     types.StringNull(),
+		"ca_certificate":               caCertificate,
+		"reverse_private_endpoint_ids": types.ListNull(types.StringType),
+		"exactly_once":                 types.BoolNull(),
+	}
+	src := models.ClickPipeSourceModel{
+		Kafka:         types.ObjectValueMust(models.ClickPipeKafkaSourceModel{}.ObjectType().AttrTypes, kafkaAttrs),
+		ObjectStorage: types.ObjectNull(models.ClickPipeObjectStorageSourceModel{}.ObjectType().AttrTypes),
+		Kinesis:       types.ObjectNull(models.ClickPipeKinesisSourceModel{}.ObjectType().AttrTypes),
+		PubSub:        types.ObjectNull(models.ClickPipePubSubSourceModel{}.ObjectType().AttrTypes),
+		Postgres:      types.ObjectNull(models.ClickPipePostgresSourceModel{}.ObjectType().AttrTypes),
+		MySQL:         types.ObjectNull(models.ClickPipeMySQLSourceModel{}.ObjectType().AttrTypes),
+		BigQuery:      types.ObjectNull(models.ClickPipeBigQuerySourceModel{}.ObjectType().AttrTypes),
+		MongoDB:       types.ObjectNull(models.ClickPipeMongoDBSourceModel{}.ObjectType().AttrTypes),
+	}
+	return models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("service-123"),
+		Name:      types.StringValue("test-kafka-sr-pipe"),
+		Scaling:   types.ObjectNull(models.ClickPipeScalingModel{}.ObjectType().AttrTypes),
+		State:     types.StringValue(api.ClickPipeRunningState),
+		Stopped:   types.BoolValue(false),
+		Source:    src.ObjectValue(),
+		Destination: types.ObjectValueMust(
+			models.ClickPipeDestinationModel{}.ObjectType().AttrTypes,
+			map[string]attr.Value{
+				"database":         types.StringValue("default"),
+				"table":            types.StringNull(),
+				"managed_table":    types.BoolNull(),
+				"table_definition": types.ObjectNull(models.ClickPipeDestinationTableDefinitionModel{}.ObjectType().AttrTypes),
+				"columns":          types.ListNull(models.ClickPipeDestinationColumnModel{}.ObjectType()),
+				"roles":            types.ListNull(types.StringType),
+			},
+		),
+		FieldMappings: types.ListNull(models.ClickPipeFieldMappingModel{}.ObjectType()),
+		Settings:      types.DynamicNull(),
+		TriggerResync: types.BoolNull(),
+	}
+}
+
+func TestClickPipeUpdate_KafkaOmitsImmutableFields(t *testing.T) {
+	ctx := context.Background()
+	state := kafkaUpdateModel(types.StringNull(), "main-pass")
+	plan := kafkaUpdateModel(types.StringValue("PEM-CA"), "main-pass") // mutable-field change drives the source PATCH
+	apiPipe := &api.ClickPipe{
+		ID:    "test-pipe-id",
+		Name:  "test-pipe",
+		State: api.ClickPipeRunningState,
+		Source: api.ClickPipeSource{
+			Kafka: &api.ClickPipeKafkaSource{
+				Type:           "kafka",
+				Format:         "AvroConfluent",
+				Brokers:        "broker:9092",
+				Topics:         "test-topic",
+				Authentication: "PLAIN",
+				SchemaRegistry: &api.ClickPipeKafkaSchemaRegistry{
+					URL:            "https://schema-registry.example.com",
+					Authentication: "PLAIN",
+				},
+			},
+		},
+		Destination: api.ClickPipeDestination{Database: "default"},
+	}
+
+	mc := minimock.NewController(t)
+	var captured *api.ClickPipeUpdate
+	mock := api.NewClientMock(mc)
+	mock.UpdateClickPipeMock.Set(func(_ context.Context, _, _ string, update api.ClickPipeUpdate) (*api.ClickPipe, error) {
+		captured = &update
+		return apiPipe, nil
+	})
+	mock.WaitForClickPipeStateMock.Set(func(_ context.Context, _, _ string, _ func(string) bool, _ time.Duration) (*api.ClickPipe, error) {
+		return apiPipe, nil
+	})
+	mock.GetClickPipeMock.Set(func(_ context.Context, _, _ string) (*api.ClickPipe, error) {
+		return apiPipe, nil
+	})
+
+	r := &ClickPipeResource{client: mock}
+	resp := driveClickPipeUpdate(ctx, t, r, state, plan)
+	require.False(t, resp.Diagnostics.HasError(), "update failed: %v", resp.Diagnostics.Errors())
+
+	require.NotNil(t, captured, "UpdateClickPipe was not called")
+	require.NotNil(t, captured.Source, "update payload carries no source")
+	kafka := captured.Source.Kafka
+	require.NotNil(t, kafka, "update payload carries no kafka source")
+
+	assert.Nil(t, kafka.SchemaRegistry, "schema registry must never be sent on update")
+	assert.Nil(t, kafka.Credentials, "unchanged credentials must be omitted")
+	assert.Empty(t, kafka.Type, "immutable type must be omitted")
+	assert.Empty(t, kafka.Format, "immutable format must be omitted")
+	assert.Empty(t, kafka.Brokers, "immutable brokers must be omitted")
+	assert.Empty(t, kafka.Topics, "immutable topics must be omitted")
+	assert.Nil(t, kafka.ConsumerGroup, "immutable consumer group must be omitted")
+	assert.Nil(t, kafka.Offset, "immutable offset must be omitted")
+
+	require.NotNil(t, kafka.CACertificate, "the mutable ca_certificate change must be carried")
+	assert.Equal(t, "PEM-CA", *kafka.CACertificate)
+}
+
+// Tests a Kafka source credential rotation IS carried, while the immutable fields stay omitted.
+func TestClickPipeUpdate_KafkaSendsChangedKafkaCredentials(t *testing.T) {
+	ctx := context.Background()
+	state := kafkaUpdateModel(types.StringNull(), "main-pass")
+	plan := kafkaUpdateModel(types.StringNull(), "rotated-pass")
+	apiPipe := &api.ClickPipe{
+		ID:    "test-pipe-id",
+		Name:  "test-pipe",
+		State: api.ClickPipeRunningState,
+		Source: api.ClickPipeSource{
+			Kafka: &api.ClickPipeKafkaSource{
+				Type:           "kafka",
+				Format:         "AvroConfluent",
+				Brokers:        "broker:9092",
+				Topics:         "test-topic",
+				Authentication: "PLAIN",
+				SchemaRegistry: &api.ClickPipeKafkaSchemaRegistry{
+					URL:            "https://schema-registry.example.com",
+					Authentication: "PLAIN",
+				},
+			},
+		},
+		Destination: api.ClickPipeDestination{Database: "default"},
+	}
+
+	mc := minimock.NewController(t)
+	var captured *api.ClickPipeUpdate
+	mock := api.NewClientMock(mc)
+	mock.UpdateClickPipeMock.Set(func(_ context.Context, _, _ string, update api.ClickPipeUpdate) (*api.ClickPipe, error) {
+		captured = &update
+		return apiPipe, nil
+	})
+	mock.WaitForClickPipeStateMock.Set(func(_ context.Context, _, _ string, _ func(string) bool, _ time.Duration) (*api.ClickPipe, error) {
+		return apiPipe, nil
+	})
+	mock.GetClickPipeMock.Set(func(_ context.Context, _, _ string) (*api.ClickPipe, error) {
+		return apiPipe, nil
+	})
+
+	r := &ClickPipeResource{client: mock}
+	resp := driveClickPipeUpdate(ctx, t, r, state, plan)
+	require.False(t, resp.Diagnostics.HasError(), "update failed: %v", resp.Diagnostics.Errors())
+
+	require.NotNil(t, captured, "UpdateClickPipe was not called")
+	require.NotNil(t, captured.Source, "update payload carries no source")
+	kafka := captured.Source.Kafka
+	require.NotNil(t, kafka, "update payload carries no kafka source")
+
+	require.NotNil(t, kafka.Credentials, "rotated credentials must be carried")
+	require.NotNil(t, kafka.Credentials.ClickPipeSourceCredentials, "rotated credentials must carry username/password")
+	assert.Equal(t, "kuser", kafka.Credentials.Username)
+	assert.Equal(t, "rotated-pass", kafka.Credentials.Password)
+
+	assert.Nil(t, kafka.SchemaRegistry, "schema registry must never be sent on update")
+	assert.Empty(t, kafka.Brokers, "immutable brokers must be omitted")
+	assert.Nil(t, kafka.ConsumerGroup, "immutable consumer group must be omitted")
+}

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
@@ -60,8 +60,9 @@ func (r requiresReplaceIfSchemaRegistryChanges) PlanModifyObject(_ context.Conte
 	}
 
 	state, plan := req.StateValue, req.PlanValue
-	// Unknown values cannot prove a change; never plan a destructive replacement on a guess.
-	if state.IsUnknown() || plan.IsUnknown() {
+	// Never plan a destructive replacement on an unknown value, but warn
+	if plan.IsUnknown() {
+		addUnknownSchemaRegistryWarning(req.Path, resp)
 		return
 	}
 	if state.IsNull() && plan.IsNull() {
@@ -89,16 +90,33 @@ func (r requiresReplaceIfSchemaRegistryChanges) PlanModifyObject(_ context.Conte
 	// `terraform import` cannot read credentials, so the first post-import plan sees config
 	// credentials against null state credentials; that difference alone must not force a replacement.
 	stateCreds, ok := stateAttrs["credentials"].(types.Object)
-	if !ok || stateCreds.IsNull() || stateCreds.IsUnknown() {
+	if !ok || stateCreds.IsNull() {
 		return
 	}
 	planCreds, ok := planAttrs["credentials"].(types.Object)
-	if !ok || planCreds.IsUnknown() {
+	if !ok {
+		return
+	}
+	if planCreds.IsUnknown() {
+		addUnknownSchemaRegistryWarning(req.Path, resp)
 		return
 	}
 	if credentialsObjectChanged(planCreds, stateCreds) {
 		resp.RequiresReplace = true
 	}
+}
+
+func addUnknownSchemaRegistryWarning(p path.Path, resp *planmodifier.ObjectResponse) {
+	resp.Diagnostics.AddAttributeWarning(
+		p,
+		"Schema registry change cannot be determined",
+		"The planned schema registry value is not known until apply, so the provider cannot tell "+
+			"whether it differs from the pipe's immutable schema registry. Unknown values are recorded "+
+			"in state but never sent to the API, so the live pipe keeps its current schema registry. "+
+			"To rotate schema registry credentials, replace the pipe: run `terraform apply -replace=...` "+
+			"with this pipe's resource address, or bump `password_wo_version`, which forces replacement "+
+			"at plan time.",
+	)
 }
 
 // planStateAttribute decides the planned `state` and must run as ModifyPlan's

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
@@ -42,6 +42,65 @@ func (r requiresReplaceIfSourceTypeChanges) PlanModifyObject(ctx context.Context
 	// If both are null (staying null), no replacement needed
 }
 
+type requiresReplaceIfSchemaRegistryChanges struct{}
+
+func (r requiresReplaceIfSchemaRegistryChanges) Description(_ context.Context) string {
+	return "Requires replacement if the schema registry changes (it is immutable after creation). " +
+		"Credential differences are ignored while the state holds no credentials (fresh import)."
+}
+
+func (r requiresReplaceIfSchemaRegistryChanges) MarkdownDescription(ctx context.Context) string {
+	return r.Description(ctx)
+}
+
+func (r requiresReplaceIfSchemaRegistryChanges) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// If we're creating or destroying the entire resource, don't need to check
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	state, plan := req.StateValue, req.PlanValue
+	// Unknown values cannot prove a change; never plan a destructive replacement on a guess.
+	if state.IsUnknown() || plan.IsUnknown() {
+		return
+	}
+	if state.IsNull() && plan.IsNull() {
+		return
+	}
+	// Adding a registry to a pipe without one (or removing it) is an immutable change.
+	if state.IsNull() != plan.IsNull() {
+		resp.RequiresReplace = true
+		return
+	}
+
+	stateAttrs, planAttrs := state.Attributes(), plan.Attributes()
+	for name, stateVal := range stateAttrs {
+		if name == "credentials" {
+			continue
+		}
+		planVal, ok := planAttrs[name]
+		if !ok || !planVal.Equal(stateVal) {
+			resp.RequiresReplace = true
+			return
+		}
+	}
+
+	// Credentials: compare only once state holds them.
+	// `terraform import` cannot read credentials, so the first post-import plan sees config
+	// credentials against null state credentials; that difference alone must not force a replacement.
+	stateCreds, ok := stateAttrs["credentials"].(types.Object)
+	if !ok || stateCreds.IsNull() || stateCreds.IsUnknown() {
+		return
+	}
+	planCreds, ok := planAttrs["credentials"].(types.Object)
+	if !ok || planCreds.IsUnknown() {
+		return
+	}
+	if credentialsObjectChanged(planCreds, stateCreds) {
+		resp.RequiresReplace = true
+	}
+}
+
 // planStateAttribute decides the planned `state` and must run as ModifyPlan's
 // final step: the framework marks `state` Unknown whenever the proposed plan
 // differs from prior state, even when ModifyPlan's repairs resolve the

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers.go
@@ -80,7 +80,17 @@ func (r requiresReplaceIfSchemaRegistryChanges) PlanModifyObject(_ context.Conte
 			continue
 		}
 		planVal, ok := planAttrs[name]
-		if !ok || !planVal.Equal(stateVal) {
+		if !ok {
+			resp.RequiresReplace = true
+			return
+		}
+		// A value not known until apply (e.g. url from another resource's output) can't
+		// prove a change; warn rather than force a destructive replacement on a guess.
+		if planVal.IsUnknown() {
+			addUnknownSchemaRegistryWarning(req.Path, resp)
+			return
+		}
+		if !planVal.Equal(stateVal) {
 			resp.RequiresReplace = true
 			return
 		}
@@ -112,10 +122,8 @@ func addUnknownSchemaRegistryWarning(p path.Path, resp *planmodifier.ObjectRespo
 		"Schema registry change cannot be determined",
 		"The planned schema registry value is not known until apply, so the provider cannot tell "+
 			"whether it differs from the pipe's immutable schema registry. Unknown values are recorded "+
-			"in state but never sent to the API, so the live pipe keeps its current schema registry. "+
-			"To rotate schema registry credentials, replace the pipe: run `terraform apply -replace=...` "+
-			"with this pipe's resource address, or bump `password_wo_version`, which forces replacement "+
-			"at plan time.",
+			"in state but are never sent to the API, so the live pipe keeps its current schema registry. "+
+			"To change the schema registry, recreate the pipe.",
 	)
 }
 

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
@@ -237,6 +237,18 @@ func TestRequiresReplaceIfSchemaRegistryChanges(t *testing.T) {
 			expectedRequiresReplace: false,
 			expectedWarning:         true,
 		},
+		"plan-url-unknown": {
+			stateRaw:   updateRaw,
+			planRaw:    updateRaw,
+			stateValue: sr("https://sr.example", "PLAIN", knownCreds),
+			planValue: types.ObjectValueMust(srType, map[string]attr.Value{
+				"url":            types.StringUnknown(),
+				"authentication": types.StringValue("PLAIN"),
+				"credentials":    knownCreds,
+			}),
+			expectedRequiresReplace: false,
+			expectedWarning:         true,
+		},
 		"plan-password-attribute-unknown": {
 			stateRaw:                updateRaw,
 			planRaw:                 updateRaw,

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickhouse/resource/models"
 )
 
 func TestRequiresReplaceIfSourceTypeChanges(t *testing.T) {
@@ -127,5 +129,142 @@ func TestRequiresReplaceIfSourceTypeChanges_Description(t *testing.T) {
 	markdownDescription := modifier.MarkdownDescription(context.Background())
 	if markdownDescription == "" {
 		t.Error("MarkdownDescription should not be empty")
+	}
+}
+
+func TestRequiresReplaceIfSchemaRegistryChanges(t *testing.T) {
+	t.Parallel()
+
+	credsType := models.ClickPipeSourceCredentialsModel{}.ObjectType().AttrTypes
+	srType := models.ClickPipeKafkaSchemaRegistryModel{}.ObjectType().AttrTypes
+
+	creds := func(username, password types.String, woVersion types.Int64) types.Object {
+		return types.ObjectValueMust(credsType, map[string]attr.Value{
+			"username":            username,
+			"password":            password,
+			"password_wo":         types.StringNull(),
+			"password_wo_version": woVersion,
+		})
+	}
+	sr := func(url, auth string, credentials types.Object) types.Object {
+		return types.ObjectValueMust(srType, map[string]attr.Value{
+			"url":            types.StringValue(url),
+			"authentication": types.StringValue(auth),
+			"credentials":    credentials,
+		})
+	}
+
+	knownCreds := creds(types.StringValue("sr-user"), types.StringValue("sr-pass"), types.Int64Null())
+	updateRaw := tftypes.NewValue(tftypes.Object{}, map[string]tftypes.Value{})
+
+	testCases := map[string]struct {
+		stateRaw                tftypes.Value
+		planRaw                 tftypes.Value
+		stateValue              types.Object
+		planValue               types.Object
+		expectedRequiresReplace bool
+	}{
+		"null-to-null": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              types.ObjectNull(srType),
+			planValue:               types.ObjectNull(srType),
+			expectedRequiresReplace: false,
+		},
+		"adding-registry": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              types.ObjectNull(srType),
+			planValue:               sr("https://sr.example", "PLAIN", knownCreds),
+			expectedRequiresReplace: true,
+		},
+		"removing-registry": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               types.ObjectNull(srType),
+			expectedRequiresReplace: true,
+		},
+		"identical": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               sr("https://sr.example", "PLAIN", knownCreds),
+			expectedRequiresReplace: false,
+		},
+		"url-changed": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               sr("https://other.example", "PLAIN", knownCreds),
+			expectedRequiresReplace: true,
+		},
+		"credentials-changed": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               sr("https://sr.example", "PLAIN", creds(types.StringValue("sr-user"), types.StringValue("rotated"), types.Int64Null())),
+			expectedRequiresReplace: true,
+		},
+		"wo-version-bump": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", creds(types.StringValue("sr-user"), types.StringNull(), types.Int64Value(1))),
+			planValue:               sr("https://sr.example", "PLAIN", creds(types.StringValue("sr-user"), types.StringNull(), types.Int64Value(2))),
+			expectedRequiresReplace: true,
+		},
+		"import-reconciliation-null-state-credentials": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", types.ObjectNull(credsType)),
+			planValue:               sr("https://sr.example", "PLAIN", knownCreds),
+			expectedRequiresReplace: false,
+		},
+		"plan-credentials-unknown": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               sr("https://sr.example", "PLAIN", types.ObjectUnknown(credsType)),
+			expectedRequiresReplace: false,
+		},
+		"creating-resource": {
+			stateRaw:                tftypes.NewValue(tftypes.Object{}, nil),
+			planRaw:                 updateRaw,
+			stateValue:              types.ObjectNull(srType),
+			planValue:               sr("https://sr.example", "PLAIN", knownCreds),
+			expectedRequiresReplace: false,
+		},
+		"destroying-resource": {
+			stateRaw:                updateRaw,
+			planRaw:                 tftypes.NewValue(tftypes.Object{}, nil),
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               types.ObjectNull(srType),
+			expectedRequiresReplace: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			modifier := requiresReplaceIfSchemaRegistryChanges{}
+			req := planmodifier.ObjectRequest{
+				State: tfsdk.State{
+					Raw: testCase.stateRaw,
+				},
+				Plan: tfsdk.Plan{
+					Raw: testCase.planRaw,
+				},
+				StateValue: testCase.stateValue,
+				PlanValue:  testCase.planValue,
+			}
+			resp := &planmodifier.ObjectResponse{}
+
+			modifier.PlanModifyObject(context.Background(), req, resp)
+
+			if resp.RequiresReplace != testCase.expectedRequiresReplace {
+				t.Errorf("expected RequiresReplace to be %v, got %v", testCase.expectedRequiresReplace, resp.RequiresReplace)
+			}
+		})
 	}
 }

--- a/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_plan_modifiers_test.go
@@ -163,6 +163,7 @@ func TestRequiresReplaceIfSchemaRegistryChanges(t *testing.T) {
 		stateValue              types.Object
 		planValue               types.Object
 		expectedRequiresReplace bool
+		expectedWarning         bool
 	}{
 		"null-to-null": {
 			stateRaw:                updateRaw,
@@ -226,6 +227,22 @@ func TestRequiresReplaceIfSchemaRegistryChanges(t *testing.T) {
 			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
 			planValue:               sr("https://sr.example", "PLAIN", types.ObjectUnknown(credsType)),
 			expectedRequiresReplace: false,
+			expectedWarning:         true,
+		},
+		"plan-registry-unknown": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               types.ObjectUnknown(srType),
+			expectedRequiresReplace: false,
+			expectedWarning:         true,
+		},
+		"plan-password-attribute-unknown": {
+			stateRaw:                updateRaw,
+			planRaw:                 updateRaw,
+			stateValue:              sr("https://sr.example", "PLAIN", knownCreds),
+			planValue:               sr("https://sr.example", "PLAIN", creds(types.StringValue("sr-user"), types.StringUnknown(), types.Int64Null())),
+			expectedRequiresReplace: true,
 		},
 		"creating-resource": {
 			stateRaw:                tftypes.NewValue(tftypes.Object{}, nil),
@@ -264,6 +281,9 @@ func TestRequiresReplaceIfSchemaRegistryChanges(t *testing.T) {
 
 			if resp.RequiresReplace != testCase.expectedRequiresReplace {
 				t.Errorf("expected RequiresReplace to be %v, got %v", testCase.expectedRequiresReplace, resp.RequiresReplace)
+			}
+			if hasWarning := resp.Diagnostics.WarningsCount() > 0; hasWarning != testCase.expectedWarning {
+				t.Errorf("expected warning presence to be %v, got diagnostics: %v", testCase.expectedWarning, resp.Diagnostics)
 			}
 		})
 	}


### PR DESCRIPTION
Importing a Kafka pipe with a schema registry, then applying, failed with a 400 due to a validation error. This PR fixes the provider-side contributors to this bug.

**Changes:**
- Schema registry is immutable, so changing it now forces replacement.
  - The first plan post-import has no credentials in state, so it does not force replacement here.
  - Unknown-at-plan-time values do not force replacement, but warn.
- Stop sending immutable Kafka fields on update. Mutable fields are still sent when they change.
- Clarify documentation and messages related to Kafka pipe immutable fields.

See [CLP-1103](https://linear.app/clickhouse/issue/CLP-1103/bug-in-terraform-provider-v3173-preventing-clickpipe-updates-with) for companion OpenAPI PR and testing.