### PR TITLE
fix(ci): resolve upgrade-test base version from the Terraform registry

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -243,16 +243,22 @@ runs:
 
           if [ "${{ inputs.upgrade_from }}" == "" ]
           then
-            # Get latest stable release
-            LATEST="$(curl -s -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/ClickHouse/terraform-provider-clickhouse/releases/latest | jq -r '.name')"
+            # Ask the registry, not the GitHub releases API: the registry is what
+            # `terraform init` installs from, so it can't name a version this test
+            # is unable to install. Releases sit as drafts for hours after the tag
+            # is pushed, so the two disagree. x.y.z filter drops alpha versions.
+            # `|| true` so a failed fetch reaches the error message below.
+            LATEST="$(curl -sfL https://registry.terraform.io/v1/providers/ClickHouse/clickhouse/versions \
+              | jq -r '.versions[].version | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
+              | sort -V | tail -1)" || true
 
-            if [ "$LATEST" == "null" ]
+            if [ -z "$LATEST" ]
             then
-              echo "Error getting latest release"
+              echo "Error getting latest stable version from the Terraform registry"
               exit 1
             fi
 
-            echo "tag=$LATEST" >> "$GITHUB_OUTPUT"
+            echo "tag=v$LATEST" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${{ inputs.upgrade_from }}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
The Release workflow's `test_upgrade` input promises to "run upgrade test from latest stable version of the plugin to the one being released". It doesn't — during the draft window it silently upgrades from an older release.

## Why

goreleaser creates every release as a draft (`.goreleaser-stable.yml`), and a human publishes it later. That gap is not small:

```
v3.25.0  created=2026-08-11T01:06Z  published=2026-08-11T20:31Z   (19h)
v3.22.0  created=2026-07-24T12:37Z  published=2026-07-24T21:49Z    (9h)
v3.24.0  created=2026-08-05T10:44Z  published=2026-08-05T11:17Z
```

`GET /releases/latest` skips drafts, so anything released inside that window resolves to the *previous* release with no warning. The release run on 2026-08-11 at 11:49 tested the upgrade from **3.24.0**, while the `v3.24.1` and `v3.25.0` tags both already existed:

```
git checkout -f tags/v3.24.0
- Installing clickhouse/clickhouse v3.24.0...
```

So the upgrade path that actually ships gets less coverage than the workflow claims, and the shortfall is invisible in the logs.

## The change

Resolve the version from the Terraform registry instead of the GitHub releases API.

The registry is where `terraform init` installs the provider from, which makes it the only source that cannot name a version this test is then unable to install. The releases API can disagree with it in both directions — a draft release is on GitHub but not the registry, and a published alpha is a non-draft, non-prerelease release that `/releases/latest` could return even though it isn't a stable version. The `x.y.z` filter closes the second case explicitly, so it no longer depends on how goreleaser marks alphas.

Dropping the GitHub call also removes an unauthenticated API request made once per matrix job (~75 per release run, against a 60/hour per-IP limit) — the reason that step carries a 10-attempt retry.

## Verification

Ran the step's shell in isolation across all four paths:

| Path | Result |
|---|---|
| Default | `tag=v3.25.0` (matches the registry's own `.version`) |
| `upgrade_from: v3.20.0` override | `tag=v3.20.0`, unchanged |
| Registry 404 | Error message, exit 1 -> retry wrapper retries |
| Registry unreachable | Error message, exit 1 -> retry wrapper retries |

The `|| true` is important: without it `set -e` plus `pipefail` kills the step before the error message prints, which is what the original code did on a bad response.

Also confirmed the versions endpoint is not paginated (128 versions, no cursor) so `sort -V | tail -1` sees the full set, and that the output format is still `vX.Y.Z` for all three consumers of `steps.get_latest_stable_release.outputs.tag`.

## Note

This closes the alpha-leak case and the rate-limit exposure outright. It does not eliminate the lag itself — while a release is an unpublished draft it genuinely isn't installable, so the test correctly falls back to the previous version. Closing that window means publishing releases sooner (or automatically), which is a separate call.