### PR TITLE
fix(clickpipes): allow ReplacingMergeTree without version column

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -150,7 +150,7 @@ Required:
 Optional:
 
 - `column_ids` (List of String) Column IDs to sum for SummingMergeTree engine. Required when engine type is `SummingMergeTree`.
-- `version_column_id` (String) Column ID to use as version for ReplacingMergeTree engine. Required when engine type is `ReplacingMergeTree`.
+- `version_column_id` (String) Optional column ID to use as version for ReplacingMergeTree engine. When omitted, the most recently inserted row is retained during merges.
 
 
 

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -1841,7 +1841,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										},
 									},
 									"version_column_id": schema.StringAttribute{
-										MarkdownDescription: "Column ID to use as version for ReplacingMergeTree engine. Required when engine type is `ReplacingMergeTree`.",
+										MarkdownDescription: "Optional column ID to use as version for ReplacingMergeTree engine. When omitted, the most recently inserted row is retained during merges.",
 										Optional:            true,
 									},
 									"column_ids": schema.ListAttribute{
@@ -1979,14 +1979,7 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 				engineType := engineModel.Type.ValueString()
 
 				// Validate versionColumnId
-				if engineType == ClickPipeEngineReplacingMergeTree {
-					if engineModel.VersionColumnID.IsNull() {
-						response.Diagnostics.AddError(
-							"Invalid Configuration",
-							"version_column_id is required for ReplacingMergeTree engine",
-						)
-					}
-				} else {
+				if engineType != ClickPipeEngineReplacingMergeTree {
 					if !engineModel.VersionColumnID.IsNull() {
 						response.Diagnostics.AddError(
 							"Invalid Configuration",

--- a/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
@@ -856,6 +856,49 @@ func TestClickPipeResource_ModifyPlan_RejectsTableDefinitionForCDC_Issue571(t *t
 	})
 }
 
+// Issue #575: version_column_id is optional for ReplacingMergeTree. When it
+// is omitted, ClickHouse uses the most recently inserted row during merges.
+func TestClickPipeResource_ModifyPlan_ReplacingMergeTreeAllowsMissingVersionColumnID_Issue575(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+
+	plan := buildObjectStoragePlan(types.BoolValue(false), types.StringNull())
+	destination := buildObjectStorageDestination()
+	destination.TableDefinition = models.ClickPipeDestinationTableDefinitionModel{
+		Engine: models.ClickPipeDestinationTableEngineModel{
+			Type:            types.StringValue(ClickPipeEngineReplacingMergeTree),
+			VersionColumnID: types.StringNull(),
+			ColumnIDs:       types.ListNull(types.StringType),
+		}.ObjectValue(),
+		SortingKey:  types.ListValueMust(types.StringType, []attr.Value{types.StringValue("id")}),
+		PartitionBy: types.StringNull(),
+		PrimaryKey:  types.StringNull(),
+	}.ObjectValue()
+	plan.Destination = destination.ObjectValue()
+
+	planVal := tfsdk.Plan{Schema: sch}
+	if d := planVal.Set(ctx, &plan); d.HasError() {
+		t.Fatalf("encoding plan failed: %v", d.Errors())
+	}
+
+	req := resource.ModifyPlanRequest{
+		State:  tfsdk.State{Schema: sch}, // null Raw => create
+		Plan:   planVal,
+		Config: tfsdk.Config{Schema: sch, Raw: planVal.Raw},
+	}
+	resp := &resource.ModifyPlanResponse{Plan: tfsdk.Plan{Schema: sch, Raw: planVal.Raw}}
+	r.ModifyPlan(ctx, req, resp)
+
+	assert.False(t, resp.Diagnostics.HasError(), "ReplacingMergeTree without version_column_id should be valid: %v", resp.Diagnostics.Errors())
+}
+
 func TestClickPipeResource_ConfigValidators_RejectCDCScaling(t *testing.T) {
 	ctx := context.Background()
 	r := &ClickPipeResource{}


### PR DESCRIPTION
Summary:
- Allow managed ClickPipes tables to omit version_column_id for ReplacingMergeTree.
- Keep validation for incompatible engines and referenced columns.
- Update resource documentation and add regression coverage for issue #575.

Testing:
- go test ./... in golang:1.26-bookworm
- go vet ./... in golang:1.26-bookworm
- git diff --check

Fixes #575