### PR TITLE
chore: match clickpipe example dirs in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # Component globs are intentionally LAST: CODEOWNERS gives the last matching
 # pattern precedence, so these keep routing e.g. ClickPipes reviews to their
 # team even though those files live inside the clickhouse service group.
-**/clickpipe* @ClickHouse/clickpipes
+**/*clickpipe* @ClickHouse/clickpipes
 **/postgres* @ClickHouse/clickgres
 **/clickstack* @ClickHouse/clickstack
 **/*udf* @ClickHouse/sql-ui


### PR DESCRIPTION
`.github/CODEOWNERS` matched only the `/clickpipe*` prefix, so it missed the generated ClickPipes example directories. That meant changes there weren't getting routed to the ClickPipes team. This updates the pattern to `**/*clickpipe*`. 