### PR TITLE
feat(postgres): support GCP private preview

### DIFF
--- a/docs/resources/postgres_service.md
+++ b/docs/resources/postgres_service.md
@@ -8,11 +8,7 @@ description: |-
   service. A Managed Postgres service is a fully-managed Postgres instance
   provisioned in the ClickHouse Cloud control plane.
   Supports AWS (cloud_provider = "aws") and GCP (cloud_provider = "gcp").
-  ~> Private preview: Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
-  For GCP, use a region such as us-west1 and a size such as c4a-highmem-4.
-  Use the region name without a gcp- prefix. Available sizes are listed in the
-  Postgres create API reference https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size.
-  The API validates size and region availability when creating the service.
+  ~> Note: Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and region.
   Supported lifecycle
   Create — standard, as a read replica (read_replica_of), or by
   point-in-time restore (restore_to_point_in_time)ReadUpdate — size, ha_type, tags, pg_config, pgbouncer_config,
@@ -170,12 +166,7 @@ provisioned in the ClickHouse Cloud control plane.
 
 Supports AWS (`cloud_provider = "aws"`) and GCP (`cloud_provider = "gcp"`).
 
-~> **Private preview:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
-
-For GCP, use a region such as `us-west1` and a size such as `c4a-highmem-4`.
-Use the region name without a `gcp-` prefix. Available sizes are listed in the
-[Postgres create API reference](https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size).
-The API validates size and region availability when creating the service.
+~> **Note:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and region.
 
 ## Supported lifecycle
 

--- a/docs/resources/postgres_service.md
+++ b/docs/resources/postgres_service.md
@@ -7,6 +7,12 @@ description: |-
   Manages a ClickHouse Cloud Managed Postgres https://clickhouse.com/cloud/postgres
   service. A Managed Postgres service is a fully-managed Postgres instance
   provisioned in the ClickHouse Cloud control plane.
+  Supports AWS (cloud_provider = "aws") and GCP (cloud_provider = "gcp").
+  ~> Private preview: Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
+  For GCP, use a region such as us-west1 and a size such as c4a-highmem-4.
+  Use the region name without a gcp- prefix. Available sizes are listed in the
+  Postgres create API reference https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size.
+  The API validates size and region availability when creating the service.
   Supported lifecycle
   Create — standard, as a read replica (read_replica_of), or by
   point-in-time restore (restore_to_point_in_time)ReadUpdate — size, ha_type, tags, pg_config, pgbouncer_config,
@@ -141,7 +147,7 @@ description: |-
   The size attribute is not validated client-side beyond non-empty.
   Invalid sizes surface as an HTTP 400 at apply time rather than a
   plan-time error. Pinning the list to a compile-time snapshot would
-  mean new AWS instance families require a provider patch release
+  mean new AWS or GCP instance families require a provider patch release
   before users can adopt them; size is the most frequently changed
   attribute, so the trade-off goes the other way here. The
   cloud_provider, ha_type, and postgres_version attributes
@@ -161,6 +167,15 @@ description: |-
 Manages a [ClickHouse Cloud Managed Postgres](https://clickhouse.com/cloud/postgres)
 service. A Managed Postgres service is a fully-managed Postgres instance
 provisioned in the ClickHouse Cloud control plane.
+
+Supports AWS (`cloud_provider = "aws"`) and GCP (`cloud_provider = "gcp"`).
+
+~> **Private preview:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
+
+For GCP, use a region such as `us-west1` and a size such as `c4a-highmem-4`.
+Use the region name without a `gcp-` prefix. Available sizes are listed in the
+[Postgres create API reference](https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size).
+The API validates size and region availability when creating the service.
 
 ## Supported lifecycle
 
@@ -341,7 +356,7 @@ UI, or CLI directly.
 - The `size` attribute is not validated client-side beyond non-empty.
   Invalid sizes surface as an HTTP 400 at apply time rather than a
   plan-time error. Pinning the list to a compile-time snapshot would
-  mean new AWS instance families require a provider patch release
+  mean new AWS or GCP instance families require a provider patch release
   before users can adopt them; `size` is the most frequently changed
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes
@@ -394,7 +409,7 @@ resource "clickhouse_postgres_service" "example" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `cloud_provider` (String) Cloud provider hosting the instance. Currently only 'aws' is supported. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).
+- `cloud_provider` (String) Cloud provider hosting the instance. Supported values are 'aws' and 'gcp'. Postgres on GCP is in private preview; contact ClickHouse support to enable access for your organization and region. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).
 - `ha_type` (String) High-availability mode. One of 'none' (single replica), 'async' (asynchronous replica), or 'sync' (synchronous replica). Mutable post-create; an HA flip triggers a transition. Omitting the attribute preserves the prior value (the server defaults to 'none' on Create); to actively downgrade, set 'ha_type = "none"' explicitly. Omit for a read replica or point-in-time restore (inherited from the source).
 - `password` (String, Sensitive) Superuser password. Config-owned: the API does not return the password, so Terraform manages exactly the value declared here and never reads it back. One of `password` or `password_wo` is required for a standard service; forbidden for a read replica (it inherits the primary's superuser); optional for a point-in-time restore (omit to keep the source's password, which Terraform then does not track). Changing this value rotates the password (PATCH /password). Must be ≥12 chars with at least one lowercase, one uppercase, and one digit. Stored in (sensitive) state — prefer `password_wo` to keep it out of state. `terraform import` cannot recover the live password — the configured value is rotated in on the first apply after import.
 - `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Superuser password, write-only: applied to the service but never persisted to Terraform state (requires Terraform >= 1.11). Preferred over `password`. Requires `password_wo_version`; increment the version to rotate to the current `password_wo` value. Same complexity rules as `password`. Forbidden for a read replica.
@@ -403,7 +418,7 @@ resource "clickhouse_postgres_service" "example" {
 - `pgbouncer_config` (Map of String) PgBouncer connection-pooler parameters (pgBouncerConfig) as a key-value map. Same Optional+Computed semantics as pg_config; set `pgbouncer_config = {}` to clear.
 - `postgres_version` (String) Major Postgres version (e.g. '18'). The server picks the patch release within that major. Changing the major triggers destroy-and-recreate. Omit for a read replica or point-in-time restore (inherited from the source).
 - `read_replica_of` (String) ID of the primary instance to replicate. When set, this instance is created as a read replica (streaming replication) of that primary. Immutable for a live replica: changing or removing it destroys and recreates the instance as a standalone primary. The one exception is an out-of-band promotion — if you promote the replica via the API/UI (is_primary becomes true), changing or removing read_replica_of then reconciles state in place without destroying the promoted primary. Mutually exclusive with restore_to_point_in_time and with password/password_wo (a replica inherits the primary's superuser). After an out-of-band promotion, removing read_replica_of requires declaring password or password_wo, which rotates the promoted primary's superuser password.
-- `region` (String) Cloud region (e.g. 'us-east-1'). No client-side validation; the server rejects unsupported regions. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).
+- `region` (String) Cloud region (e.g. 'us-east-1' for AWS or 'us-west1' for GCP). No client-side validation; the server rejects unsupported regions. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).
 - `restore_to_point_in_time` (Attributes) Create this instance by restoring another Postgres instance's backup to a point in time. The whole block is create-time only: changing source_id / restore_target (re-restore to a new point) OR removing it both destroy and recreate the instance. The restored instance's name is this resource's top-level `name` and it is independent of its source. cloud_provider / region / postgres_version are inherited from the source — omit them, or set them to match (a mismatch is a plan-time error); size and ha_type must be omitted (the restored instance comes up at the backup's size and a server-assigned HA mode). Mutually exclusive with read_replica_of. (see [below for nested schema](#nestedatt--restore_to_point_in_time))
 - `size` (String) Instance size (VM SKU). See https://clickhouse.com/docs/cloud/managed-postgres/scaling for the supported instance families. No client-side enum; the server rejects unsupported sizes with HTTP 400 at apply time. Resizable in place. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).
 - `tags` (Map of String) Resource tags as a key-value map. Values must be non-empty (server's PATCH returns 400 on omitted value). Set `tags = {}` to clear all tags; omit the attribute to preserve the prior value.

--- a/examples/full/postgres/gcp/README.md
+++ b/examples/full/postgres/gcp/README.md
@@ -1,0 +1,19 @@
+## GCP Managed Postgres example
+
+The Terraform code deploys following resources:
+- 1 ClickHouse Managed Postgres service (primary) on GCP
+- 1 read replica of the primary
+- 3 data sources reading the primary back (by ID, all services, CA certificates)
+
+NOTE: `clickhouse_postgres_service` is a beta resource — it ships in the regular provider build but its behavior may change in future provider versions.
+
+Postgres on GCP is in **private preview**. Contact ClickHouse support to enable
+access for your organization and selected region before running this example.
+The default region is `us-west1` and the instance size is `c4a-highmem-4`;
+size and region availability are validated by the API.
+
+## How to run
+
+- Rename `variables.tfvars.sample` to `variables.tfvars` and fill in all needed data.
+- Run `terraform init`
+- Run `terraform <plan|apply> -var-file=variables.tfvars`

--- a/examples/full/postgres/gcp/README.md
+++ b/examples/full/postgres/gcp/README.md
@@ -7,10 +7,7 @@ The Terraform code deploys following resources:
 
 NOTE: `clickhouse_postgres_service` is a beta resource — it ships in the regular provider build but its behavior may change in future provider versions.
 
-Postgres on GCP is in **private preview**. Contact ClickHouse support to enable
-access for your organization and selected region before running this example.
-The default region is `us-west1` and the instance size is `c4a-highmem-4`;
-size and region availability are validated by the API.
+NOTE: Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and region.
 
 ## How to run
 

--- a/examples/full/postgres/gcp/main.tf
+++ b/examples/full/postgres/gcp/main.tf
@@ -28,10 +28,11 @@ variable "region" {
 # Primary: exercises explicit version, HA, runtime config (pg_config /
 # pgbouncer_config), tags, and a user-managed password.
 resource "clickhouse_postgres_service" "primary" {
+  # size = "c4a-highmem-4" # Requires access to the GCP ARM preview.
   name             = var.service_name
   cloud_provider   = "gcp"
   region           = var.region
-  size             = "c4a-highmem-4"
+  size             = "c4-highmem-4"
   postgres_version = "18"
   ha_type          = "async"
 
@@ -53,10 +54,11 @@ resource "clickhouse_postgres_service" "primary" {
 
 # Read replica of the primary (inherits the superuser, so no password here).
 resource "clickhouse_postgres_service" "replica" {
+  # size = "c4a-highmem-4" # Requires access to the GCP ARM preview.
   name            = "${var.service_name}-replica"
   cloud_provider  = "gcp"
   region          = var.region
-  size            = "c4a-highmem-4"
+  size            = "c4-highmem-4"
   read_replica_of = clickhouse_postgres_service.primary.id
 }
 

--- a/examples/full/postgres/gcp/main.tf
+++ b/examples/full/postgres/gcp/main.tf
@@ -1,0 +1,96 @@
+# Postgres on GCP is in private preview. Enable access for your organization
+# and selected region with ClickHouse support before applying.
+
+variable "organization_id" {
+  type = string
+}
+
+variable "token_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "token_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "service_name" {
+  type    = string
+  default = "my-postgres-e2e"
+}
+
+variable "region" {
+  type    = string
+  default = "us-west1"
+}
+
+# Primary: exercises explicit version, HA, runtime config (pg_config /
+# pgbouncer_config), tags, and a user-managed password.
+resource "clickhouse_postgres_service" "primary" {
+  name             = var.service_name
+  cloud_provider   = "gcp"
+  region           = var.region
+  size             = "c4a-highmem-4"
+  postgres_version = "18"
+  ha_type          = "async"
+
+  password = "TerraformE2E123"
+
+  pg_config = {
+    max_connections = "200"
+  }
+
+  pgbouncer_config = {
+    default_pool_size = "25"
+  }
+
+  tags = {
+    environment = "e2e"
+    managed_by  = "terraform"
+  }
+}
+
+# Read replica of the primary (inherits the superuser, so no password here).
+resource "clickhouse_postgres_service" "replica" {
+  name            = "${var.service_name}-replica"
+  cloud_provider  = "gcp"
+  region          = var.region
+  size            = "c4a-highmem-4"
+  read_replica_of = clickhouse_postgres_service.primary.id
+}
+
+# All three data sources, against the primary.
+data "clickhouse_postgres_service" "by_id" {
+  id = clickhouse_postgres_service.primary.id
+}
+
+data "clickhouse_postgres_services" "all" {}
+
+data "clickhouse_postgres_service_ca_certificates" "certs" {
+  service_id = clickhouse_postgres_service.primary.id
+}
+
+output "primary_id" {
+  value = clickhouse_postgres_service.primary.id
+}
+
+output "replica_id" {
+  value = clickhouse_postgres_service.replica.id
+}
+
+output "primary_is_primary" {
+  value = clickhouse_postgres_service.primary.is_primary
+}
+
+output "replica_is_primary" {
+  value = clickhouse_postgres_service.replica.is_primary
+}
+
+output "ca_certificate_present" {
+  value = length(data.clickhouse_postgres_service_ca_certificates.certs.certificate) > 0
+}
+
+output "services_count" {
+  value = length(data.clickhouse_postgres_services.all.services)
+}

--- a/examples/full/postgres/gcp/provider.tf
+++ b/examples/full/postgres/gcp/provider.tf
@@ -1,0 +1,15 @@
+# This file is generated automatically please do not edit
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "3.26.0"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/full/postgres/gcp/provider.tf
+++ b/examples/full/postgres/gcp/provider.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     clickhouse = {
-      version = "3.26.0"
+      version = "3.27.0"
       source  = "ClickHouse/clickhouse"
     }
   }

--- a/examples/full/postgres/gcp/provider.tf.template
+++ b/examples/full/postgres/gcp/provider.tf.template
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    clickhouse = {
+      version = "${CLICKHOUSE_TERRAFORM_PROVIDER_VERSION}"
+      source  = "ClickHouse/clickhouse"
+    }
+  }
+}
+
+provider "clickhouse" {
+  organization_id = var.organization_id
+  token_key       = var.token_key
+  token_secret    = var.token_secret
+}

--- a/examples/full/postgres/gcp/variables.tfvars.sample
+++ b/examples/full/postgres/gcp/variables.tfvars.sample
@@ -1,0 +1,5 @@
+organization_id = "your-org-id"
+token_key       = "your-token-key"
+token_secret    = "your-token-secret"
+service_name    = "my-postgres-e2e"
+region          = "us-west1"

--- a/internal/service/postgres/resource/descriptions/postgres_service.md
+++ b/internal/service/postgres/resource/descriptions/postgres_service.md
@@ -6,12 +6,7 @@ provisioned in the ClickHouse Cloud control plane.
 
 Supports AWS (`cloud_provider = "aws"`) and GCP (`cloud_provider = "gcp"`).
 
-~> **Private preview:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
-
-For GCP, use a region such as `us-west1` and a size such as `c4a-highmem-4`.
-Use the region name without a `gcp-` prefix. Available sizes are listed in the
-[Postgres create API reference](https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size).
-The API validates size and region availability when creating the service.
+~> **Note:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and region.
 
 ## Supported lifecycle
 

--- a/internal/service/postgres/resource/descriptions/postgres_service.md
+++ b/internal/service/postgres/resource/descriptions/postgres_service.md
@@ -4,6 +4,15 @@ Manages a [ClickHouse Cloud Managed Postgres](https://clickhouse.com/cloud/postg
 service. A Managed Postgres service is a fully-managed Postgres instance
 provisioned in the ClickHouse Cloud control plane.
 
+Supports AWS (`cloud_provider = "aws"`) and GCP (`cloud_provider = "gcp"`).
+
+~> **Private preview:** Postgres on GCP is in private preview. Contact ClickHouse support to enable access for your organization and selected region before applying a GCP configuration.
+
+For GCP, use a region such as `us-west1` and a size such as `c4a-highmem-4`.
+Use the region name without a `gcp-` prefix. Available sizes are listed in the
+[Postgres create API reference](https://clickhouse.com/docs/products/cloud/api-reference/postgres/postgres-service-create#body-size).
+The API validates size and region availability when creating the service.
+
 ## Supported lifecycle
 
 - Create — standard, as a read replica (`read_replica_of`), or by
@@ -183,7 +192,7 @@ UI, or CLI directly.
 - The `size` attribute is not validated client-side beyond non-empty.
   Invalid sizes surface as an HTTP 400 at apply time rather than a
   plan-time error. Pinning the list to a compile-time snapshot would
-  mean new AWS instance families require a provider patch release
+  mean new AWS or GCP instance families require a provider patch release
   before users can adopt them; `size` is the most frequently changed
   attribute, so the trade-off goes the other way here. The
   `cloud_provider`, `ha_type`, and `postgres_version` attributes

--- a/internal/service/postgres/resource/postgres_service.go
+++ b/internal/service/postgres/resource/postgres_service.go
@@ -68,8 +68,21 @@ func (r *PostgresServiceResource) Metadata(_ context.Context, req resource.Metad
 // existing instance drops its origin block) and the live-replica modification
 // block (which needs is_primary from prior state). All of these live in
 // ModifyPlan, which has prior state.
-func (r *PostgresServiceResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+func (r *PostgresServiceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
+
+	var cloudProvider types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cloud_provider"), &cloudProvider)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if cloudProvider.ValueString() == "gcp" {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("cloud_provider"),
+			"Postgres on GCP is in private preview",
+			"Postgres on GCP is in private preview. Your organization must have access to GCP and the selected Postgres region. Contact ClickHouse support to request access.",
+		)
+	}
 }
 
 // configIsOrigin reports whether the config declares a read replica or restore.
@@ -311,7 +324,7 @@ func (r *PostgresServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"cloud_provider": schema.StringAttribute{
-				Description: "Cloud provider hosting the instance. Currently only 'aws' is supported. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).",
+				Description: "Cloud provider hosting the instance. Supported values are 'aws' and 'gcp'. Postgres on GCP is in private preview; contact ClickHouse support to enable access for your organization and region. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).",
 				Optional:    true,
 				Computed:    true,
 				Validators: []validator.String{
@@ -323,7 +336,7 @@ func (r *PostgresServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"region": schema.StringAttribute{
-				Description: "Cloud region (e.g. 'us-east-1'). No client-side validation; the server rejects unsupported regions. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).",
+				Description: "Cloud region (e.g. 'us-east-1' for AWS or 'us-west1' for GCP). No client-side validation; the server rejects unsupported regions. Required for a standard create; omit for a read replica or point-in-time restore (inherited from the source).",
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
+++ b/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
@@ -1,0 +1,201 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/postgres/resource/models"
+)
+
+func TestPostgresSchema_cloudProviderAndSize(t *testing.T) {
+	ctx := context.Background()
+	r := &PostgresServiceResource{}
+	var resp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &resp)
+
+	for _, tc := range []struct {
+		attribute string
+		value     types.String
+		wantError bool
+	}{
+		{"cloud_provider", types.StringValue("aws"), false},
+		{"cloud_provider", types.StringValue("gcp"), false},
+		{"cloud_provider", types.StringValue("azure"), true},
+		{"cloud_provider", types.StringValue("GCP"), true},
+		{"cloud_provider", types.StringValue(""), true},
+		{"cloud_provider", types.StringNull(), false},
+		{"cloud_provider", types.StringUnknown(), false},
+		{"size", types.StringValue("m6gd.large"), false},
+		{"size", types.StringValue("c4a-highmem-4"), false},
+		{"size", types.StringValue("c4-standard-4"), false},
+		{"size", types.StringValue("c4d-highmem-8"), false},
+		{"size", types.StringValue("z3-highlssd-8"), false},
+		{"size", types.StringValue("future-server-supported-size"), false},
+		{"size", types.StringValue(""), true},
+	} {
+		t.Run(tc.attribute+"/"+tc.value.String(), func(t *testing.T) {
+			attribute := resp.Schema.Attributes[tc.attribute].(schema.StringAttribute)
+			var validation validator.StringResponse
+			for _, v := range attribute.Validators {
+				v.ValidateString(ctx, validator.StringRequest{
+					Path: path.Root(tc.attribute), ConfigValue: tc.value,
+				}, &validation)
+			}
+			require.Equal(t, tc.wantError, validation.Diagnostics.HasError(), "%v", validation.Diagnostics)
+		})
+	}
+}
+
+func TestPostgresValidateConfig_privatePreview(t *testing.T) {
+	ctx := context.Background()
+	r := &PostgresServiceResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	for _, tc := range []struct {
+		name      string
+		provider  types.String
+		wantCount int
+	}{
+		{"aws", types.StringValue("aws"), 1},
+		{"gcp", types.StringValue("gcp"), 2},
+		{"inherited", types.StringNull(), 1},
+		{"unknown", types.StringUnknown(), 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := gateModel(true)
+			model.CloudProvider = tc.provider
+			state := tfsdk.State{Schema: schemaResp.Schema}
+			require.False(t, state.Set(ctx, model).HasError())
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(ctx, resource.ValidateConfigRequest{
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: state.Raw},
+			}, &resp)
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+			require.Equal(t, tc.wantCount, resp.Diagnostics.WarningsCount(), "%v", resp.Diagnostics)
+			require.Equal(t, "Beta Resource", resp.Diagnostics.Warnings()[0].Summary())
+			if tc.name == "gcp" {
+				warning := resp.Diagnostics.Warnings()[1]
+				require.Contains(t, warning.Summary(), "private preview")
+				require.Contains(t, warning.Detail(), "Contact ClickHouse support")
+				require.Equal(t, path.Root("cloud_provider"), warning.(diag.DiagnosticWithPath).Path())
+			}
+		})
+	}
+}
+
+func TestPostgresCreate_cloudProviders(t *testing.T) {
+	for _, tc := range []struct {
+		provider string
+		region   string
+		size     string
+	}{
+		{"aws", "us-east-1", "m6gd.large"},
+		{"gcp", "us-west1", "c4a-highmem-4"},
+	} {
+		t.Run(tc.provider, func(t *testing.T) {
+			ctx := context.Background()
+			client := api.NewClientMock(minimock.NewController(t))
+			r := &PostgresServiceResource{client: client}
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			model := gateModel(true)
+			model.CloudProvider = types.StringValue(tc.provider)
+			model.Region = types.StringValue(tc.region)
+			model.Size = types.StringValue(tc.size)
+			model.Password = types.StringValue("ConfiguredPassword123")
+			model.PgConfig = types.MapNull(types.StringType)
+			model.PgBouncerConfig = types.MapNull(types.StringType)
+			encoded := tfsdk.State{Schema: schemaResp.Schema}
+			require.False(t, encoded.Set(ctx, model).HasError())
+
+			pg := &api.Postgres{
+				Id: "pg-new", Name: "n", Provider: tc.provider, Region: tc.region,
+				Size: tc.size, PostgresVersion: "18", HaType: "none",
+				State: api.PostgresStateRunning, IsPrimary: true,
+				Hostname: "pg.example.com", Username: "postgres",
+			}
+			client.CreatePostgresMock.Expect(ctx, api.PostgresCreate{
+				Name: "n", Provider: tc.provider, Region: tc.region, Size: tc.size,
+				PostgresVersion: "18", HaType: "none", Tags: []api.Tag{},
+			}).Return(pg, "initial-server-password", nil)
+			client.WaitForPostgresStateMock.ExpectPostgresIdParam2(pg.Id).
+				ExpectMaxWaitSecondsParam4(postgresDefaultCreateTimeoutSeconds).Return(nil)
+			client.SetPostgresPasswordMock.Expect(ctx, pg.Id, api.PostgresPassword{
+				Password: "ConfiguredPassword123",
+			}).Return(nil, nil)
+			client.GetPostgresMock.Expect(ctx, pg.Id).Return(pg, nil)
+			client.GetPostgresConfigMock.Expect(ctx, pg.Id).Return(&api.PostgresConfig{}, nil)
+
+			resp := resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+			r.Create(ctx, resource.CreateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: encoded.Raw},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: encoded.Raw},
+			}, &resp)
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+			var got models.PostgresServiceResourceModel
+			require.False(t, resp.State.Get(ctx, &got).HasError())
+			require.Equal(t, pg.Id, got.ID.ValueString())
+			require.Equal(t, tc.provider, got.CloudProvider.ValueString())
+			require.Equal(t, tc.region, got.Region.ValueString())
+			require.Equal(t, tc.size, got.Size.ValueString())
+			require.Equal(t, "ConfiguredPassword123", got.Password.ValueString())
+		})
+	}
+}
+
+func TestPostgresPlanInheritedAttributes_GCP(t *testing.T) {
+	for _, origin := range []string{"replica", "restore"} {
+		t.Run(origin, func(t *testing.T) {
+			ctx := context.Background()
+			client := api.NewClientMock(minimock.NewController(t))
+			client.GetPostgresMock.Expect(ctx, "pg-source").Return(&api.Postgres{
+				Provider: "gcp", Region: "us-west1", Size: "c4a-highmem-4", PostgresVersion: "18",
+			}, nil)
+			r := &PostgresServiceResource{client: client}
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			model := gateModel(false)
+			model.CloudProvider = types.StringNull()
+			model.Region = types.StringNull()
+			model.PostgresVersion = types.StringNull()
+			model.Size = types.StringNull()
+			model.HaType = types.StringNull()
+			if origin == "replica" {
+				model.ReadReplicaOf = types.StringValue("pg-source")
+			} else {
+				var diags diag.Diagnostics
+				model.RestoreToPointInTime, diags = types.ObjectValueFrom(ctx, model.RestoreToPointInTime.AttributeTypes(ctx), models.PostgresRestoreModel{
+					SourceID: types.StringValue("pg-source"), RestoreTarget: types.StringValue("2026-09-01T12:00:00Z"),
+				})
+				require.False(t, diags.HasError(), "%v", diags)
+			}
+			plan := tfsdk.Plan{Schema: schemaResp.Schema}
+			require.False(t, plan.Set(ctx, model).HasError())
+			resp := resource.ModifyPlanResponse{Plan: plan}
+			r.planInheritedAttributes(ctx, model, &resp)
+			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
+			var got models.PostgresServiceResourceModel
+			require.False(t, resp.Plan.Get(ctx, &got).HasError())
+			require.Equal(t, "gcp", got.CloudProvider.ValueString())
+			require.Equal(t, "us-west1", got.Region.ValueString())
+			require.Equal(t, "18", got.PostgresVersion.ValueString())
+			if origin == "replica" {
+				require.Equal(t, "c4a-highmem-4", got.Size.ValueString())
+			} else {
+				require.True(t, got.Size.IsUnknown())
+			}
+		})
+	}
+}

--- a/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
+++ b/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
@@ -37,7 +37,7 @@ func TestPostgresSchema_cloudProviderAndSize(t *testing.T) {
 		{"cloud_provider", types.StringNull(), false},
 		{"cloud_provider", types.StringUnknown(), false},
 		{"size", types.StringValue("m6gd.large"), false},
-		{"size", types.StringValue("c4a-highmem-4"), false},
+		// {"size", types.StringValue("c4a-highmem-4"), false}, // Requires access to the GCP ARM preview.
 		{"size", types.StringValue("c4-standard-4"), false},
 		{"size", types.StringValue("c4d-highmem-8"), false},
 		{"size", types.StringValue("z3-highlssd-8"), false},
@@ -102,7 +102,7 @@ func TestPostgresCreate_cloudProviders(t *testing.T) {
 		size     string
 	}{
 		{"aws", "us-east-1", "m6gd.large"},
-		{"gcp", "us-west1", "c4a-highmem-4"},
+		{"gcp", "us-west1", "c4-highmem-4"},
 	} {
 		t.Run(tc.provider, func(t *testing.T) {
 			ctx := context.Background()
@@ -161,7 +161,7 @@ func TestPostgresPlanInheritedAttributes_GCP(t *testing.T) {
 			ctx := context.Background()
 			client := api.NewClientMock(minimock.NewController(t))
 			client.GetPostgresMock.Expect(ctx, "pg-source").Return(&api.Postgres{
-				Provider: "gcp", Region: "us-west1", Size: "c4a-highmem-4", PostgresVersion: "18",
+				Provider: "gcp", Region: "us-west1", Size: "c4-highmem-4", PostgresVersion: "18",
 			}, nil)
 			r := &PostgresServiceResource{client: client}
 			var schemaResp resource.SchemaResponse
@@ -192,7 +192,7 @@ func TestPostgresPlanInheritedAttributes_GCP(t *testing.T) {
 			require.Equal(t, "us-west1", got.Region.ValueString())
 			require.Equal(t, "18", got.PostgresVersion.ValueString())
 			if origin == "replica" {
-				require.Equal(t, "c4a-highmem-4", got.Size.ValueString())
+				require.Equal(t, "c4-highmem-4", got.Size.ValueString())
 			} else {
 				require.True(t, got.Size.IsUnknown())
 			}

--- a/internal/service/postgres/resource/postgres_service_constants.go
+++ b/internal/service/postgres/resource/postgres_service_constants.go
@@ -5,6 +5,7 @@ package resource
 
 var postgresCloudProviders = []string{
 	"aws",
+	"gcp",
 }
 
 var postgresVersions = []string{


### PR DESCRIPTION
`clickhouse_postgres_service` rejects `cloud_provider = "gcp"` during Terraform validation even though the Postgres OpenAPI supports it. Allow GCP through the existing AWS lifecycle and API client, and show a private preview warning when GCP is explicitly selected. Size and region availability remain validated by the API, following the existing AWS behavior.

Document the organization/region access requirement and add a primary + read replica + data sources example under `examples/full/postgres/gcp`, which the existing E2E workflow discovers automatically. The example uses `c4-highmem-4`; the ARM alternative is commented out while separately gated.

Validation:

- `make test`, `make fmt`, `make lint`, `make build`, `make docs-validate`, and `make docs-check` pass locally with Go 1.26.0. The full unit target was rerun for staging verification.
- New tests cover AWS/GCP creation and state, provider and size validation, private preview warnings including null/unknown values, and GCP replica/restore inheritance.
- Terraform 1.11.4 validates both AWS and GCP examples. Offline AWS/GCP plans succeed using dummy credentials and a loopback-only API URL.
- Tested the local PR build against staging in `us-central1`: primary/reader creation, TLS and fresh data replication, all Postgres data-source types, imports, invalid configurations and API rejections, tag/config updates and clearing, write-only password rotation, and point-in-time restore with data before/after the recovery point.
- Destroyed all three test services through Terraform; verified HTTP 404 for each ID, empty managed state, and all 38 pre-existing services unchanged. Production was untouched during this staging run.

Other observations: `max_connections` increases with a reader require a reader-first apply, then the primary; the API-requested restart was exercised separately because this resource does not expose restart. Reader password propagation took about 32 seconds and a fresh row took about 57 seconds in this run. The initial runner ended before saving the created reader, so its recorded ID was imported to recover state; the initial two-resource apply was not an uninterrupted success.
