### PR TITLE
feat(ClickPipes/MySQL): Allow setting server id

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -407,6 +407,7 @@ Optional:
 - `disable_tls` (Boolean) Disable TLS for the MySQL connection.
 - `iam_role` (String) IAM role ARN for IAM authentication. Required when authentication is set to `IAM_ROLE`.
 - `port` (Number) The port of the MySQL instance. Default is 3306.
+- `server_id` (Number) Optional MySQL `server_id` the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned randomly. Must be a non-zero unsigned 32-bit integer (1 to 4294967295).
 - `skip_cert_verification` (Boolean) Skip certificate verification for the MySQL connection.
 - `ssh_key_resource_id` (String) ID of a standalone SSH key resource (`clickhouse_clickpipes_ssh_key`) to tunnel the connection through. Mutually exclusive with inline SSH configuration. Immutable; changing it forces resource replacement.
 - `tls_host` (String) TLS/SSL host for secure connections. Used to verify the server certificate.

--- a/examples/clickpipe/cdc_mysql/main.tf
+++ b/examples/clickpipe/cdc_mysql/main.tf
@@ -60,6 +60,11 @@ resource "clickhouse_clickpipe" "mysql_cdc" {
       host = var.mysql_host
       port = var.mysql_port
 
+      # Optional: server_id the pipe declares itself as in the MySQL replication
+      # topology. Must be unique across replicas connected to the source. If
+      # omitted, one is assigned automatically.
+      # server_id = 4242
+
       credentials = {
         username = var.mysql_username
         password = var.mysql_password

--- a/examples/clickpipe/cdc_mysql/main.tf
+++ b/examples/clickpipe/cdc_mysql/main.tf
@@ -62,7 +62,7 @@ resource "clickhouse_clickpipe" "mysql_cdc" {
 
       # Optional: server_id the pipe declares itself as in the MySQL replication
       # topology. Must be unique across replicas connected to the source. If
-      # omitted, one is assigned automatically.
+      # omitted, one is assigned randomly.
       # server_id = 4242
 
       credentials = {

--- a/internal/api/clickpipe_models.go
+++ b/internal/api/clickpipe_models.go
@@ -230,6 +230,7 @@ type ClickPipeMySQLSource struct {
 	CACertificate         *string                      `json:"caCertificate,omitempty"`
 	DisableTLS            *bool                        `json:"disableTls,omitempty"`
 	SkipCertVerification  *bool                        `json:"skipCertVerification,omitempty"`
+	ServerID              *uint32                      `json:"serverId,omitempty"`
 	Credentials           *ClickPipeSourceCredentials  `json:"credentials,omitempty"`
 	Settings              *ClickPipeMySQLSettings      `json:"settings,omitempty"`
 	Mappings              []ClickPipeMySQLTableMapping `json:"tableMappings,omitempty"`

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -1255,7 +1255,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 							// narrows the value to uint32 behind a runtime bounds check.
 							"server_id": schema.Int64Attribute{
 								MarkdownDescription: fmt.Sprintf(
-									"Optional MySQL `server_id` the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned automatically. Must be an unsigned 32-bit integer (1 to %d).",
+									"Optional MySQL `server_id` the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned randomly. Must be a non-zero unsigned 32-bit integer (1 to %d).",
 									uint32(math.MaxUint32),
 								),
 								Optional: true,

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -1247,6 +1248,24 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Default:     booldefault.StaticBool(false),
+							},
+							// server_id is a uint32 on the wire (see api.ClickPipeMySQLSource.ServerID),
+							// Int64Attribute is the smallest type that can hold its full domain.
+							// The validator below enforces the real range, and extractSourceFromPlan
+							// narrows the value to uint32 behind a runtime bounds check.
+							"server_id": schema.Int64Attribute{
+								MarkdownDescription: fmt.Sprintf(
+									"Optional MySQL `server_id` the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned automatically. Must be an unsigned 32-bit integer (1 to %d).",
+									uint32(math.MaxUint32),
+								),
+								Optional: true,
+								Computed: true,
+								Validators: []validator.Int64{
+									int64validator.Between(1, math.MaxUint32),
+								},
+								PlanModifiers: []planmodifier.Int64{
+									int64planmodifier.UseStateForUnknown(),
+								},
 							},
 							"credentials": schema.SingleNestedAttribute{
 								MarkdownDescription: "The credentials for the MySQL instance. Username is always required. For `basic` authentication, supply either `password` or `password_wo`. For `IAM_ROLE` authentication, password is optional.",
@@ -3719,6 +3738,12 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			val := mysqlModel.SkipCertVerification.ValueBool()
 			mysqlSource.SkipCertVerification = &val
 		}
+		if !mysqlModel.ServerID.IsNull() && !mysqlModel.ServerID.IsUnknown() {
+			if v := mysqlModel.ServerID.ValueInt64(); v >= 1 && v <= math.MaxUint32 {
+				serverID := uint32(v)
+				mysqlSource.ServerID = &serverID
+			}
+		}
 		if !isUpdate {
 			mysqlSource.SSHKeyResourceID = mysqlModel.SSHKeyResourceID.ValueStringPointer()
 		}
@@ -4818,6 +4843,14 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			mysqlModel.SkipCertVerification = types.BoolValue(*clickPipe.Source.MySQL.SkipCertVerification)
 		} else {
 			mysqlModel.SkipCertVerification = types.BoolValue(false)
+		}
+
+		if clickPipe.Source.MySQL.ServerID != nil {
+			mysqlModel.ServerID = types.Int64Value(int64(*clickPipe.Source.MySQL.ServerID))
+		} else if !stateMySQLModel.ServerID.IsNull() {
+			mysqlModel.ServerID = stateMySQLModel.ServerID
+		} else {
+			mysqlModel.ServerID = types.Int64Null()
 		}
 
 		if len(tableMappingList) > 0 {

--- a/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
@@ -246,6 +246,7 @@ func buildMySQLPlanWithCredentials(credentials types.Object) models.ClickPipeRes
 		"ca_certificate":         types.StringNull(),
 		"disable_tls":            types.BoolNull(),
 		"skip_cert_verification": types.BoolNull(),
+		"server_id":              types.Int64Null(),
 		"credentials":            credentials,
 		"settings":               types.ObjectValueMust(models.ClickPipeMySQLSettingsModel{}.ObjectType().AttrTypes, settingsAttrs),
 		"table_mappings": types.SetValueMust(models.ClickPipeMySQLTableMappingModel{}.ObjectType(), []attr.Value{

--- a/internal/service/clickhouse/resource/clickpipe_mysql_server_id_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_mysql_server_id_test.go
@@ -1,0 +1,243 @@
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickhouse/resource/models"
+)
+
+// buildMySQLServerIDPlan returns a minimal MySQL CDC plan/state with the given
+// server_id value (known, null, or unknown).
+func uint32Ptr(v uint32) *uint32 { return &v }
+
+func buildMySQLServerIDPlan(serverID types.Int64) models.ClickPipeResourceModel {
+	settingsModel := models.ClickPipeMySQLSettingsModel{
+		ReplicationMode: types.StringValue(api.ClickPipeReplicationModeCDC),
+	}
+	mysqlAttrs := map[string]attr.Value{
+		"type":                   types.StringValue("mysql"),
+		"host":                   types.StringValue("mysql.example.com"),
+		"port":                   types.Int64Value(3306),
+		"authentication":         types.StringValue(clickPipeAuthBasic),
+		"iam_role":               types.StringNull(),
+		"tls_host":               types.StringNull(),
+		"ca_certificate":         types.StringNull(),
+		"disable_tls":            types.BoolNull(),
+		"skip_cert_verification": types.BoolNull(),
+		"server_id":              serverID,
+		"credentials":            dbSourceCredentials(),
+		"settings":               settingsModel.ObjectValue(),
+		"table_mappings":         types.SetValueMust(models.ClickPipeMySQLTableMappingModel{}.ObjectType(), []attr.Value{}),
+		"ssh_key_resource_id":    types.StringNull(),
+	}
+	sourceModel := dbSourceModels(
+		types.ObjectNull(models.ClickPipePostgresSourceModel{}.ObjectType().AttrTypes),
+		types.ObjectValueMust(models.ClickPipeMySQLSourceModel{}.ObjectType().AttrTypes, mysqlAttrs),
+	)
+	return models.ClickPipeResourceModel{
+		ID:        types.StringValue("test-pipe-id"),
+		ServiceID: types.StringValue("service-123"),
+		Name:      types.StringValue("test-mysql-server-id"),
+		Source:    sourceModel.ObjectValue(),
+	}
+}
+
+func TestExtractSourceFromPlan_MySQL_ServerIDSet(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Value(4242))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.MySQL)
+	assert.NotNil(t, source.MySQL.ServerID)
+	assert.Equal(t, uint32(4242), *source.MySQL.ServerID)
+}
+
+// server_id is a uint32 on the wire; the upper bound must survive the
+// int64 (Terraform) -> uint32 (API) narrowing.
+func TestExtractSourceFromPlan_MySQL_ServerIDMaxValue(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Value(math.MaxUint32))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.MySQL.ServerID)
+	assert.Equal(t, uint32(math.MaxUint32), *source.MySQL.ServerID)
+}
+
+// Values outside the uint32 range are rejected by the schema validator; the
+// conversion path must never emit a wrapped value if one slips through.
+func TestExtractSourceFromPlan_MySQL_ServerIDOutOfRangeNotSent(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Value(math.MaxUint32 + 1))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.Nil(t, source.MySQL.ServerID)
+}
+
+func TestExtractSourceFromPlan_MySQL_ServerIDNull(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Null())
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.MySQL)
+	assert.Nil(t, source.MySQL.ServerID)
+}
+
+// server_id is Optional+Computed, so on create it is unknown when not configured.
+// An unknown value must not be sent (the control plane assigns one).
+func TestExtractSourceFromPlan_MySQL_ServerIDUnknown(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Unknown())
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, false)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.MySQL)
+	assert.Nil(t, source.MySQL.ServerID)
+}
+
+func TestExtractSourceFromPlan_MySQL_ServerIDKeptOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	r := &ClickPipeResource{}
+
+	plan := buildMySQLServerIDPlan(types.Int64Value(4242))
+
+	diagnostics := diag.Diagnostics{}
+	source := r.extractSourceFromPlan(ctx, &diagnostics, plan, nil, true)
+
+	assert.False(t, diagnostics.HasError(), "expected no errors, got: %v", diagnostics.Errors())
+	assert.NotNil(t, source.MySQL)
+	assert.NotNil(t, source.MySQL.ServerID)
+	assert.Equal(t, uint32(4242), *source.MySQL.ServerID)
+}
+
+func TestClickPipeMySQLSource_ServerIDJSON(t *testing.T) {
+	withServerID, err := json.Marshal(api.ClickPipeMySQLSource{Host: "h", Port: 3306, ServerID: uint32Ptr(4242)})
+	assert.NoError(t, err)
+	assert.Contains(t, string(withServerID), `"serverId":4242`)
+
+	withoutServerID, err := json.Marshal(api.ClickPipeMySQLSource{Host: "h", Port: 3306})
+	assert.NoError(t, err)
+	assert.NotContains(t, string(withoutServerID), "serverId")
+}
+
+func mysqlAPIResponse(serverID *uint32) *api.ClickPipe {
+	return &api.ClickPipe{
+		ID:    "test-pipe-id",
+		Name:  "test-pipe",
+		State: "Running",
+		Source: api.ClickPipeSource{
+			MySQL: &api.ClickPipeMySQLSource{
+				Type:     api.ClickPipeMySQLSourceTypeMySQL,
+				Host:     "mysql.example.com",
+				Port:     3306,
+				ServerID: serverID,
+				Settings: &api.ClickPipeMySQLSettings{ReplicationMode: api.ClickPipeReplicationModeCDC},
+				Mappings: []api.ClickPipeMySQLTableMapping{{
+					SourceSchemaName: "mydb",
+					SourceTable:      "users",
+					TargetTable:      "users",
+				}},
+			},
+		},
+		Destination: api.ClickPipeDestination{Database: "default"},
+	}
+}
+
+func readMySQLModelFromState(ctx context.Context, t *testing.T, state models.ClickPipeResourceModel) models.ClickPipeMySQLSourceModel {
+	var sourceModel models.ClickPipeSourceModel
+	diags := state.Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{})
+	assert.False(t, diags.HasError(), "reading source: %v", diags)
+	var mysqlModel models.ClickPipeMySQLSourceModel
+	diags = sourceModel.MySQL.As(ctx, &mysqlModel, basetypes.ObjectAsOptions{})
+	assert.False(t, diags.HasError(), "reading mysql source: %v", diags)
+	return mysqlModel
+}
+
+func TestClickPipeResource_syncClickPipeState_MySQLServerID(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		stateServerID types.Int64
+		apiServerID   *uint32
+		expected      types.Int64
+	}{
+		{
+			name:          "API value wins over state",
+			stateServerID: types.Int64Value(1),
+			apiServerID:   uint32Ptr(4242),
+			expected:      types.Int64Value(4242),
+		},
+		{
+			name:          "auto-assigned value is adopted when state is null",
+			stateServerID: types.Int64Null(),
+			apiServerID:   uint32Ptr(math.MaxUint32),
+			expected:      types.Int64Value(math.MaxUint32),
+		},
+		{
+			name:          "state value preserved when API omits the field",
+			stateServerID: types.Int64Value(4242),
+			apiServerID:   nil,
+			expected:      types.Int64Value(4242),
+		},
+		{
+			name:          "null when neither API nor state has a value",
+			stateServerID: types.Int64Null(),
+			apiServerID:   nil,
+			expected:      types.Int64Null(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := buildMySQLServerIDPlan(tt.stateServerID)
+
+			mc := minimock.NewController(t)
+			apiClientMock := api.NewClientMock(mc).
+				GetClickPipeMock.
+				Expect(ctx, state.ServiceID.ValueString(), state.ID.ValueString()).
+				Return(mysqlAPIResponse(tt.apiServerID), nil)
+
+			r := &ClickPipeResource{client: apiClientMock}
+			err := r.syncClickPipeState(ctx, &state)
+			assert.NoError(t, err)
+
+			mysqlModel := readMySQLModelFromState(ctx, t, state)
+			assert.True(t, tt.expected.Equal(mysqlModel.ServerID), "expected server_id %v, got %v", tt.expected, mysqlModel.ServerID)
+		})
+	}
+}

--- a/internal/service/clickhouse/resource/clickpipe_ssh_key_resource_id_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_ssh_key_resource_id_test.go
@@ -282,6 +282,7 @@ func buildMySQLSSHKeyResourcePlan(sshKeyResourceID types.String) models.ClickPip
 		"ca_certificate":         types.StringNull(),
 		"disable_tls":            types.BoolNull(),
 		"skip_cert_verification": types.BoolNull(),
+		"server_id":              types.Int64Null(),
 		"credentials":            dbSourceCredentials(),
 		"settings":               settingsModel.ObjectValue(),
 		"table_mappings":         types.SetValueMust(models.ClickPipeMySQLTableMappingModel{}.ObjectType(), []attr.Value{}),

--- a/internal/service/clickhouse/resource/clickpipe_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_test.go
@@ -1195,6 +1195,7 @@ func buildMySQLCredentialsPlan(password, passwordWO types.String, passwordWOVers
 			"ca_certificate":         types.StringNull(),
 			"disable_tls":            types.BoolNull(),
 			"skip_cert_verification": types.BoolNull(),
+			"server_id":              types.Int64Null(),
 			"credentials":            types.ObjectValueMust(models.ClickPipeSourceCredentialsModel{}.ObjectType().AttrTypes, credAttrs),
 			"settings":               types.ObjectValueMust(models.ClickPipeMySQLSettingsModel{}.ObjectType().AttrTypes, settingsAttrs),
 			"table_mappings":         types.SetValueMust(models.ClickPipeMySQLTableMappingModel{}.ObjectType(), []attr.Value{}),

--- a/internal/service/clickhouse/resource/models/clickpipe_resource.go
+++ b/internal/service/clickhouse/resource/models/clickpipe_resource.go
@@ -731,6 +731,11 @@ func (m ClickPipeMySQLTableMappingModel) ObjectValue() types.Object {
 	})
 }
 
+// ClickPipeMySQLSourceModel is the Terraform view of api.ClickPipeMySQLSource.
+//
+// ServerID is a uint32 in the API but is held as Int64 here: the plugin
+// framework has no unsigned type and Int32 cannot represent values above
+// 2147483647. The schema validator enforces the uint32 range.
 type ClickPipeMySQLSourceModel struct {
 	Type                 types.String `tfsdk:"type"`
 	Host                 types.String `tfsdk:"host"`
@@ -741,6 +746,7 @@ type ClickPipeMySQLSourceModel struct {
 	CACertificate        types.String `tfsdk:"ca_certificate"`
 	DisableTLS           types.Bool   `tfsdk:"disable_tls"`
 	SkipCertVerification types.Bool   `tfsdk:"skip_cert_verification"`
+	ServerID             types.Int64  `tfsdk:"server_id"`
 	Credentials          types.Object `tfsdk:"credentials"`
 	Settings             types.Object `tfsdk:"settings"`
 	TableMappings        types.Set    `tfsdk:"table_mappings"`
@@ -759,6 +765,7 @@ func (m ClickPipeMySQLSourceModel) ObjectType() types.ObjectType {
 			"ca_certificate":         types.StringType,
 			"disable_tls":            types.BoolType,
 			"skip_cert_verification": types.BoolType,
+			"server_id":              types.Int64Type,
 			"credentials":            ClickPipeSourceCredentialsModel{}.ObjectType(),
 			"settings":               ClickPipeMySQLSettingsModel{}.ObjectType(),
 			"table_mappings":         types.SetType{ElemType: ClickPipeMySQLTableMappingModel{}.ObjectType()},
@@ -778,6 +785,7 @@ func (m ClickPipeMySQLSourceModel) ObjectValue() types.Object {
 		"ca_certificate":         m.CACertificate,
 		"disable_tls":            m.DisableTLS,
 		"skip_cert_verification": m.SkipCertVerification,
+		"server_id":              m.ServerID,
 		"credentials":            m.Credentials,
 		"settings":               m.Settings,
 		"table_mappings":         m.TableMappings,


### PR DESCRIPTION
This PR adds support to MySQL ClickPipes server_id parameter as documented at:

- UI docs: https://clickhouse.com/docs/integrations/clickpipes/mysql#advanced-settings
- API spec: https://clickhouse.com/docs/products/cloud/api-reference/clickpipes/create-clickpipe#body-source-mysql-one-of-0-server-id

Follows:
- https://linear.app/clickhouse/issue/DBI-798/pick-a-range-for-random-server-id-allow-user-override 