### PR TITLE
fix(e2e): update azurerm private DNS attrs for v5 schema

### DIFF
--- a/examples/full/private_endpoint/azure/azure.tf
+++ b/examples/full/private_endpoint/azure/azure.tf
@@ -94,15 +94,13 @@ resource "azurerm_private_dns_zone" "clickhouse_cloud_private_link_zone" {
 
 resource "azurerm_private_dns_a_record" "this" {
   name                = "*"
-  zone_name           = azurerm_private_dns_zone.clickhouse_cloud_private_link_zone.name
-  resource_group_name = azurerm_resource_group.this.name
+  private_dns_zone_id = azurerm_private_dns_zone.clickhouse_cloud_private_link_zone.id
   ttl                 = 300
   records             = azurerm_private_endpoint.this.private_service_connection[*].private_ip_address
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "this" {
-  name                  = "clickhouse-private-link"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.clickhouse_cloud_private_link_zone.name
-  virtual_network_id    = azurerm_virtual_network.this.id
+  name                = "clickhouse-private-link"
+  private_dns_zone_id = azurerm_private_dns_zone.clickhouse_cloud_private_link_zone.id
+  virtual_network_id  = azurerm_virtual_network.this.id
 }


### PR DESCRIPTION
## Summary
- azurerm v5 renamed `zone_name` / `private_dns_zone_name` + `resource_group_name` on `azurerm_private_dns_a_record` and `azurerm_private_dns_zone_virtual_network_link` to a single `private_dns_zone_id`.
- The scheduled E2E `terraform init -upgrade` picked up the new major on July 29, breaking `private_endpoint/azure` on every run since.
- Update the two resources in `examples/full/private_endpoint/azure/azure.tf` to the v5 attribute. `.id` on the zone encodes the RG, so placement and dependency graph are unchanged.

## Test plan
- [ ] Trigger the E2E workflow on this branch (`E2E tests` → `workflow_dispatch`) and confirm `e2e (*, private_endpoint, azure)` reaches apply/destroy.
- [ ] Confirm no other Azure examples regress (`basic`, `clickpipe/kafka_azure_eventhub`, `clickpipe/object_storage_azure_blob`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)