### PR TITLE
fix(clickstack): make imported sources and dashboards usable without hand edits

### DIFF
--- a/docs/resources/clickstack_dashboard.md
+++ b/docs/resources/clickstack_dashboard.md
@@ -91,4 +91,10 @@ terraform import clickhouse_clickstack_dashboard.collectors 65f0c0ffeecafef00dba
 # For a dashboard in a non-default team (multi-team / EE deployments), prefix the
 # ID with the team ID:
 terraform import clickhouse_clickstack_dashboard.collectors 65f0c0ffeecafef00dba5e01/65f0c0ffeecafef00dba5e02
+
+# `terraform plan -generate-config-out=...` writes the dashboard body with the
+# literal ids the API returns (sourceId on every tile, for instance). Terraform
+# generates config from state alone and cannot know those ids belong to other
+# resources, so replace them by hand to link the dashboard to its sources:
+# sourceId = clickhouse_clickstack_source.traces.id
 ```

--- a/examples/resources/clickhouse_clickstack_dashboard/import.sh
+++ b/examples/resources/clickhouse_clickstack_dashboard/import.sh
@@ -4,3 +4,9 @@ terraform import clickhouse_clickstack_dashboard.collectors 65f0c0ffeecafef00dba
 # For a dashboard in a non-default team (multi-team / EE deployments), prefix the
 # ID with the team ID:
 terraform import clickhouse_clickstack_dashboard.collectors 65f0c0ffeecafef00dba5e01/65f0c0ffeecafef00dba5e02
+
+# `terraform plan -generate-config-out=...` writes the dashboard body with the
+# literal ids the API returns (sourceId on every tile, for instance). Terraform
+# generates config from state alone and cannot know those ids belong to other
+# resources, so replace them by hand to link the dashboard to its sources:
+# sourceId = clickhouse_clickstack_source.traces.id

--- a/internal/service/clickstack/dashboard_resource.go
+++ b/internal/service/clickstack/dashboard_resource.go
@@ -172,13 +172,20 @@ func (r *dashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 	// On import, dashboard_json is null/unknown because no config value exists
 	// yet. Populate it from the fetched body so the imported state is
 	// re-appliable without an immediate diff. The dashboard id and filter ids
-	// are dropped: the API rejects them in an authored body.
+	// are dropped: the API rejects them in an authored body. Select entries are
+	// cleaned up for the same reason — the API exports aggregation fields its own
+	// write schema rejects.
 	if state.DashboardJSON.IsNull() || state.DashboardJSON.IsUnknown() {
 		authored := body
-		if stripped, err := stripServerIDs(body); err == nil {
+		if stripped, err := stripServerIDs(authored); err == nil {
 			authored = stripped
 		} else {
 			tflog.Warn(ctx, "could not strip server-assigned ids from the imported dashboard body: "+err.Error())
+		}
+		if cleaned, err := dropInvalidSelectFields(authored); err == nil {
+			authored = cleaned
+		} else {
+			tflog.Warn(ctx, "could not drop invalid select fields from the imported dashboard body: "+err.Error())
 		}
 		state.DashboardJSON = types.StringValue(string(authored))
 	}

--- a/internal/service/clickstack/dashboard_resource_test.go
+++ b/internal/service/clickstack/dashboard_resource_test.go
@@ -420,6 +420,17 @@ func TestDashboardResource_Read(t *testing.T) {
 			wantNormalized: `{"id":"d1","name":"D","filters":[{"id":"f1","name":"Env"}],"tiles":[]}`,
 		},
 		{
+			// The API exports aggregation fields its own write schema rejects, so
+			// the backfilled body drops them or every plan fails validation.
+			name: "import drops select fields the write schema rejects",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"data":{"id":"d1","name":"D","tiles":[{"name":"T","config":{"select":[{"aggFn":"count","level":0.9,"valueExpression":"Duration"}]}}]}}`))
+			},
+			stateDashJSON:  nil,
+			wantDashJSON:   `{"name":"D","tiles":[{"config":{"select":[{"aggFn":"count"}]},"name":"T"}]}`,
+			wantNormalized: `{"id":"d1","name":"D","tiles":[{"name":"T","config":{"select":[{"aggFn":"count","level":0.9,"valueExpression":"Duration"}]}}]}`,
+		},
+		{
 			name:          "not found removes resource from state",
 			handler:       func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNotFound) },
 			stateDashJSON: ptr(serverBody),

--- a/internal/service/clickstack/dashboard_select_fixups.go
+++ b/internal/service/clickstack/dashboard_select_fixups.go
@@ -1,0 +1,93 @@
+package clickstack
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// The two aggregations the select-entry rules key off.
+const (
+	aggFnCount    = "count"
+	aggFnQuantile = "quantile"
+)
+
+// dropInvalidSelectFields removes fields from a dashboard's select entries that
+// the API exports but its own write schema rejects:
+//
+//	level:           only valid with the quantile aggregation
+//	valueExpression: rejected with the count aggregation
+//
+// Both are leftovers from switching a tile's aggregation in the UI — the
+// dashboard renders fine with them, and the API keeps returning them — but a
+// body containing them fails /dashboards/validate ("tiles.8.config.select.0:
+// Level can only be used with quantile aggregation function"), so an imported
+// dashboard could not be planned without hand edits.
+//
+// It runs on the import path only: an authored body is the operator's to fix,
+// and rewriting it here would hide a real mistake.
+func dropInvalidSelectFields(body json.RawMessage) (json.RawMessage, error) {
+	// Dynamic typing is required: the dashboard body is an arbitrary document
+	// whose schema is not fixed at this layer.
+	var doc any //nolint:forbidigo // generic JSON handling needs dynamic typing
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("drop invalid select fields: parse: %w", err)
+	}
+
+	// Walk the whole document rather than the tiles[].config.select path: an
+	// aggFn identifies a select entry wherever it sits, so this holds if the
+	// dashboard format nests one somewhere new.
+	if !walkJSON(doc, fixSelectEntry) {
+		return body, nil
+	}
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("drop invalid select fields: marshal: %w", err)
+	}
+	return out, nil
+}
+
+// fixSelectEntry drops the incompatible fields from a single select entry,
+// reporting whether it changed anything. Objects without an aggFn are left
+// alone.
+func fixSelectEntry(obj map[string]any) bool { //nolint:forbidigo // generic JSON handling needs dynamic typing
+	aggFn, ok := obj["aggFn"].(string)
+	if !ok {
+		return false
+	}
+
+	changed := false
+	if _, has := obj["level"]; has && aggFn != aggFnQuantile {
+		delete(obj, "level")
+		changed = true
+	}
+	if _, has := obj["valueExpression"]; has && aggFn == aggFnCount {
+		delete(obj, "valueExpression")
+		changed = true
+	}
+	return changed
+}
+
+// walkJSON applies visit to every JSON object in v, depth first, and reports
+// whether any visit changed something.
+func walkJSON(v any, visit func(map[string]any) bool) bool { //nolint:forbidigo // generic JSON handling needs dynamic typing
+	changed := false
+	switch t := v.(type) {
+	case map[string]any: //nolint:forbidigo // generic JSON handling needs dynamic typing
+		if visit(t) {
+			changed = true
+		}
+		for _, child := range t {
+			if walkJSON(child, visit) {
+				changed = true
+			}
+		}
+	case []any: //nolint:forbidigo // generic JSON handling needs dynamic typing
+		for _, child := range t {
+			if walkJSON(child, visit) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}

--- a/internal/service/clickstack/dashboard_select_fixups_test.go
+++ b/internal/service/clickstack/dashboard_select_fixups_test.go
@@ -1,0 +1,85 @@
+package clickstack
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDropInvalidSelectFields covers the bodies the API exports but rejects on
+// write: a level carried over from a quantile aggregation, and a valueExpression
+// left behind when a tile switched to count.
+func TestDropInvalidSelectFields(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, body, want string
+	}{
+		{
+			name: "level dropped on non-quantile aggregation",
+			body: `{"tiles":[{"config":{"select":[{"aggFn":"count","level":0.9,"alias":"p90"}]}}]}`,
+			want: `{"tiles":[{"config":{"select":[{"aggFn":"count","alias":"p90"}]}}]}`,
+		},
+		{
+			name: "level kept on quantile aggregation",
+			body: `{"tiles":[{"config":{"select":[{"aggFn":"quantile","level":0.9,"valueExpression":"Duration"}]}}]}`,
+			want: `{"tiles":[{"config":{"select":[{"aggFn":"quantile","level":0.9,"valueExpression":"Duration"}]}}]}`,
+		},
+		{
+			name: "stale valueExpression dropped on count",
+			body: `{"tiles":[{"config":{"select":[{"aggFn":"count","valueExpression":"Duration","alias":"2xx"}]}}]}`,
+			want: `{"tiles":[{"config":{"select":[{"aggFn":"count","alias":"2xx"}]}}]}`,
+		},
+		{
+			name: "empty valueExpression dropped on count",
+			body: `{"tiles":[{"config":{"select":[{"aggFn":"count","valueExpression":""}]}}]}`,
+			want: `{"tiles":[{"config":{"select":[{"aggFn":"count"}]}}]}`,
+		},
+		{
+			name: "valueExpression kept on non-count aggregation",
+			body: `{"tiles":[{"config":{"select":[{"aggFn":"sum","valueExpression":"Value"}]}}]}`,
+			want: `{"tiles":[{"config":{"select":[{"aggFn":"sum","valueExpression":"Value"}]}}]}`,
+		},
+		{
+			name: "select given as a plain string is untouched",
+			body: `{"tiles":[{"config":{"select":"Timestamp, Body"}}]}`,
+			want: `{"tiles":[{"config":{"select":"Timestamp, Body"}}]}`,
+		},
+		{
+			name: "select nested anywhere else is cleaned too",
+			body: `{"tiles":[{"alert":{"select":[{"aggFn":"count","level":0.5}]}}]}`,
+			want: `{"tiles":[{"alert":{"select":[{"aggFn":"count"}]}}]}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := dropInvalidSelectFields(json.RawMessage(tc.body))
+			if err != nil {
+				t.Fatalf("dropInvalidSelectFields: %v", err)
+			}
+			if !jsonEqual(t, got, json.RawMessage(tc.want)) {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDropInvalidSelectFieldsInvalidJSON(t *testing.T) {
+	t.Parallel()
+	if _, err := dropInvalidSelectFields(json.RawMessage(`{"tiles":`)); err == nil {
+		t.Fatal("expected an error for a malformed body")
+	}
+}
+
+// jsonEqual compares two JSON documents ignoring key order and formatting.
+func jsonEqual(t *testing.T, a, b json.RawMessage) bool {
+	t.Helper()
+	ca, err := canonicalizeJSON(string(a))
+	if err != nil {
+		t.Fatalf("canonicalize %s: %v", a, err)
+	}
+	cb, err := canonicalizeJSON(string(b))
+	if err != nil {
+		t.Fatalf("canonicalize %s: %v", b, err)
+	}
+	return ca == cb
+}

--- a/internal/service/clickstack/plan_modifiers.go
+++ b/internal/service/clickstack/plan_modifiers.go
@@ -102,6 +102,35 @@ func (m rfc3339EqualPlanModifier) PlanModifyString(_ context.Context, req planmo
 	}
 }
 
+// emptyStringEqualsNullPlanModifier treats an unset attribute and an empty
+// string as the same value: when the config omits the attribute and state holds
+// "", the state value is kept so no diff is produced.
+//
+// The ClickStack API echoes an unset optional expression back as "" rather than
+// omitting it, so an imported source whose config leaves those fields out would
+// otherwise show `- event_attributes_expression = "" -> null` as an
+// update-in-place on every plan. Sending "" and sending nothing are equivalent
+// to the API, so keeping "" loses nothing.
+type emptyStringEqualsNullPlanModifier struct{}
+
+func (m emptyStringEqualsNullPlanModifier) Description(_ context.Context) string {
+	return "Treats an omitted attribute and an empty string as equal, so a server-echoed \"\" does not show as a diff."
+}
+
+func (m emptyStringEqualsNullPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m emptyStringEqualsNullPlanModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() || req.StateValue.ValueString() != "" {
+		return
+	}
+	resp.PlanValue = req.StateValue
+}
+
 // jsonEqualPlanModifier suppresses a spurious diff on a JSON-string attribute
 // when the config and stored state are semantically equal (same JSON, possibly
 // reformatted or with reordered object keys).

--- a/internal/service/clickstack/plan_modifiers_test.go
+++ b/internal/service/clickstack/plan_modifiers_test.go
@@ -62,6 +62,34 @@ func TestRFC3339EqualPlanModifier(t *testing.T) {
 	}
 }
 
+func TestEmptyStringEqualsNullPlanModifier(t *testing.T) {
+	t.Parallel()
+	str := types.StringValue
+	cases := []struct {
+		name         string
+		state, cfg   types.String
+		wantSuppress bool // true => plan set to state (no diff)
+	}{
+		{"server-echoed empty against omitted config", str(""), types.StringNull(), true},
+		{"real value against omitted config", str("ResourceAttributes"), types.StringNull(), false},
+		{"empty state against a set config", str(""), str("ResourceAttributes"), false},
+		{"null state (create)", types.StringNull(), str("ResourceAttributes"), false},
+		{"unknown state", types.StringUnknown(), types.StringNull(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resp := planmodifier.StringResponse{PlanValue: tc.cfg}
+			emptyStringEqualsNullPlanModifier{}.PlanModifyString(context.Background(),
+				planmodifier.StringRequest{StateValue: tc.state, ConfigValue: tc.cfg}, &resp)
+			suppressed := resp.PlanValue.Equal(tc.state)
+			if suppressed != tc.wantSuppress {
+				t.Errorf("suppress=%v, want %v (plan=%v)", suppressed, tc.wantSuppress, resp.PlanValue)
+			}
+		})
+	}
+}
+
 func TestJSONEqualPlanModifier(t *testing.T) {
 	t.Parallel()
 	str := types.StringValue

--- a/internal/service/clickstack/source_resource.go
+++ b/internal/service/clickstack/source_resource.go
@@ -141,9 +141,16 @@ func (r *sourceResource) Metadata(_ context.Context, req resource.MetadataReques
 	resp.TypeName = req.ProviderTypeName + "_clickstack_source"
 }
 
-// optStr is a reusable optional string attribute.
+// optStr is a reusable optional string attribute. The API echoes an unset
+// expression back as "", so every one of these treats "" and unset as the same
+// value (see emptyStringEqualsNullPlanModifier) — otherwise an imported source
+// plans an endless no-op update.
 func optStr(desc string) schema.StringAttribute {
-	return schema.StringAttribute{Optional: true, Description: desc}
+	return schema.StringAttribute{
+		Optional:      true,
+		Description:   desc,
+		PlanModifiers: []planmodifier.String{emptyStringEqualsNullPlanModifier{}},
+	}
 }
 
 func (r *sourceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/clickstack/source_resource_test.go
+++ b/internal/service/clickstack/source_resource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickstack/client"
 )
@@ -92,6 +93,28 @@ func TestSourceResource_Schema(t *testing.T) {
 	} {
 		if _, ok := resp.Schema.Attributes[attr]; !ok {
 			t.Errorf("expected resource schema to contain attribute %q", attr)
+		}
+	}
+
+	// Optional expression attributes must treat the API's echoed "" as unset,
+	// otherwise an imported source plans a no-op update forever.
+	for _, attr := range []string{
+		"event_attributes_expression", "resource_attributes_expression",
+		"body_expression", "section",
+	} {
+		s, ok := resp.Schema.Attributes[attr].(schema.StringAttribute)
+		if !ok {
+			t.Errorf("attribute %q is not a string attribute", attr)
+			continue
+		}
+		found := false
+		for _, pm := range s.PlanModifiers {
+			if _, ok := pm.(emptyStringEqualsNullPlanModifier); ok {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("attribute %q is missing emptyStringEqualsNullPlanModifier", attr)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the two problems Vladimir hit while importing existing ClickStack sources and dashboards into Terraform.

Both come from the same thing: the API hands back a value it will not accept if you send it straight back, so the config Terraform writes out during an import does not work as-is.

### Sources plan a no-op update forever

The sources API returns `""` for an optional expression that was never set, instead of leaving the field out. A config that omits the field therefore plans `- event_attributes_expression = "" -> null` as an update-in-place on every plan, and it never goes away.

Optional string attributes on `clickhouse_clickstack_source` now treat `""` and "not set" as the same value. Sending `""` and sending nothing mean the same thing to the API, so a config that does set `""` on purpose keeps working.

### Dashboard import failed validation

The dashboard API returns select entries carrying a `level` on a non-quantile aggregation and a `valueExpression` on a count aggregation — leftovers from switching a tile's aggregation in the UI. Its own write schema rejects both, so every plan after an import failed on

```
tiles.8.config.select.0: Level can only be used with quantile aggregation function
tiles.2.config.select.0: Value expression cannot be used with count aggregation function
```

even though the dashboard renders fine. The body written into state on import now drops those fields. This runs on the import path only — a hand-written body is the operator's to fix, and rewriting it silently would hide a real mistake.

### Also from the thread, not fixed here

- **Literal ids in generated config** (`sourceId = "69b0..."` instead of a reference to the source resource). Terraform generates config from state alone and cannot know an id belongs to another resource, so the provider cannot emit the reference. Added a note to the import docs saying to swap it by hand.
- One case is deliberately left as an error: `valueExpression: ""` on a *non-count* aggregation trips "Value expression is required for non-count aggregation functions". There is no correct value to substitute, so the operator has to fill it in.

### Testing

Unit tests for both fixes (the plan modifier, the select cleanup, and the import path wiring). `make test`, `make lint` and `make docs-check` pass. Acceptance tests cannot cover the `""` case — the OSS API used by `make testacc` returns null for those fields.
