### PR TITLE
fix(clickpipes): wait for deletion before releasing Terraform resources

### DIFF
--- a/internal/api/clickpipe.go
+++ b/internal/api/clickpipe.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -546,13 +550,63 @@ func (c *ClientImpl) ChangeClickPipeState(ctx context.Context, serviceId string,
 	return &clickPipeResponse.Result, nil
 }
 
+// DeleteClickPipe waits for authoritative absence after the API accepts deletion.
+// The 15-minute budget covers DELETE, service wake-up, retries and GET polling;
+// the HTTP client's timeout only limits individual requests.
 func (c *ClientImpl) DeleteClickPipe(ctx context.Context, serviceId string, clickPipeId string) error {
-	req, err := http.NewRequest(http.MethodDelete, c.getClickPipePath(serviceId, clickPipeId, ""), nil)
-	if err != nil {
-		return err
+	return c.deleteClickPipeWithBudget(ctx, serviceId, clickPipeId, 15*time.Minute, 5*time.Second)
+}
+
+func (c *ClientImpl) deleteClickPipeWithBudget(ctx context.Context, serviceId, clickPipeId string, maxWait, interval time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, maxWait)
+	defer cancel()
+
+	deleteAccepted := false
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("waiting for ClickPipe %s deletion: %w", clickPipeId, err)
+		}
+		var err error
+		if !deleteAccepted {
+			var req *http.Request
+			req, err = http.NewRequest(http.MethodDelete, c.getClickPipePath(serviceId, clickPipeId, ""), nil)
+			if err != nil {
+				return err
+			}
+			_, err = c.doClickPipeRequest(ctx, serviceId, req)
+			if err == nil {
+				deleteAccepted = true
+				continue
+			}
+		} else {
+			// Every existing state, including Deleting, means cleanup is pending.
+			_, err = c.GetClickPipe(ctx, serviceId, clickPipeId)
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("waiting for ClickPipe %s deletion: %w", clickPipeId, ctx.Err())
+		}
+		if IsNotFound(err) {
+			return nil
+		}
+		if err != nil && !isClickPipeDeletionRetryable(err) {
+			return err
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("waiting for ClickPipe %s deletion: %w", clickPipeId, ctx.Err())
+		case <-timer.C:
+		}
 	}
-	_, err = c.doClickPipeRequest(ctx, serviceId, req)
-	return err
+}
+
+func isClickPipeDeletionRetryable(err error) bool {
+	var networkErr net.Error
+	var operationErr *net.OpError
+	return is5xx(err) || strings.HasPrefix(err.Error(), "status: 429") ||
+		errors.As(err, &operationErr) || (errors.As(err, &networkErr) && networkErr.Timeout()) ||
+		errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 }
 
 func (c *ClientImpl) GetClickPipeSettings(ctx context.Context, serviceId string, clickPipeId string) (map[string]any, error) {

--- a/internal/api/clickpipe_delete_test.go
+++ b/internal/api/clickpipe_delete_test.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeleteClickPipe(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		deleteStatus int
+		getStatuses  []int
+		wantError    string
+	}{
+		{name: "waits for absence", deleteStatus: 200, getStatuses: []int{200, 200, 404}},
+		{name: "already absent", deleteStatus: 404},
+		{name: "delete forbidden", deleteStatus: 403, wantError: "status: 403"},
+		{name: "poll unauthorized", deleteStatus: 200, getStatuses: []int{401}, wantError: "status: 401"},
+		{name: "poll forbidden", deleteStatus: 200, getStatuses: []int{403}, wantError: "status: 403"},
+		{name: "poll server failure", deleteStatus: 200, getStatuses: []int{503, 200, 404}},
+		{name: "poll throttled", deleteStatus: 200, getStatuses: []int{429, 404}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var deletes, gets int
+			client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != testClickPipesPath+"pipe-1" {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				switch r.Method {
+				case http.MethodDelete:
+					deletes++
+					w.WriteHeader(tc.deleteStatus)
+				case http.MethodGet:
+					gets++
+					if gets > len(tc.getStatuses) {
+						t.Error("unexpected extra GET")
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					w.WriteHeader(tc.getStatuses[gets-1])
+					state := "Deleting"
+					if gets == 1 {
+						state = "Running"
+					}
+					_, _ = w.Write([]byte(`{"result":{"id":"pipe-1","state":"` + state + `"}}`))
+				default:
+					t.Errorf("unexpected method: %s", r.Method)
+				}
+			})
+			err := client.deleteClickPipeWithBudget(t.Context(), testServiceID, "pipe-1", 20*time.Second, time.Millisecond)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("delete: %v", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("error = %v; want %s", err, tc.wantError)
+			}
+			if deletes != 1 || gets != len(tc.getStatuses) {
+				t.Fatalf("DELETE calls = %d, GET calls = %d; want 1, %d", deletes, gets, len(tc.getStatuses))
+			}
+		})
+	}
+}
+
+func TestDeleteClickPipeDeadline(t *testing.T) {
+	for _, phase := range []string{"pending", "delete retry", "poll retry", "throttled", "in flight"} {
+		t.Run(phase, func(t *testing.T) {
+			client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if phase == "delete retry" || (phase == "poll retry" && r.Method == http.MethodGet) {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				if phase == "throttled" {
+					w.Header().Set(ResponseHeaderRateLimitReset, "120")
+					w.WriteHeader(http.StatusTooManyRequests)
+					return
+				}
+				if phase == "in flight" {
+					<-r.Context().Done()
+					return
+				}
+				_, _ = w.Write([]byte(`{"result":{"state":"Deleting"}}`))
+			})
+			start := time.Now()
+			err := client.deleteClickPipeWithBudget(t.Context(), testServiceID, "pipe-1", 100*time.Millisecond, time.Millisecond)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("error = %v; want deadline exceeded", err)
+			}
+			if elapsed := time.Since(start); elapsed > time.Second {
+				t.Fatalf("deadline was not respected: %v", elapsed)
+			}
+		})
+	}
+}
+
+func TestDeleteClickPipeCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			cancel()
+		}
+		_, _ = w.Write([]byte(`{"result":{"state":"Deleting"}}`))
+	})
+	err := client.DeleteClickPipe(ctx, testServiceID, "pipe-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v; want canceled", err)
+	}
+}
+
+func TestDeleteClickPipeRetriesDelete(t *testing.T) {
+	var deletes int
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deletes++
+			if deletes == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	if err := client.DeleteClickPipe(t.Context(), testServiceID, "pipe-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deletes != 2 {
+		t.Fatalf("DELETE calls = %d; want 2", deletes)
+	}
+}
+
+func TestDeleteClickPipeMalformedResponse(t *testing.T) {
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not JSON`))
+	})
+	err := client.DeleteClickPipe(t.Context(), testServiceID, "pipe-1")
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("error = %v; want invalid JSON error", err)
+	}
+}

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -257,7 +257,13 @@ func (c *ClientImpl) doRequestWithStatus(
 			}
 
 			// Wait for the calculated exponential backoff number of seconds.
-			time.Sleep(time.Second * time.Duration(resetSeconds))
+			timer := time.NewTimer(time.Second * time.Duration(resetSeconds))
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, backoff.Permanent(ctx.Err())
+			case <-timer.C:
+			}
 
 			// Double wait time for next loop
 			currentExponentialBackoff = currentExponentialBackoff * 2


### PR DESCRIPTION
## Problem
ClickPipe DELETE acknowledges a request before backend teardown necessarily finishes. Terraform currently returns immediately, allowing dependent resources to be removed or recreated while cleanup is pending.

## Solution
- Keep the existing public HTTP 200 DELETE contract, then poll GET until 404.
- Treat an already-absent pipe as successful deletion.
- Bound deletion, wake-up, retries, and polling with a 15-minute overall timeout while respecting earlier caller deadlines and cancellation.
- Retry transient failures and make HTTP retry delays context-aware; propagate permanent failures.

## Testing
- `go test ./internal/api ./internal/service/clickhouse/resource -timeout=120s`
- `go test -race ./internal/api -run TestDeleteClickPipe -count=1`
- `go vet ./...`
- golangci-lint: 0 issues.
- Tests cover pending states followed by absence, repeated deletion, transient failures, permanent authorization errors, malformed responses, cancellation, and timeout.
- All applicable GitHub CI checks passed.

## Dependency
Confirmed streaming backend completion requires https://github.com/ClickHouse/clickpipes-platform/pull/7339 to retain deleting pipes until teardown finishes. With the existing immediate-tombstone behavior, GET may still return 404 before cleanup completes. DB-pipe teardown retains its existing completion semantics. Control Plane dependency cleanup remains a separate completion boundary.