### PR TITLE
feat(clickpipes): add partition_by_expr to Postgres CDC table_mappings

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -558,6 +558,7 @@ Required:
 Optional:
 
 - `excluded_columns` (Set of String) Columns to exclude from replication.
+- `partition_by_expr` (String) ClickHouse PARTITION BY expression applied to the destination table when ClickPipes creates it. Cannot be changed on an existing table mapping: remove the mapping in one apply, then re-add it with the new value in a subsequent apply (re-adding re-snapshots the table).
 - `partition_key` (String) Custom partitioning column used for parallel snapshotting. Only beneficial for PostgreSQL 13 (no benefit for PG14+, which supports indexed ctid scans). Must be an indexed column of type: `smallint`, `integer`, `bigint`, `timestamp without time zone`, or `timestamp with time zone`. Unrelated to ClickHouse partitioning.
 - `sorting_keys` (List of String) Ordered list of columns to use as sorting key for the target table. Required when use_custom_sorting_key is true.
 - `table_engine` (String) Table engine to use for the target table. (`MergeTree`, `ReplacingMergeTree`, `Null`)

--- a/internal/api/clickpipe_models.go
+++ b/internal/api/clickpipe_models.go
@@ -210,6 +210,7 @@ type ClickPipePostgresTableMapping struct {
 	SortingKeys         []string `json:"sortingKeys,omitempty"`
 	TableEngine         *string  `json:"tableEngine,omitempty"`
 	PartitionKey        *string  `json:"partitionKey,omitempty"`
+	PartitionByExpr     *string  `json:"partitionByExpr,omitempty"`
 }
 
 type ClickPipeMySQLSource struct {

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -1121,6 +1121,15 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										"partition_by_expr": schema.StringAttribute{
 											Description: "ClickHouse PARTITION BY expression applied to the destination table when ClickPipes creates it. Cannot be changed on an existing table mapping: remove the mapping in one apply, then re-add it with the new value in a subsequent apply (re-adding re-snapshots the table).",
 											Optional:    true,
+											Validators: []validator.String{
+												// The API stores a blank expression as unset, which reads
+												// back as null and would produce "inconsistent result
+												// after apply". Omit the attribute instead of blanking it.
+												stringvalidator.RegexMatches(
+													regexp.MustCompile(`\S`),
+													"must not be empty or whitespace-only; omit the attribute instead",
+												),
+											},
 										},
 									},
 								},

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -1118,6 +1118,10 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 											Description: "Custom partitioning column used for parallel snapshotting. Only beneficial for PostgreSQL 13 (no benefit for PG14+, which supports indexed ctid scans). Must be an indexed column of type: `smallint`, `integer`, `bigint`, `timestamp without time zone`, or `timestamp with time zone`. Unrelated to ClickHouse partitioning.",
 											Optional:    true,
 										},
+										"partition_by_expr": schema.StringAttribute{
+											Description: "ClickHouse PARTITION BY expression applied to the destination table when ClickPipes creates it. Cannot be changed on an existing table mapping: remove the mapping in one apply, then re-add it with the new value in a subsequent apply (re-adding re-snapshots the table).",
+											Optional:    true,
+										},
 									},
 								},
 							},
@@ -2377,6 +2381,15 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 										} else if !stateMapping.UseCustomSortingKey.Equal(planMapping.UseCustomSortingKey) {
 											changed = true
 											changeDetail = "use_custom_sorting_key"
+										} else if !stateMapping.TableEngine.Equal(planMapping.TableEngine) {
+											changed = true
+											changeDetail = "table_engine"
+										} else if !stateMapping.PartitionKey.Equal(planMapping.PartitionKey) {
+											changed = true
+											changeDetail = "partition_key"
+										} else if !stateMapping.PartitionByExpr.Equal(planMapping.PartitionByExpr) {
+											changed = true
+											changeDetail = "partition_by_expr"
 										}
 
 										if changed {
@@ -3428,6 +3441,10 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 					mapping.PartitionKey = mappingModel.PartitionKey.ValueStringPointer()
 				}
 
+				if !mappingModel.PartitionByExpr.IsNull() {
+					mapping.PartitionByExpr = mappingModel.PartitionByExpr.ValueStringPointer()
+				}
+
 				tableMappings[i] = mapping
 			}
 		}
@@ -3764,6 +3781,10 @@ func (c *ClickPipeResource) convertTableMappingModelToAPI(ctx context.Context, d
 
 	if !mappingModel.PartitionKey.IsNull() {
 		mapping.PartitionKey = mappingModel.PartitionKey.ValueStringPointer()
+	}
+
+	if !mappingModel.PartitionByExpr.IsNull() {
+		mapping.PartitionByExpr = mappingModel.PartitionByExpr.ValueStringPointer()
 	}
 
 	return mapping
@@ -4402,6 +4423,12 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 				tableMappingModel.PartitionKey = types.StringValue(*mapping.PartitionKey)
 			} else {
 				tableMappingModel.PartitionKey = types.StringNull()
+			}
+
+			if mapping.PartitionByExpr != nil && *mapping.PartitionByExpr != "" {
+				tableMappingModel.PartitionByExpr = types.StringValue(*mapping.PartitionByExpr)
+			} else {
+				tableMappingModel.PartitionByExpr = types.StringNull()
 			}
 
 			tableMappingList = append(tableMappingList, tableMappingModel.ObjectValue())
@@ -5281,6 +5308,11 @@ func (c *ClickPipeResource) Update(ctx context.Context, req resource.UpdateReque
 						stateMappingsMap[key] = mapping
 					}
 
+					// Key-existence checks are sufficient here: in-place edits to an
+					// existing mapping (target_table, table_engine, partition_key,
+					// partition_by_expr, ...) are rejected at plan time by ModifyPlan's
+					// mapping-immutability guard, and the API refuses add+remove of the
+					// same source table in one PATCH anyway.
 					// Find mappings to add (in plan but not in state)
 					var tableMappingsToAdd []api.ClickPipePostgresTableMapping
 					for key, mapping := range planMappingsMap {

--- a/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"context"
+	"maps"
 	"strings"
 	"testing"
 
@@ -106,6 +107,7 @@ func buildPostgresPlanWithCredentials(credentials types.Object) models.ClickPipe
 		"sorting_keys":           types.ListNull(types.StringType),
 		"table_engine":           types.StringNull(),
 		"partition_key":          types.StringNull(),
+		"partition_by_expr":      types.StringNull(),
 	}
 	pgAttrs := map[string]attr.Value{
 		"type":           types.StringValue("postgres"),
@@ -599,6 +601,7 @@ func postgresPlanWithExcludedColumns(ctx context.Context, excludedColumns []stri
 		"sorting_keys":           types.ListNull(types.StringType), // sorting_keys stays an ordered List
 		"table_engine":           types.StringNull(),
 		"partition_key":          types.StringNull(),
+		"partition_by_expr":      types.StringNull(),
 	}
 
 	var src models.ClickPipeSourceModel
@@ -616,8 +619,11 @@ func postgresPlanWithExcludedColumns(ctx context.Context, excludedColumns []stri
 	return state
 }
 
-func TestClickPipeResource_ModifyPlan_ExcludedColumnsReorder_Issue558(t *testing.T) {
-	ctx := context.Background()
+// driveClickPipeModifyPlan encodes the given state/plan models against the
+// resource schema and drives ModifyPlan for an update (non-null state + plan),
+// returning the resulting diagnostics.
+func driveClickPipeModifyPlan(ctx context.Context, t *testing.T, stateModel, planModel models.ClickPipeResourceModel) diag.Diagnostics {
+	t.Helper()
 	r := &ClickPipeResource{}
 
 	schemaResp := &resource.SchemaResponse{}
@@ -627,39 +633,43 @@ func TestClickPipeResource_ModifyPlan_ExcludedColumnsReorder_Issue558(t *testing
 	}
 	sch := schemaResp.Schema
 
-	// run drives ModifyPlan for an update (non-null state + plan) and returns the
-	// resulting diagnostics.
-	run := func(t *testing.T, stateModel, planModel models.ClickPipeResourceModel) diag.Diagnostics {
-		t.Helper()
-		stateVal := tfsdk.State{Schema: sch}
-		if d := stateVal.Set(ctx, &stateModel); d.HasError() {
-			t.Fatalf("encoding prior state failed: %v", d.Errors())
-		}
-		planVal := tfsdk.Plan{Schema: sch}
-		if d := planVal.Set(ctx, &planModel); d.HasError() {
-			t.Fatalf("encoding plan failed: %v", d.Errors())
-		}
-		req := resource.ModifyPlanRequest{
-			State:  stateVal,
-			Plan:   planVal,
-			Config: tfsdk.Config{Schema: sch, Raw: planVal.Raw},
-		}
-		resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Schema: sch, Raw: planVal.Raw}}
-		r.ModifyPlan(ctx, req, resp)
-		return resp.Diagnostics
+	stateVal := tfsdk.State{Schema: sch}
+	if d := stateVal.Set(ctx, &stateModel); d.HasError() {
+		t.Fatalf("encoding prior state failed: %v", d.Errors())
 	}
+	planVal := tfsdk.Plan{Schema: sch}
+	if d := planVal.Set(ctx, &planModel); d.HasError() {
+		t.Fatalf("encoding plan failed: %v", d.Errors())
+	}
+	req := resource.ModifyPlanRequest{
+		State:  stateVal,
+		Plan:   planVal,
+		Config: tfsdk.Config{Schema: sch, Raw: planVal.Raw},
+	}
+	resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Schema: sch, Raw: planVal.Raw}}
+	r.ModifyPlan(ctx, req, resp)
+	return resp.Diagnostics
+}
 
-	// detailContains reports whether any error diagnostic's detail contains substr.
-	// We assert on the specific immutability message rather than HasError() so the
-	// test is robust against unrelated ModifyPlan diagnostics.
-	detailContains := func(diags diag.Diagnostics, substr string) bool {
-		for _, d := range diags.Errors() {
-			if strings.Contains(d.Detail(), substr) {
-				return true
-			}
+// errorDetailContains reports whether any error diagnostic's detail contains
+// substr. Tests assert on the specific immutability message rather than
+// HasError() so they are robust against unrelated ModifyPlan diagnostics.
+func errorDetailContains(diags diag.Diagnostics, substr string) bool {
+	for _, d := range diags.Errors() {
+		if strings.Contains(d.Detail(), substr) {
+			return true
 		}
-		return false
 	}
+	return false
+}
+
+func TestClickPipeResource_ModifyPlan_ExcludedColumnsReorder_Issue558(t *testing.T) {
+	ctx := context.Background()
+
+	run := func(t *testing.T, stateModel, planModel models.ClickPipeResourceModel) diag.Diagnostics {
+		return driveClickPipeModifyPlan(ctx, t, stateModel, planModel)
+	}
+	detailContains := errorDetailContains
 
 	t.Run("reordered excluded_columns is not a forbidden modification", func(t *testing.T) {
 		// state = order a refresh wrote (API order); plan = config order. Same set.
@@ -681,6 +691,73 @@ func TestClickPipeResource_ModifyPlan_ExcludedColumnsReorder_Issue558(t *testing
 
 		assert.True(t, detailContains(diags, "Cannot modify target_table"),
 			"a real target_table change on an existing mapping must still be rejected; got: %v", diags.Errors())
+	})
+}
+
+// setPostgresMappingAttr rebuilds the model's single Postgres table mapping with
+// one attribute replaced.
+func setPostgresMappingAttr(ctx context.Context, t *testing.T, m *models.ClickPipeResourceModel, field string, v attr.Value) {
+	t.Helper()
+	var src models.ClickPipeSourceModel
+	if d := m.Source.As(ctx, &src, basetypes.ObjectAsOptions{}); d.HasError() {
+		t.Fatalf("decoding source failed: %v", d.Errors())
+	}
+	var pg models.ClickPipePostgresSourceModel
+	if d := src.Postgres.As(ctx, &pg, basetypes.ObjectAsOptions{}); d.HasError() {
+		t.Fatalf("decoding postgres source failed: %v", d.Errors())
+	}
+
+	elems := pg.TableMappings.Elements()
+	if len(elems) != 1 {
+		t.Fatalf("fixture must have exactly one table mapping, got %d", len(elems))
+	}
+	attrs := maps.Clone(elems[0].(types.Object).Attributes())
+	attrs[field] = v
+	pg.TableMappings = types.SetValueMust(
+		models.ClickPipePostgresTableMappingModel{}.ObjectType(),
+		[]attr.Value{types.ObjectValueMust(models.ClickPipePostgresTableMappingModel{}.ObjectType().AttrTypes, attrs)},
+	)
+	src.Postgres = pg.ObjectValue()
+	m.Source = src.ObjectValue()
+}
+
+// Issue #648 — table_engine, partition_key, and partition_by_expr were missing
+// from ModifyPlan's mapping-immutability checklist, so changing one on an
+// existing mapping slipped past the plan and silently no-op'd in Update. The
+// API rejects add+remove of the same source table in one PATCH by design
+// (a re-add would re-snapshot into the populated destination table), so there
+// is no in-place edit to fall back on: the plan-time error is the contract.
+func TestClickPipeResource_ModifyPlan_MappingValueFieldsImmutable_Issue648(t *testing.T) {
+	ctx := context.Background()
+
+	valueFields := map[string]attr.Value{
+		"table_engine":      types.StringValue("Null"),
+		"partition_key":     types.StringValue("id"),
+		"partition_by_expr": types.StringValue("toYYYYMM(created_at)"),
+	}
+	for field, newValue := range valueFields {
+		t.Run("changing "+field+" is rejected at plan time", func(t *testing.T) {
+			state := postgresPlanWithExcludedColumns(ctx, []string{"status"}, "users")
+			plan := postgresPlanWithExcludedColumns(ctx, []string{"status"}, "users")
+			setPostgresMappingAttr(ctx, t, &plan, field, newValue)
+
+			diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+			assert.True(t, errorDetailContains(diags, "Cannot modify "+field),
+				"a %s change on an existing mapping must be rejected at plan time; got: %v", field, diags.Errors())
+		})
+	}
+
+	t.Run("identical value fields do not trip the guard", func(t *testing.T) {
+		state := postgresPlanWithExcludedColumns(ctx, []string{"status"}, "users")
+		plan := postgresPlanWithExcludedColumns(ctx, []string{"status"}, "users")
+		setPostgresMappingAttr(ctx, t, &state, "partition_by_expr", types.StringValue("toYYYYMM(created_at)"))
+		setPostgresMappingAttr(ctx, t, &plan, "partition_by_expr", types.StringValue("toYYYYMM(created_at)"))
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.False(t, errorDetailContains(diags, "Cannot modify"),
+			"an unchanged mapping must not be flagged; got: %v", diags.Errors())
 	})
 }
 

--- a/internal/service/clickhouse/resource/clickpipe_pause_before_edit_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_pause_before_edit_test.go
@@ -88,6 +88,7 @@ func postgresUpdateModel(ctx context.Context, t *testing.T, tables ...string) mo
 			"sorting_keys":           types.ListNull(types.StringType),
 			"table_engine":           types.StringNull(),
 			"partition_key":          types.StringNull(),
+			"partition_by_expr":      types.StringNull(),
 		})
 	}
 

--- a/internal/service/clickhouse/resource/clickpipe_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_test.go
@@ -454,6 +454,7 @@ func getPostgresInitialState() models.ClickPipeResourceModel {
 									"sorting_keys":           types.ListNull(types.StringType),
 									"table_engine":           types.StringNull(),
 									"partition_key":          types.StringNull(),
+									"partition_by_expr":      types.StringNull(),
 								},
 							),
 						},

--- a/internal/service/clickhouse/resource/models/clickpipe_resource.go
+++ b/internal/service/clickhouse/resource/models/clickpipe_resource.go
@@ -372,6 +372,7 @@ type ClickPipePostgresTableMappingModel struct {
 	SortingKeys         types.List   `tfsdk:"sorting_keys"`
 	TableEngine         types.String `tfsdk:"table_engine"`
 	PartitionKey        types.String `tfsdk:"partition_key"`
+	PartitionByExpr     types.String `tfsdk:"partition_by_expr"`
 }
 
 func (m ClickPipePostgresTableMappingModel) ObjectType() types.ObjectType {
@@ -385,6 +386,7 @@ func (m ClickPipePostgresTableMappingModel) ObjectType() types.ObjectType {
 			"sorting_keys":           types.ListType{ElemType: types.StringType},
 			"table_engine":           types.StringType,
 			"partition_key":          types.StringType,
+			"partition_by_expr":      types.StringType,
 		},
 	}
 }
@@ -399,6 +401,7 @@ func (m ClickPipePostgresTableMappingModel) ObjectValue() types.Object {
 		"sorting_keys":           m.SortingKeys,
 		"table_engine":           m.TableEngine,
 		"partition_key":          m.PartitionKey,
+		"partition_by_expr":      m.PartitionByExpr,
 	})
 }
 


### PR DESCRIPTION
Closes #648.

## What

Exposes the API's `partitionByExpr` on Postgres CDC `table_mappings`, so the destination table's ClickHouse `PARTITION BY` expression can be set declaratively when ClickPipes creates the table. Only Postgres CDC supports this field per the control-plane OpenAPI spec — MySQL and MongoDB table mappings don't have it.

```hcl
table_mappings = [{
  source_schema_name = "public"
  source_table       = "events"
  target_table       = "events"
  partition_by_expr  = "toYYYYMM(created_at)"
}]
```

## Also fixes: ModifyPlan mapping-immutability guard gap

The plan-time guard that rejects in-place edits to existing table mappings ("Cannot modify X for existing table mapping...") had a stale field checklist: it covered `target_table`, `excluded_columns`, `sorting_keys`, and `use_custom_sorting_key`, but was never extended when `table_engine`/`partition_key` were added. Changing one of those on an existing mapping slipped past the plan, was silently omitted from the Update PATCH (the add/remove diff keys on mapping identity), and surfaced as a confusing "Provider produced inconsistent result after apply".

`table_engine`, `partition_key`, and `partition_by_expr` are now in the checklist, so these edits fail at `terraform plan` with the guard's existing remove-the-mapping-and-re-add guidance.

An in-place edit cannot be expressed against the API at all: the control plane rejects add+remove of the same source table within a single PATCH by design, because re-adding a mapping re-snapshots into the already-populated destination table. The plan-time error (rather than an apply-time 400 on an already-paused pipe) is therefore the contract. No false positives for existing configs: state sync preserves null `table_engine` when the API echoes a server default and maps empty `partition_key`/`partition_by_expr` to null, covered by the "identical value fields" subtest.

## Testing

- `TestClickPipeResource_ModifyPlan_MappingValueFieldsImmutable_Issue648`: per-field plan-time rejection subtests + a no-false-positive control.
- Existing #558 guard tests still pass (their plan-driver closures were extracted into shared helpers).
- `go build ./...`, full `go test ./...`, `gofmt`, and `make docs-alpha` drift check all clean.

## Follow-up (out of scope)

The MySQL mapping guard has the same stale-checklist gap for `table_engine`/`partition_key` — same one-line-per-field fix when picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)