### PR TITLE
chore(codeowners): own internal/api and the clickhouse cloud resources

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,10 +6,6 @@
 /internal/service/postgres/   @ClickHouse/clickgres
 /internal/service/clickstack/ @ClickHouse/clickstack
 
-# ClickHouse instance resources and the shared API client. Both sit before the
-# component globs below on purpose: whatever a component already owns there
-# (udf.go, clickpipe_*.go, ...) keeps routing to that component's team, and
-# everything else in these two directories is ours.
 /internal/api/                         @rndD @mdevils @balanza
 /internal/service/clickhouse/resource/ @rndD @mdevils @balanza
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,10 +6,12 @@
 /internal/service/postgres/   @ClickHouse/clickgres
 /internal/service/clickstack/ @ClickHouse/clickstack
 
-# The shared API client. Placed before the component globs below on purpose, so
-# component-specific files inside it (internal/api/postgres.go, udf.go,
-# clickpipe.go, ...) still route to the team that owns that component.
-/internal/api/ @rndD @mdevils @balanza
+# ClickHouse instance resources and the shared API client. Both sit before the
+# component globs below on purpose: whatever a component already owns there
+# (udf.go, clickpipe_*.go, ...) keeps routing to that component's team, and
+# everything else in these two directories is ours.
+/internal/api/                         @rndD @mdevils @balanza
+/internal/service/clickhouse/resource/ @rndD @mdevils @balanza
 
 # Component globs are intentionally LAST: CODEOWNERS gives the last matching
 # pattern precedence, so these keep routing e.g. ClickPipes reviews to their

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,11 @@
 /internal/service/postgres/   @ClickHouse/clickgres
 /internal/service/clickstack/ @ClickHouse/clickstack
 
+# The shared API client. Placed before the component globs below on purpose, so
+# component-specific files inside it (internal/api/postgres.go, udf.go,
+# clickpipe.go, ...) still route to the team that owns that component.
+/internal/api/ @rndD @mdevils @balanza
+
 # Component globs are intentionally LAST: CODEOWNERS gives the last matching
 # pattern precedence, so these keep routing e.g. ClickPipes reviews to their
 # team even though those files live inside the clickhouse service group.


### PR DESCRIPTION
Adds `@rndD`, `@mdevils` and `@balanza` as owners of `/internal/api/` and `/internal/service/clickhouse/resource/` - we are picking up the ClickHouse instance resources and their API surface.
