### PR TITLE
refactor(clickhouse): delegate UDF HTTP status parsing to internal/api

### DIFF
--- a/GO_CONVENTIONS.md
+++ b/GO_CONVENTIONS.md
@@ -143,6 +143,15 @@ methods of the same type.
   `resp.Diagnostics` and **return early** on `resp.Diagnostics.HasError()`.
 - Every returned `error` must be checked. `errcheck` enforces this; do not
   silently `_ =` an error without a comment explaining why it's safe.
+- [`internal/api`](internal/api) owns HTTP status classification, because it
+  owns the error format it produces (`status: %d, body: %s`). Classify through
+  its predicates — `api.IsNotFound`, `api.IsConflict`, `api.IsBadRequestWith`,
+  … — or `api.StatusFromMessage` for a status with no named predicate. Never
+  parse status out of error text in the service layer: a second parser silently
+  stops agreeing with the first the moment the format changes. Note that the
+  predicates match a prefix on the outermost error, so on a path that wraps
+  errors before classifying them, go through `api.StatusFromMessage`, which
+  matches anywhere in the message.
 
 ## Context and logging
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,8 +1,37 @@
 package api
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 )
+
+// statusPattern matches the HTTP status this package records when a request
+// fails, formatted as `status: %d, body: %s` (see common.go). The word
+// boundaries keep it from matching a longer run of digits or a status-like
+// suffix of another word.
+var statusPattern = regexp.MustCompile(`(?i)\bstatus:\s*(\d{3})\b`)
+
+// StatusFromMessage returns the HTTP status recorded in an error message or
+// response body, or 0 if it holds none.
+//
+// This package owns the error format, so it also owns recovering the status
+// from it: code outside this package must not parse error text itself. Unlike
+// the prefix-matching predicates below, this finds the status anywhere in the
+// message, so it still works once a caller has wrapped the error with context.
+func StatusFromMessage(message string) int {
+	match := statusPattern.FindStringSubmatch(message)
+	if len(match) != 2 {
+		return 0
+	}
+
+	status, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+
+	return status
+}
 
 func IsNotFound(err error) bool {
 	if err == nil {

--- a/internal/api/errors_test.go
+++ b/internal/api/errors_test.go
@@ -58,6 +58,63 @@ func TestIsServiceIdle(t *testing.T) {
 	}
 }
 
+func TestStatusFromMessage(t *testing.T) {
+	cases := []struct {
+		name    string
+		message string
+		want    int
+	}{
+		{name: "empty", message: "", want: 0},
+		{
+			name:    "raw client error",
+			message: `status: 404, body: {"error":"not found"}`,
+			want:    404,
+		},
+		{
+			// The client records the status at the front, but callers wrap
+			// errors with context before classifying them. The status must
+			// still be found once it is no longer a prefix.
+			name:    "wrapped with context",
+			message: `check whether UDF "f" already exists: status: 404, body: not found`,
+			want:    404,
+		},
+		{name: "server error", message: "status: 502, body: bad gateway", want: 502},
+		{name: "no space after colon", message: "status:410, body: gone", want: 410},
+		{name: "case insensitive", message: "STATUS: 422, body: unprocessable", want: 422},
+		{name: "no status present", message: "dial tcp: connection refused", want: 0},
+		{
+			name:    "unrelated number is not a status",
+			message: "gave up after 3 attempts",
+			want:    0,
+		},
+		{
+			// Guarded by the trailing word boundary, so a longer run of digits
+			// is not silently truncated to a plausible status.
+			name:    "four digits is not a status",
+			message: "status: 4041, body: nope",
+			want:    0,
+		},
+		{
+			// Guarded by the leading word boundary.
+			name:    "status must be its own word",
+			message: "httpstatus: 404, body: not found",
+			want:    0,
+		},
+		{
+			name:    "first status wins",
+			message: `status: 502, body: {"error":"upstream said status: 404"}`,
+			want:    502,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StatusFromMessage(tc.message); got != tc.want {
+				t.Errorf("StatusFromMessage(%q) = %v; want %v", tc.message, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsBadRequestWith(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/service/clickhouse/resource/udf.go
+++ b/internal/service/clickhouse/resource/udf.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1133,10 +1132,7 @@ type udfErrorMetadata struct {
 	requestID string
 }
 
-var (
-	udfStatusPattern    = regexp.MustCompile(`(?i)\bstatus:\s*(\d{3})\b`)
-	udfRequestIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$`)
-)
+var udfRequestIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$`)
 
 func udfErrorInfo(err error) (status int, code, message, requestID string) {
 	var metadataChain []udfErrorMetadata
@@ -1239,9 +1235,7 @@ func parseUDFErrorText(raw string) udfErrorMetadata {
 	if trimmed == "" {
 		return metadata
 	}
-	if match := udfStatusPattern.FindStringSubmatch(trimmed); len(match) == 2 {
-		metadata.status, _ = strconv.Atoi(match[1])
-	}
+	metadata.status = api.StatusFromMessage(trimmed)
 
 	if value, ok := parseEmbeddedUDFJSON(trimmed); ok {
 		metadata.code = jsonStringField(value, "code")

--- a/internal/service/clickhouse/resource/udf_test.go
+++ b/internal/service/clickhouse/resource/udf_test.go
@@ -1469,6 +1469,56 @@ func TestShouldRetryUDFUploadStopsForCanceledContext(t *testing.T) {
 	}
 }
 
+// TestUDFErrorClassificationSurvivesWrapping pins the status classification the
+// UDF paths depend on. The status is recovered by api.StatusFromMessage, and
+// these cases guard the delegation: the UDF code wraps errors with context
+// before classifying them, so a status that is no longer a prefix must still be
+// found. api.IsNotFound deliberately does not handle that (it matches a prefix
+// on the outermost error only), which is why the UDF predicates exist.
+func TestUDFErrorClassificationSurvivesWrapping(t *testing.T) {
+	notFound := fmt.Errorf("check whether UDF %q already exists: %w", "my_fn",
+		errors.New(`status: 404, body: {"error":"function not found"}`))
+	gone := fmt.Errorf("publish UDF version: %w",
+		errors.New("status: 410, body: upload expired"))
+	serverError := fmt.Errorf("wait for UDF build: %w",
+		errors.New("status: 502, body: bad gateway"))
+	transport := fmt.Errorf("upload UDF source archive: %w",
+		errors.New("dial tcp 10.0.0.1:443: connect: connection refused"))
+
+	if status, _, _, _ := udfErrorInfo(notFound); status != 404 {
+		t.Errorf("udfErrorInfo(wrapped 404) status = %d; want 404", status)
+	}
+	if !isUDFNotFound(notFound) {
+		t.Error("isUDFNotFound(wrapped 404) = false; want true")
+	}
+	if !isUDFHTTPStatus(gone, 410) {
+		t.Error("isUDFHTTPStatus(wrapped 410, 410) = false; want true")
+	}
+	if !isUDFServerError(serverError) {
+		t.Error("isUDFServerError(wrapped 502) = false; want true")
+	}
+	if isUDFServerError(notFound) {
+		t.Error("isUDFServerError(wrapped 404) = true; want false")
+	}
+	if !isUDFTransportError(transport) {
+		t.Error("isUDFTransportError(no status) = false; want true")
+	}
+	if isUDFTransportError(gone) {
+		t.Error("isUDFTransportError(wrapped 410) = true; want false")
+	}
+
+	// The UDF-specific carve-out: a 404 whose body says the API could not
+	// perform the operation is not resource drift, so it must not be treated
+	// as a missing UDF.
+	cannotGet := errors.New(`status: 404, body: {"error":"cannot get function my_fn"}`)
+	if isUDFNotFound(cannotGet) {
+		t.Error(`isUDFNotFound("cannot get") = true; want false`)
+	}
+	if !isUDFHTTPStatus(cannotGet, 404) {
+		t.Error("isUDFHTTPStatus(cannot-get 404, 404) = false; want true")
+	}
+}
+
 func TestUDFBuildErrorKeepsOnlyActionableCause(t *testing.T) {
 	raw := "Build Failure: failed at ECS build task: Task completed with non-zero exit code: 1\nReason: {\"success\":false,\"error\":\"panic: [X] Failed to extract source zip file: main.py was not found in the zip archive\"}"
 	detail := udfBuildFailureDetail("my_fn", 1, true, types.Int64Null(), true, raw)


### PR DESCRIPTION
## Why

`internal/api` owns the error format it produces — `status: %d, body: %s` (`internal/api/common.go:265`) — so it should also own recovering the HTTP status from it. Every resource in the provider classifies errors through its predicates (`api.IsNotFound`, `api.IsConflict`, …).

`udf.go` was the one exception. It carried a second parser, `udfStatusPattern`, and used it *alongside* `api.IsConflict` (`udf.go:767`, `:1011`) and `api.IsForbidden` (`:1025`) in the same file — two sources of truth for one question. A change to the error format would have silently broken only one of them: no compile error, no test failure, just UDF quietly misclassifying 404s and no longer noticing that a function was deleted outside Terraform.

I confirmed this was the only such case. Searching the whole service layer for status-text parsing turns up nothing outside `internal/api` once this change is in.

## What changed

- **`internal/api/errors.go`** — adds `StatusFromMessage(message string) int`, with the regexp moved **verbatim** from `udf.go:1137`.
- **`internal/service/clickhouse/resource/udf.go`** — deletes `udfStatusPattern`, sources the status from `api.StatusFromMessage`, drops the now-unused `strconv` import.
- **`GO_CONVENTIONS.md`** — records the rule under `## Error handling`, so the boundary stops being something the next contributor has to reverse-engineer.

### Why a `string` parameter rather than `error`

Two callers need it: per-link inside `udfErrorInfo`'s unwrap walk, and `safeUDFBuildCause`, which parses a build-log string that was never an `error` value.

### Why UDF needed its own parser in the first place

The existing predicates match a **prefix** on the outermost error. The UDF paths wrap errors with context before classifying them (`udf.go:567`, `udf_polling.go:101`), which pushes `status: 404` off the front and makes a prefix match fail. `StatusFromMessage` matches anywhere in the message, so it works either way. That distinction is now documented in `GO_CONVENTIONS.md`.

## Behavior

Unchanged. The regexp moved verbatim, and `TestUDFErrorClassificationSurvivesWrapping` was written **before** the refactor to pin the classification these paths depend on — `udfErrorInfo`, `isUDFNotFound`, `isUDFHTTPStatus`, `isUDFServerError`, `isUDFTransportError`, plus the UDF-specific carve-out where a 404 saying `cannot get`/`cannot delete` is not treated as drift. It passes both before and after the move, which is what makes this safe to call a pure refactor.

`TestStatusFromMessage` covers the new function with 11 cases, including the word-boundary guards (`status: 4041` → 0, `httpstatus: 404` → 0) and the wrapped-error case above.

## Deliberately out of scope

- **`IsNotFound` / `IsConflict` / `IsForbidden` / `is5xx` are untouched.** Routing them through `StatusFromMessage` would make them chain-aware and change error classification for *every* resource in the provider — a real behavior change that deserves its own PR and its own test sweep, not a silent rider on a refactor.
- **`udf.go`'s size.** At 39 free functions against a peer range of 4-8, it's still an outlier; the message-extraction, request-ID, and truncation helpers are presentation logic, aren't duplicated anywhere, and stay put.

## Verification

- `go test ./...` — 11 packages, 0 failures
- `golangci-lint run` — 0 issues
- `go vet ./...`, `go fmt ./...` — clean

Two local gates could not run, both for environmental reasons unrelated to this change, and both fail identically on a clean tree:

- `make fmt` / `make lint` panic with `file requires newer Go version go1.27 (application built with go1.26)`. `Makefile:107` pins `GOTOOLCHAIN := go1.26.0` when building `golangci-lint`, which mismatches a local Go 1.27.1. Running the linter under the pinned toolchain gives the clean result above.
- `make docs-check` fails downloading the Terraform CLI with `openpgp: key expired`. This change touches no `Schema()`, no examples, and nothing under `docs/`, so generated docs cannot have changed. Relying on CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
