### PR TITLE
fix(service): bound 404 tolerance after create, finish the state-wait cleanup

### DIFF
--- a/internal/api/client_mock.go
+++ b/internal/api/client_mock.go
@@ -572,9 +572,9 @@ type ClientMock struct {
 	beforeWaitForReversePrivateEndpointStateCounter uint64
 	WaitForReversePrivateEndpointStateMock          mClientMockWaitForReversePrivateEndpointState
 
-	funcWaitForServiceState          func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) (err error)
+	funcWaitForServiceState          func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) (err error)
 	funcWaitForServiceStateOrigin    string
-	inspectFuncWaitForServiceState   func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int)
+	inspectFuncWaitForServiceState   func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption)
 	afterWaitForServiceStateCounter  uint64
 	beforeWaitForServiceStateCounter uint64
 	WaitForServiceStateMock          mClientMockWaitForServiceState
@@ -29444,6 +29444,7 @@ type ClientMockWaitForServiceStateParams struct {
 	serviceId      string
 	stateChecker   func(string) bool
 	maxWaitSeconds int
+	opts           []WaitOption
 }
 
 // ClientMockWaitForServiceStateParamPtrs contains pointers to parameters of the Client.WaitForServiceState
@@ -29452,6 +29453,7 @@ type ClientMockWaitForServiceStateParamPtrs struct {
 	serviceId      *string
 	stateChecker   *func(string) bool
 	maxWaitSeconds *int
+	opts           *[]WaitOption
 }
 
 // ClientMockWaitForServiceStateResults contains results of the Client.WaitForServiceState
@@ -29466,6 +29468,7 @@ type ClientMockWaitForServiceStateExpectationOrigins struct {
 	originServiceId      string
 	originStateChecker   string
 	originMaxWaitSeconds string
+	originOpts           string
 }
 
 // Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
@@ -29479,7 +29482,7 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) Optional() *mClient
 }
 
 // Expect sets up expected params for Client.WaitForServiceState
-func (mmWaitForServiceState *mClientMockWaitForServiceState) Expect(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) *mClientMockWaitForServiceState {
+func (mmWaitForServiceState *mClientMockWaitForServiceState) Expect(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) *mClientMockWaitForServiceState {
 	if mmWaitForServiceState.mock.funcWaitForServiceState != nil {
 		mmWaitForServiceState.mock.t.Fatalf("ClientMock.WaitForServiceState mock is already set by Set")
 	}
@@ -29492,7 +29495,7 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) Expect(ctx context.
 		mmWaitForServiceState.mock.t.Fatalf("ClientMock.WaitForServiceState mock is already set by ExpectParams functions")
 	}
 
-	mmWaitForServiceState.defaultExpectation.params = &ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds}
+	mmWaitForServiceState.defaultExpectation.params = &ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds, opts}
 	mmWaitForServiceState.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
 	for _, e := range mmWaitForServiceState.expectations {
 		if minimock.Equal(e.params, mmWaitForServiceState.defaultExpectation.params) {
@@ -29595,8 +29598,31 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) ExpectMaxWaitSecond
 	return mmWaitForServiceState
 }
 
+// ExpectOptsParam5 sets up expected param opts for Client.WaitForServiceState
+func (mmWaitForServiceState *mClientMockWaitForServiceState) ExpectOptsParam5(opts ...WaitOption) *mClientMockWaitForServiceState {
+	if mmWaitForServiceState.mock.funcWaitForServiceState != nil {
+		mmWaitForServiceState.mock.t.Fatalf("ClientMock.WaitForServiceState mock is already set by Set")
+	}
+
+	if mmWaitForServiceState.defaultExpectation == nil {
+		mmWaitForServiceState.defaultExpectation = &ClientMockWaitForServiceStateExpectation{}
+	}
+
+	if mmWaitForServiceState.defaultExpectation.params != nil {
+		mmWaitForServiceState.mock.t.Fatalf("ClientMock.WaitForServiceState mock is already set by Expect")
+	}
+
+	if mmWaitForServiceState.defaultExpectation.paramPtrs == nil {
+		mmWaitForServiceState.defaultExpectation.paramPtrs = &ClientMockWaitForServiceStateParamPtrs{}
+	}
+	mmWaitForServiceState.defaultExpectation.paramPtrs.opts = &opts
+	mmWaitForServiceState.defaultExpectation.expectationOrigins.originOpts = minimock.CallerInfo(1)
+
+	return mmWaitForServiceState
+}
+
 // Inspect accepts an inspector function that has same arguments as the Client.WaitForServiceState
-func (mmWaitForServiceState *mClientMockWaitForServiceState) Inspect(f func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int)) *mClientMockWaitForServiceState {
+func (mmWaitForServiceState *mClientMockWaitForServiceState) Inspect(f func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption)) *mClientMockWaitForServiceState {
 	if mmWaitForServiceState.mock.inspectFuncWaitForServiceState != nil {
 		mmWaitForServiceState.mock.t.Fatalf("Inspect function is already set for ClientMock.WaitForServiceState")
 	}
@@ -29621,7 +29647,7 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) Return(err error) *
 }
 
 // Set uses given function f to mock the Client.WaitForServiceState method
-func (mmWaitForServiceState *mClientMockWaitForServiceState) Set(f func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) (err error)) *ClientMock {
+func (mmWaitForServiceState *mClientMockWaitForServiceState) Set(f func(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) (err error)) *ClientMock {
 	if mmWaitForServiceState.defaultExpectation != nil {
 		mmWaitForServiceState.mock.t.Fatalf("Default expectation is already set for the Client.WaitForServiceState method")
 	}
@@ -29637,14 +29663,14 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) Set(f func(ctx cont
 
 // When sets expectation for the Client.WaitForServiceState which will trigger the result defined by the following
 // Then helper
-func (mmWaitForServiceState *mClientMockWaitForServiceState) When(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) *ClientMockWaitForServiceStateExpectation {
+func (mmWaitForServiceState *mClientMockWaitForServiceState) When(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) *ClientMockWaitForServiceStateExpectation {
 	if mmWaitForServiceState.mock.funcWaitForServiceState != nil {
 		mmWaitForServiceState.mock.t.Fatalf("ClientMock.WaitForServiceState mock is already set by Set")
 	}
 
 	expectation := &ClientMockWaitForServiceStateExpectation{
 		mock:               mmWaitForServiceState.mock,
-		params:             &ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds},
+		params:             &ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds, opts},
 		expectationOrigins: ClientMockWaitForServiceStateExpectationOrigins{origin: minimock.CallerInfo(1)},
 	}
 	mmWaitForServiceState.expectations = append(mmWaitForServiceState.expectations, expectation)
@@ -29679,17 +29705,17 @@ func (mmWaitForServiceState *mClientMockWaitForServiceState) invocationsDone() b
 }
 
 // WaitForServiceState implements Client
-func (mmWaitForServiceState *ClientMock) WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) (err error) {
+func (mmWaitForServiceState *ClientMock) WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) (err error) {
 	mm_atomic.AddUint64(&mmWaitForServiceState.beforeWaitForServiceStateCounter, 1)
 	defer mm_atomic.AddUint64(&mmWaitForServiceState.afterWaitForServiceStateCounter, 1)
 
 	mmWaitForServiceState.t.Helper()
 
 	if mmWaitForServiceState.inspectFuncWaitForServiceState != nil {
-		mmWaitForServiceState.inspectFuncWaitForServiceState(ctx, serviceId, stateChecker, maxWaitSeconds)
+		mmWaitForServiceState.inspectFuncWaitForServiceState(ctx, serviceId, stateChecker, maxWaitSeconds, opts...)
 	}
 
-	mm_params := ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds}
+	mm_params := ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds, opts}
 
 	// Record call args
 	mmWaitForServiceState.WaitForServiceStateMock.mutex.Lock()
@@ -29708,7 +29734,7 @@ func (mmWaitForServiceState *ClientMock) WaitForServiceState(ctx context.Context
 		mm_want := mmWaitForServiceState.WaitForServiceStateMock.defaultExpectation.params
 		mm_want_ptrs := mmWaitForServiceState.WaitForServiceStateMock.defaultExpectation.paramPtrs
 
-		mm_got := ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds}
+		mm_got := ClientMockWaitForServiceStateParams{ctx, serviceId, stateChecker, maxWaitSeconds, opts}
 
 		if mm_want_ptrs != nil {
 
@@ -29732,6 +29758,11 @@ func (mmWaitForServiceState *ClientMock) WaitForServiceState(ctx context.Context
 					mmWaitForServiceState.WaitForServiceStateMock.defaultExpectation.expectationOrigins.originMaxWaitSeconds, *mm_want_ptrs.maxWaitSeconds, mm_got.maxWaitSeconds, minimock.Diff(*mm_want_ptrs.maxWaitSeconds, mm_got.maxWaitSeconds))
 			}
 
+			if mm_want_ptrs.opts != nil && !minimock.Equal(*mm_want_ptrs.opts, mm_got.opts) {
+				mmWaitForServiceState.t.Errorf("ClientMock.WaitForServiceState got unexpected parameter opts, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+					mmWaitForServiceState.WaitForServiceStateMock.defaultExpectation.expectationOrigins.originOpts, *mm_want_ptrs.opts, mm_got.opts, minimock.Diff(*mm_want_ptrs.opts, mm_got.opts))
+			}
+
 		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
 			mmWaitForServiceState.t.Errorf("ClientMock.WaitForServiceState got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 				mmWaitForServiceState.WaitForServiceStateMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
@@ -29744,9 +29775,9 @@ func (mmWaitForServiceState *ClientMock) WaitForServiceState(ctx context.Context
 		return (*mm_results).err
 	}
 	if mmWaitForServiceState.funcWaitForServiceState != nil {
-		return mmWaitForServiceState.funcWaitForServiceState(ctx, serviceId, stateChecker, maxWaitSeconds)
+		return mmWaitForServiceState.funcWaitForServiceState(ctx, serviceId, stateChecker, maxWaitSeconds, opts...)
 	}
-	mmWaitForServiceState.t.Fatalf("Unexpected call to ClientMock.WaitForServiceState. %v %v %v %v", ctx, serviceId, stateChecker, maxWaitSeconds)
+	mmWaitForServiceState.t.Fatalf("Unexpected call to ClientMock.WaitForServiceState. %v %v %v %v %v", ctx, serviceId, stateChecker, maxWaitSeconds, opts)
 	return
 }
 

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -13,7 +13,7 @@ type Client interface {
 	ListServices(ctx context.Context, filters []string) ([]Service, error)
 	GetOrgPrivateEndpointConfig(ctx context.Context, cloudProvider string, region string) (*OrgPrivateEndpointConfig, error)
 	CreateService(ctx context.Context, s Service) (*Service, string, error)
-	WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error
+	WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) error
 	UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error)
 	UpdateReplicaScaling(ctx context.Context, serviceId string, s ReplicaScalingUpdate) (*Service, error)
 	GetScheduledScaling(ctx context.Context, serviceId string) (*AutoScalingSchedule, error)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -138,7 +138,42 @@ func (c *ClientImpl) CreateService(ctx context.Context, s Service) (*Service, st
 	return &serviceResponse.Result.Service, serviceResponse.Result.Password, nil
 }
 
-func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int) error {
+const defaultStateWaitPollInterval = 5 * time.Second
+
+type waitOptions struct {
+	notFoundTolerance int
+	pollInterval      time.Duration
+}
+
+// withPollInterval shortens the gap between polls. Unexported: it exists so
+// tests do not have to spend real seconds per retry.
+func withPollInterval(d time.Duration) WaitOption {
+	return func(o *waitOptions) {
+		o.pollInterval = d
+	}
+}
+
+// WaitOption configures WaitForServiceState.
+type WaitOption func(*waitOptions)
+
+// TolerateNotFound absorbs up to n 404s during the wait instead of failing on
+// the first one. Use it right after a create: the API is eventually consistent,
+// so a read issued that quickly can miss a service that does exist. Keep n
+// small — past that window a 404 means the service really is gone.
+func TolerateNotFound(n int) WaitOption {
+	return func(o *waitOptions) {
+		o.notFoundTolerance = n
+	}
+}
+
+func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, stateChecker func(string) bool, maxWaitSeconds int, opts ...WaitOption) error {
+	cfg := waitOptions{pollInterval: defaultStateWaitPollInterval}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	notFoundSeen := 0
+
 	// Wait until service is in desired state
 	checkState := func() error {
 		// Only the state field is needed here, so poll the lightweight
@@ -148,6 +183,10 @@ func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, 
 		// wait for a state transition (e.g. right after creating a
 		// service with a token scoped to only that one instance).
 		state, err := c.getServiceState(ctx, serviceId)
+		if IsNotFound(err) && notFoundSeen < cfg.notFoundTolerance {
+			notFoundSeen++
+			return err
+		}
 		if is5xx(err) || is4xxPermanent(err) {
 			// 500s are automatically retried in `doRequest`. A 4xx other
 			// than 429/408 (e.g. a missing permission) will never resolve
@@ -170,7 +209,9 @@ func (c *ClientImpl) WaitForServiceState(ctx context.Context, serviceId string, 
 		maxWaitSeconds = 5
 	}
 
-	return backoff.Retry(checkState, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), uint64(maxWaitSeconds/5)), ctx)) //nolint:gosec
+	maxRetries := uint64(time.Duration(maxWaitSeconds) * time.Second / cfg.pollInterval) //nolint:gosec
+
+	return backoff.Retry(checkState, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(cfg.pollInterval), maxRetries), ctx))
 }
 
 // getServiceState returns just the service state. Unlike GetService it does
@@ -217,8 +258,8 @@ func (c *ClientImpl) wakeService(ctx context.Context, serviceId string) error {
 // only state in which the ClickPipes API accepts creations and updates
 // (partially_running is NOT sufficient). It is a thin wrapper around
 // WaitForServiceState for internal use (e.g. after wakeService).
-func (c *ClientImpl) waitForServiceRunning(ctx context.Context, serviceId string, maxWaitSeconds int) error {
-	return c.WaitForServiceState(ctx, serviceId, func(state string) bool { return state == StateRunning }, maxWaitSeconds)
+func (c *ClientImpl) waitForServiceRunning(ctx context.Context, serviceId string, maxWaitSeconds int, opts ...WaitOption) error {
+	return c.WaitForServiceState(ctx, serviceId, func(state string) bool { return state == StateRunning }, maxWaitSeconds, opts...)
 }
 
 func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s ServiceUpdate) (*Service, error) {
@@ -247,7 +288,9 @@ func (c *ClientImpl) UpdateService(ctx context.Context, serviceId string, s Serv
 }
 
 func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Service, error) {
-	service, err := c.GetService(ctx, serviceId)
+	// Only the state decides whether a stop is needed first, so avoid the
+	// GetService fan-out and the extra permissions it would require.
+	state, err := c.getServiceState(ctx, serviceId)
 	if IsNotFound(err) {
 		// That is what we want
 		return nil, nil
@@ -255,7 +298,7 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 		return nil, err
 	}
 
-	if service.State != StateStopped && service.State != StateStopping {
+	if state != StateStopped && state != StateStopping {
 		rb, _ := json.Marshal(ServiceStateUpdate{
 			Command: "stop",
 		})
@@ -324,10 +367,18 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 
 	// Wait until service is deleted
 	checkDeleted := func() error {
-		_, err := c.GetService(ctx, serviceId)
+		// Only existence matters here, so poll the lightweight endpoint
+		// rather than the full GetService fan-out.
+		_, err := c.getServiceState(ctx, serviceId)
 		if IsNotFound(err) {
 			// That is what we want
 			return nil
+		}
+		if is5xx(err) || is4xxPermanent(err) {
+			// Same reasoning as WaitForServiceState: a missing permission
+			// will not resolve by retrying, and would otherwise look
+			// identical to "not deleted yet" for the full 5 minutes.
+			return backoff.Permanent(err)
 		} else if err != nil {
 			return err
 		}
@@ -336,9 +387,9 @@ func (c *ClientImpl) DeleteService(ctx context.Context, serviceId string) (*Serv
 	}
 
 	// Wait for up to 5 minutes for the service to be deleted
-	err = backoff.Retry(checkDeleted, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 60))
+	err = backoff.Retry(checkDeleted, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 60), ctx))
 	if err != nil {
-		return nil, fmt.Errorf("service %s was not deleted in the allocated time", serviceId)
+		return nil, fmt.Errorf("service %s was not deleted in the allocated time: %w", serviceId, err)
 	}
 
 	return &serviceResponse.Result.Service, nil

--- a/internal/api/service_test.go
+++ b/internal/api/service_test.go
@@ -244,3 +244,192 @@ func TestWaitForServiceState_stopsOnContextCancel(t *testing.T) {
 		t.Errorf("took %s; want an immediate return on a cancelled context", elapsed)
 	}
 }
+
+// A service can 404 for the first few polls right after create: the API is
+// eventually consistent, so the id the create call just returned may not be
+// visible to every read yet. With TolerateNotFound the wait must absorb that
+// window rather than failing the whole create on the first poll.
+func TestWaitForServiceState_toleratesNotFoundWithinLimit(t *testing.T) {
+	var calls int32
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if n := atomic.AddInt32(&calls, 1); n <= 3 {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"NOT_FOUND","status":404}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ResponseWithResult[Service]{Result: Service{Id: "svc-1", State: StateRunning}})
+	})
+
+	err := client.WaitForServiceState(context.Background(), "svc-1", func(state string) bool { return state == StateRunning }, 60, TolerateNotFound(5), withPollInterval(time.Millisecond))
+	if err != nil {
+		t.Fatalf("WaitForServiceState: want nil after 3 tolerated 404s, got %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 4 {
+		t.Errorf("server received %d calls; want 4 (3x 404 then success)", n)
+	}
+}
+
+// The tolerance is bounded: past the replication window a 404 means the
+// service really is gone, so the wait must give up rather than burn the full
+// maxWaitSeconds budget.
+func TestWaitForServiceState_failsOnceNotFoundToleranceExhausted(t *testing.T) {
+	var calls int32
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"NOT_FOUND","status":404}`))
+	})
+
+	err := client.WaitForServiceState(context.Background(), "svc-1", func(state string) bool { return state == StateRunning }, 5, TolerateNotFound(2), withPollInterval(time.Millisecond))
+	if err == nil {
+		t.Fatal("WaitForServiceState: want error once the 404 tolerance is exhausted, got nil")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("error = %v; want it to still match IsNotFound so delete paths can detect it", err)
+	}
+	// 2 tolerated + 1 that trips the permanent branch.
+	if n := atomic.LoadInt32(&calls); n != 3 {
+		t.Errorf("server received %d calls; want exactly 3 (tolerance 2, then give up)", n)
+	}
+}
+
+// Without the option the previous behaviour stands: a 404 is terminal on the
+// first poll. Only the post-create wait opts into tolerating it.
+func TestWaitForServiceState_notFoundIsTerminalByDefault(t *testing.T) {
+	var calls int32
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"NOT_FOUND","status":404}`))
+	})
+
+	err := client.WaitForServiceState(context.Background(), "svc-1", func(state string) bool { return state == StateRunning }, 5)
+	if err == nil {
+		t.Fatal("WaitForServiceState: want error, got nil")
+	}
+	if !IsNotFound(err) {
+		t.Errorf("error = %v; want IsNotFound to still match after backoff unwraps the permanent error", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("WaitForServiceState made %d HTTP calls on a 404; want exactly 1", n)
+	}
+}
+
+// waitForServiceRunning is a thin wrapper over WaitForServiceState. It is what
+// the ClickPipes and UDF paths use after waking a service, and it had no
+// coverage of its own — pin both the success condition and the inherited
+// fail-fast behaviour.
+func TestWaitForServiceRunning(t *testing.T) {
+	t.Run("returns once the service reports running", func(t *testing.T) {
+		var calls int32
+		client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			state := StateRunning
+			if atomic.AddInt32(&calls, 1) == 1 {
+				// partially_running is explicitly NOT sufficient here.
+				state = "partially_running"
+			}
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[Service]{Result: Service{Id: "svc-1", State: state}})
+		})
+
+		if err := client.waitForServiceRunning(context.Background(), "svc-1", 60, withPollInterval(time.Millisecond)); err != nil {
+			t.Fatalf("waitForServiceRunning: %v", err)
+		}
+		if n := atomic.LoadInt32(&calls); n != 2 {
+			t.Errorf("server received %d calls; want 2 (partially_running, then running)", n)
+		}
+	})
+
+	t.Run("fails fast on a 403 instead of polling out the budget", func(t *testing.T) {
+		var calls int32
+		client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"FORBIDDEN","status":403}`))
+		})
+
+		if err := client.waitForServiceRunning(context.Background(), "svc-1", 25); err == nil {
+			t.Fatal("waitForServiceRunning: want error, got nil")
+		}
+		if n := atomic.LoadInt32(&calls); n != 1 {
+			t.Errorf("waitForServiceRunning made %d HTTP calls on a 403; want exactly 1", n)
+		}
+	})
+}
+
+// DeleteService only ever needs the service's state, both to decide whether a
+// stop is required and to detect that the deletion finished. Neither should
+// drag in the private endpoint config, backup configuration or query endpoint
+// sub-resources, which need permissions a delete-scoped token may not hold.
+func TestDeleteService_pollsLightweightEndpointsOnly(t *testing.T) {
+	var gets, deletes int32
+	var deleted atomic.Bool
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/organizations/org-1/services/svc-1" {
+			t.Errorf("unexpected request to %q; DeleteService should only touch the base service endpoint", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			atomic.AddInt32(&deletes, 1)
+			deleted.Store(true)
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[ServiceResponseResult]{
+				Result: ServiceResponseResult{Service: Service{Id: "svc-1", State: StateStopped}},
+			})
+		default:
+			atomic.AddInt32(&gets, 1)
+			// Reads before the DELETE report the service as already stopped,
+			// so no stop command is needed; reads after it report it as gone.
+			if deleted.Load() {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"NOT_FOUND","status":404}`))
+				return
+			}
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[Service]{Result: Service{Id: "svc-1", State: StateStopped}})
+		}
+	})
+
+	svc, err := client.DeleteService(context.Background(), "svc-1")
+	if err != nil {
+		t.Fatalf("DeleteService: %v", err)
+	}
+	if svc == nil || svc.Id != "svc-1" {
+		t.Errorf("DeleteService returned %+v; want the deleted service", svc)
+	}
+	if n := atomic.LoadInt32(&deletes); n != 1 {
+		t.Errorf("issued %d DELETEs; want exactly 1", n)
+	}
+	// Initial state check, the stopped-state wait, then the deletion confirmation.
+	if n := atomic.LoadInt32(&gets); n != 3 {
+		t.Errorf("issued %d GETs; want 3 (state check, stopped-state wait, deletion confirmation)", n)
+	}
+}
+
+// A 4xx while waiting for the deletion to land will never resolve by retrying.
+// It must surface immediately rather than being retried for the full 5-minute
+// budget, which is what "not deleted yet" looks like.
+func TestDeleteService_failsFastOnForbiddenWhileConfirmingDeletion(t *testing.T) {
+	var getsAfterDelete int32
+	var deleted bool
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleted = true
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[ServiceResponseResult]{
+				Result: ServiceResponseResult{Service: Service{Id: "svc-1", State: StateStopped}},
+			})
+			return
+		}
+		if !deleted {
+			_ = json.NewEncoder(w).Encode(ResponseWithResult[Service]{Result: Service{Id: "svc-1", State: StateStopped}})
+			return
+		}
+		atomic.AddInt32(&getsAfterDelete, 1)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"FORBIDDEN","status":403}`))
+	})
+
+	if _, err := client.DeleteService(context.Background(), "svc-1"); err == nil {
+		t.Fatal("DeleteService: want error when the deletion check is forbidden, got nil")
+	}
+	if n := atomic.LoadInt32(&getsAfterDelete); n != 1 {
+		t.Errorf("polled %d times after the DELETE; want exactly 1 (no retrying a 403)", n)
+	}
+}

--- a/internal/service/clickhouse/resource/service.go
+++ b/internal/service/clickhouse/resource/service.go
@@ -51,6 +51,11 @@ var (
 //go:embed descriptions/service.md
 var serviceResourceDescription string
 
+// The API is eventually consistent, so a just-created service can 404 for the
+// first few polls on the very id the create call returned. Absorb that window
+// instead of failing the create.
+const createStateWaitNotFoundTolerance = 5
+
 // NewServiceResource is a helper function to simplify the provider implementation.
 func NewServiceResource() resource.Resource {
 	return &ServiceResource{}
@@ -1481,7 +1486,8 @@ func (r *ServiceResource) Create(ctx context.Context, req resource.CreateRequest
 		plan.GeneratedPassword = types.StringValue(generatedPassword)
 	}
 
-	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 90*60)
+	err = r.client.WaitForServiceState(ctx, s.Id, func(state string) bool { return state != api.StateProvisioning }, 90*60,
+		api.TolerateNotFound(createStateWaitNotFoundTolerance))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error retrieving service state",

--- a/internal/service/clickhouse/resource/service_test.go
+++ b/internal/service/clickhouse/resource/service_test.go
@@ -2162,6 +2162,26 @@ func TestServiceResource_generatedPassword_planApplyConsistency(t *testing.T) {
 			mutate:  func(s *models.ServiceResourceModel) { s.Name = types.StringValue("renamed") },
 			wantNil: false,
 		},
+		{
+			// password_hash takes its own branch in Update and sets
+			// passwordChanged just like a plain password does, so ModifyPlan
+			// has to mark the attribute unknown for it too.
+			name: "password_hash change clears it",
+			mutate: func(s *models.ServiceResourceModel) {
+				s.PasswordHash = types.StringValue("n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=")
+			},
+			wantNil: true,
+		},
+		{
+			// The write-only path: bumping password_wo_version with a real
+			// password_wo is the third way an apply changes the password.
+			name: "password_wo version bump clears it",
+			mutate: func(s *models.ServiceResourceModel) {
+				s.PasswordWO = types.StringValue("new-write-only-password")
+				s.PasswordWOVersion = types.Int64Value(2)
+			},
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2235,5 +2255,47 @@ func TestServiceResource_generatedPassword_planApplyConsistency(t *testing.T) {
 				t.Errorf("generated_password = %v, want it preserved", applied.GeneratedPassword)
 			}
 		})
+	}
+}
+
+// generated_password only ever exists in state: the API returns it once, in the
+// create response, and never again. Read must therefore carry it across a
+// refresh untouched. It survives today only because syncServiceState mutates
+// the model in place rather than rebuilding it — nothing else pins that, so a
+// refactor there would silently drop the value on the next plan.
+func TestServiceResource_Read_preservesGeneratedPassword(t *testing.T) {
+	ctx := context.Background()
+	r := &ServiceResource{}
+	sch := buildServiceSchema(t, ctx, r)
+
+	syncResp := getBaseResponse(encodableInitialState().ID.ValueString())
+	syncResp.State = api.StateRunning
+
+	priorState := test.NewUpdater(encodableInitialState()).Update(func(s *models.ServiceResourceModel) {
+		s.GeneratedPassword = types.StringValue("api-generated-secret")
+		s.BackupConfiguration = types.ObjectNull(models.BackupConfiguration{}.ObjectType().AttrTypes)
+	}).Get()
+
+	mc := minimock.NewController(t)
+	r.client = api.NewClientMock(mc).GetServiceMock.Return(&syncResp, nil)
+
+	stateVal := tfsdk.State{Schema: sch}
+	if d := stateVal.Set(ctx, &priorState); d.HasError() {
+		t.Fatalf("encoding state: %v", d.Errors())
+	}
+
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: sch}}
+	r.Read(ctx, resource.ReadRequest{State: stateVal}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned errors: %v", resp.Diagnostics.Errors())
+	}
+
+	var out models.ServiceResourceModel
+	if d := resp.State.Get(ctx, &out); d.HasError() {
+		t.Fatalf("decoding refreshed state: %v", d.Errors())
+	}
+	if out.GeneratedPassword.ValueString() != "api-generated-secret" {
+		t.Errorf("generated_password = %v after refresh; want it preserved as %q",
+			out.GeneratedPassword, "api-generated-secret")
 	}
 }


### PR DESCRIPTION
Follow-up to #675 and #676, both now merged.

### Fixes

**404 after create is transient, not terminal.** #675 makes every 4xx except 429/408 permanent in the state wait. `Create()` polls `WaitForServiceState` on the id `CreateService` just returned, and the API is eventually consistent — a read that fast can 404 on a service that exists. Adds a bounded `TolerateNotFound(n)` option; the post-create wait passes 5. Every other caller keeps 404 terminal on the first poll.

**Two more over-fetching waits.** #675 fixed one of three places polling the full `GetService` for a single field. `DeleteService` read the whole service just to branch on `state`, and `checkDeleted` retried a 403 for the full 5 minutes — the same bug. Both now poll the base endpoint and treat a permanent 4xx as terminal.

### Tests

- `waitForServiceRunning` — had no coverage at all, before or after becoming a wrapper in #675.
- `Read` preserving `generated_password` (#676). The attribute only lives in state; it survives a refresh today only because `syncServiceState` mutates the model in place. Nothing pinned that, so a refactor there would drop it silently.
- The two missing plan/apply consistency branches, `password_hash` and `password_wo_version` (#676). Only the plain `password` case was covered; the failure mode is Terraform's hard "inconsistent result after apply".

### Verification

`go build`, `go vet`, `gofmt -l internal/` and `go test ./...` clean. Each behavioural change is mutation-checked — reverting it fails at least one test (drop the tolerance, make it unbounded, revert `checkDeleted`, drop the field in `Read`, narrow `ModifyPlan`).

The poll interval is now injectable via an unexported option so these tests don't burn 5 real seconds per retry (`internal/api`: 32s → ~5s). Production behaviour is unchanged.