### PR TITLE
chore(codeowners): route component examples to their owning teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,20 @@
 # Component globs are intentionally LAST: CODEOWNERS gives the last matching
 # pattern precedence, so these keep routing e.g. ClickPipes reviews to their
 # team even though those files live inside the clickhouse service group.
-**/*clickpipe* @ClickHouse/clickpipes
-**/postgres* @ClickHouse/clickgres
-**/clickstack* @ClickHouse/clickstack
+#
+# Each component needs two patterns. The first matches files named after the
+# component (docs/resources/udf.md). The second matches everything inside a
+# directory named after it (examples/resources/clickhouse_udf/import.sh, whose
+# own name says nothing about the component) — without it those files fall
+# through to the catch-all above.
+**/*postgres* @ClickHouse/clickgres
+**/*postgres*/** @ClickHouse/clickgres
 **/*udf* @ClickHouse/sql-ui
+**/*udf*/** @ClickHouse/sql-ui
+**/*clickstack* @ClickHouse/clickstack
+**/*clickstack*/** @ClickHouse/clickstack
+# ClickPipes goes last on purpose: its examples are named after the systems they
+# connect to, so examples/clickpipe/cdc_postgres/ is ClickPipes' to review, not
+# ClickGres'.
+**/*clickpipe* @ClickHouse/clickpipes
+**/*clickpipe*/** @ClickHouse/clickpipes


### PR DESCRIPTION
Noticed while raising #659: a two-file clickstack change asked @ClickHouse/cloud-platform-engineering for review. The cause is in CODEOWNERS.

A pattern like `**/*clickstack*` matches a file *named* after the component (`docs/resources/clickstack_dashboard.md`), but not a file whose *directory* carries the name. So `examples/resources/clickhouse_clickstack_dashboard/import.sh` matched nothing except the `*` catch-all on line 2, and the review request went to the fallback owner instead of the team that owns the resource.

Every component has this gap — all of `examples/clickpipe/**`, `examples/full/{postgres,udf,clickpipes}/**`, and the per-resource example directories were owned by the catch-all.

The fix is a second pattern per component (`**/*clickstack*/**`) covering everything inside a directory named after it. Two ordering details:

- ClickPipes goes last. Its examples are named after the systems they connect to, so `examples/clickpipe/cdc_postgres/` matches both the postgres and the clickpipe patterns — last-match-wins keeps it with ClickPipes.
- `**/postgres*` became `**/*postgres*` so `clickhouse_postgres_service` matches at all. The old pattern only matched names *starting* with `postgres`.

### Effect

189 of 611 tracked files move to their component team. Nothing moves off a component team onto the catch-all, and no file changes hands between component teams:

| Pattern | Files |
|---|---|
| `**/*clickpipe*/**` | 152 |
| `**/*clickstack*/**` | 20 |
| `**/*udf*/**` | 10 |
| `**/*postgres*/**` | 7 |

Spot checks: `examples/clickpipe/cdc_postgres/main.tf` -> clickpipes, `examples/full/postgres/aws/main.tf` -> clickgres, `internal/service/postgres/resource/postgres_service.go` -> clickgres (unchanged), `main.go` and `.github/workflows/**` -> cloud-platform-engineering (unchanged).

I worked the before/after ownership out by applying the patterns to `git ls-files` with last-match-wins rather than by reading, so the counts above are the actual set, not an estimate.
