### PR TITLE
fix(clickstack): stop the e2e discovery step failing silently on curl exit 23

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -486,10 +486,23 @@ runs:
         echo "::group::Run terraform destroy"
         cd "examples/full/${{ inputs.test_name }}/${{ inputs.cloud_provider }}"
 
-        # Since destroy runs on failure too, it can now be reached before init
-        # ran or before anything was applied. Without this it fails on its own
-        # terms -- missing variables, no provider -- and buries the real error.
-        if [ ! -d .terraform ] || [ ! -s terraform.tfstate ]
+        # Since destroy runs on failure too, it can now be reached before
+        # anything was applied. Without this it fails on its own terms -- missing
+        # variables, no provider -- and buries the real error.
+        #
+        # Keyed on state holding resources, NOT on .terraform existing: an
+        # example whose only provider is dev-overridden has nothing for init to
+        # install, so no .terraform directory is ever created and that test would
+        # skip its own teardown on every run.
+        # Only skip on a positive count of zero. Unreadable state means resources
+        # probably do exist, so attempt the destroy and let terraform say why.
+        resource_count="unknown"
+        if [ -s terraform.tfstate ]
+        then
+          resource_count="$(jq -r '.resources | length' terraform.tfstate 2>/dev/null || echo unknown)"
+        fi
+
+        if [ ! -s terraform.tfstate ] || [ "$resource_count" = "0" ]
         then
           echo "nothing applied, skipping destroy"
           echo "::endgroup::"

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -486,6 +486,16 @@ runs:
         echo "::group::Run terraform destroy"
         cd "examples/full/${{ inputs.test_name }}/${{ inputs.cloud_provider }}"
 
+        # Since destroy runs on failure too, it can now be reached before init
+        # ran or before anything was applied. Without this it fails on its own
+        # terms -- missing variables, no provider -- and buries the real error.
+        if [ ! -d .terraform ] || [ ! -s terraform.tfstate ]
+        then
+          echo "nothing applied, skipping destroy"
+          echo "::endgroup::"
+          exit 0
+        fi
+
         if [ "${{inputs.api_url}}" != "" ]
         then
           export CLICKHOUSE_API_URL="${{inputs.api_url}}"

--- a/.github/scripts/discover_clickstack_ids.sh
+++ b/.github/scripts/discover_clickstack_ids.sh
@@ -15,11 +15,32 @@ VAR_FILE="${1:?usage: discover_clickstack_ids.sh <path-to-variables.tfvars>}"
 API_URL="${CLICKHOUSE_API_URL:-https://api.clickhouse.cloud/v1}"
 ORG_URL="${API_URL}/organizations/${ORGANIZATION_ID}"
 
-# Bounded and retried: a flaky probe would otherwise abort the whole e2e run,
-# and this step is not inside the retry wrapper the terraform steps use.
-CURL_OPTS=(-sS --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2 --retry-all-errors)
+# Bounded and retried: a flaky call would otherwise abort the whole e2e run, and
+# this step is not inside the retry wrapper the terraform steps use.
+# No --retry-all-errors, and no `-o /dev/null` on the probe below. That pair made
+# curl exit 23 (write error) on the runner while passing locally; whether the
+# trigger was the option combination or a retry against a transient gateway error
+# was never pinned down, so both went. Nothing here needs retries on
+# non-transient errors regardless.
+CURL_OPTS=(-sS --connect-timeout 10 --max-time 60 --retry 3 --retry-delay 2)
 
 api() { curl "${CURL_OPTS[@]}" --user "${TOKEN_KEY}:${TOKEN_SECRET}" "$@"; }
+
+# Returns the response body on stdout and the status code in http_code. Every
+# caller checks the curl exit status: an unguarded call under `set -e` kills the
+# script with curl's numeric exit and no message, which is exactly how the
+# original probe failed silently.
+http_code=""
+api_probe() {
+  local url="$1" out rc
+  if ! out=$(api -w '\n%{http_code}' "$url"); then
+    rc=$?
+    echo "::error::curl failed (exit ${rc}) requesting ${url}" >&2
+    return "$rc"
+  fi
+  http_code=$(printf '%s' "$out" | tail -n1)
+  printf '%s' "$out" | sed '$d'
+}
 
 services=$(api "${ORG_URL}/services") || {
   echo "::error::Could not list services in organization ${ORGANIZATION_ID}." >&2
@@ -39,12 +60,12 @@ jq -e 'has("result")' <<<"$services" >/dev/null || {
 service_id=""
 while IFS=$'\t' read -r id name; do
   [ -n "$id" ] || continue
-  code=$(api -o /dev/null -w '%{http_code}' "${ORG_URL}/services/${id}/clickstack/sources")
-  case "$code" in
+  api_probe "${ORG_URL}/services/${id}/clickstack/sources" >/dev/null || exit 1
+  case "$http_code" in
     200) ;;
     403) continue ;;
     *)
-      echo "::error::Probing service ${name} (${id}) returned ${code}; expected 200 (onboarded) or 403 (not onboarded)." >&2
+      echo "::error::Probing service ${name} (${id}) returned ${http_code}; expected 200 (onboarded) or 403 (not onboarded)." >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
The nightly `clickstack` e2e has failed on every run since #667 merged, on all three Terraform versions. Other examples are unaffected.

## What happened

The "Discover ClickStack service and connection" step exited **23** with no output at all. 

Destroy then failed with "No value for required variable" because discovery never appended the ids, which is the error you see first and is not the actual problem.

Exit 23 is curl's write error. The probe inside the service loop was the only
unguarded call in the script, so `set -e` killed it with curl's numeric exit and
no message. It was also the only call pairing `-o /dev/null` with `--retry`.

I could not reproduce it locally: same curl invocation, same API, exit 0 against
both an onboarded and a non-onboarded service. So whether the trigger was that
option combination on the runner's curl or a retry against a transient gateway
error is unresolved. Both are gone rather than guessing between them.

## Changes

- The probe captures body and status together instead of `-o /dev/null -w`, and every caller checks curl's exit status. A failure now names the URL and the exit code.
- `--retry-all-errors` dropped. It needs curl >= 7.71 and nothing here needs retries on non-transient errors.
- Destroy skips when nothing was applied. It runs on failure now, so it can be   reached before `init`, where it fails on its own missing variables and hides  the real error. This affects every example, and is why the log showed two failures instead of one.

## Verification

Discovery, apply, import, update and destroy all pass against the live `[e2e]-clickstack` service: 6 added, import checks passed, 6 changed, 6 destroyed. The failure path was checked too — bad credentials now report `UNAUTHORIZED` rather than exiting silently.

Local verification is what missed this the first time, so this wants a manual `E2E tests` dispatch on the branch before merge. 
