### PR TITLE
fix(clickstack): look the e2e ClickStack service up by name

### DIFF
--- a/.github/scripts/discover_clickstack_ids.sh
+++ b/.github/scripts/discover_clickstack_ids.sh
@@ -42,16 +42,27 @@ api_probe() {
   printf '%s' "$out" | sed '$d'
 }
 
-services=$(api "${ORG_URL}/services") || {
+# --fail so a retried request cannot leave two response bodies in $services.
+# Without it a 429 followed by a successful retry concatenates the error body
+# and the list, and jq quietly reports on whichever one it read last.
+services=$(api --fail "${ORG_URL}/services") || {
   echo "::error::Could not list services in organization ${ORGANIZATION_ID}." >&2
   exit 1
 }
 # Distinguishes an auth/API failure from a genuinely empty org — without this the
 # loop below just sees no candidates and reports "nothing onboarded".
-jq -e 'has("result")' <<<"$services" >/dev/null || {
+jq -e '(.result | type) == "array"' <<<"$services" >/dev/null || {
   echo "::error::Unexpected response listing services: ${services}" >&2
   exit 1
 }
+
+# Skips the throwaway services the other test jobs are creating right now in
+# this same org. Onboarding ClickStack is a console step, so the service being
+# looked for is always long-lived. Probing the test ones also broke the scan:
+# the warehouse example's readonly secondary answers 404 here, not 403.
+candidates=$(jq -r '.result[]
+  | select(.name | test("^\\[?(e2e|upg|import)\\]?-") | not)
+  | "\(.id)\t\(.name)"' <<<"$services")
 
 # A service without ClickStack answers 403 ("ClickStack has not been setup for
 # this service"), so the status code is what identifies the right one. State is
@@ -75,7 +86,7 @@ while IFS=$'\t' read -r id name; do
   fi
   service_id="$id"
   service_name="$name"
-done < <(jq -r '.result[] | "\(.id)\t\(.name)"' <<<"$services")
+done <<<"$candidates"
 
 if [ -z "$service_id" ]; then
   echo "::error::No service in this organization has ClickStack onboarded. Onboarding is a console step the provider cannot do." >&2
@@ -86,8 +97,13 @@ fi
 # service pointing at itself, so read its id off the sources onboarding created.
 # `// empty` matters: jq -r prints a JSON null as the string "null", which would
 # sail past the emptiness check below and land "null" in variables.tfvars.
-connection_id=$(api "${ORG_URL}/services/${service_id}/clickstack/sources" \
-  | jq -r '[.result[].connection // empty] | unique | if length == 1 then .[0] else empty end')
+# Not piped straight into jq: pipefail would then kill the script on a failed
+# request with curl's bare exit status and no message.
+sources=$(api --fail "${ORG_URL}/services/${service_id}/clickstack/sources") || {
+  echo "::error::Could not read ${service_name}'s ClickStack sources." >&2
+  exit 1
+}
+connection_id=$(jq -r '[.result[].connection // empty] | unique | if length == 1 then .[0] else empty end' <<<"$sources")
 
 if [ -z "$connection_id" ]; then
   echo "::error::Could not read a single connection id off ${service_name}'s sources. ClickStack creates its default sources once telemetry arrives, so this usually means the service has never ingested anything." >&2


### PR DESCRIPTION
The nightly clickstack e2e job dies intermittently in the discovery step, before terraform runs.

Discovery had no service id to work from, so it listed every service in the org and probed each one on the ClickStack route to find the onboarded one. All the e2e jobs share one org, so that scan also walked the throwaway services sibling jobs had live at the time — and the warehouse example's readonly secondary answers 404 on that route, not the 403 an ordinary not-onboarded service gives. Warehouse job overlaps clickstack job, clickstack job dies. That overlap is the intermittency.

Now it looks the service up by name: `[e2e]-clickstack`. One API call, no probing.

**Needs a service of that name in the org** with managed ClickStack onboarded — README updated. The name carries no per-run token, so `cleanup.sh` won't match it.

Also `--fail` on the API calls: without it, curl's retry on a 429 leaves both the error body and the successful body in the captured output, which is where the run's `jq: error ... Cannot iterate over null (null)` came from.
