### PR TITLE
feat(clickpipe): support Kinesis Protobuf schema uploads

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -312,7 +312,7 @@ Optional:
 
 - `access_key` (Attributes) The access key for the Kinesis source. Use with `IAM_USER` authentication. Can be rotated in place via an update. (see [below for nested schema](#nestedatt--source--kinesis--access_key))
 - `iam_role` (String) The IAM role for the Kinesis source. Use with `IAM_ROLE` authentication. It can be used with AWS ClickHouse service only. Read more at https://clickhouse.com/docs/en/integrations/clickpipes/kinesis.
-- `protobuf_schema` (String, Sensitive) Base64-encoded Protobuf schema. Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. Required with `format = "Protobuf"` and not supported with other formats. Changing it forces replacement. Requires Protobuf schema upload to be enabled for the organization.
+- `protobuf_schema` (String, Sensitive) Base64-encoded Protobuf schema. Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. Required with `format = "Protobuf"` and not supported with other formats. Changing it forces replacement.
 - `timestamp` (String) The timestamp for the Kinesis source. Use with `AT_TIMESTAMP` iterator type. (format `2021-01-01T00:00`)
 - `use_enhanced_fan_out` (Boolean) Whether to use enhanced fan-out consumer.
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -7,11 +7,6 @@ description: |-
   Supported source types: Kafka (Confluent, MSK, Azure Event Hubs, Redpanda, WarpStream), Object Storage (S3, GCS, Azure Blob), Kinesis, Postgres CDC, MySQL CDC, BigQuery, and MongoDB CDC.
   Known limitations:
   ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
-  Kinesis Protobuf schema uploads
-  Set source.kinesis.format = "Protobuf" and supply source.kinesis.protobuf_schema using filebase64() with a .proto or serialized FileDescriptorSet file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept protobuf_schema.
-  This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
-  The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
-  Import cannot recover the uploaded schema. Adding protobuf_schema to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.
 ---
 
 # clickhouse_clickpipe (Resource)
@@ -24,16 +19,6 @@ Known limitations:
 
 - ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.
 - Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
-
-### Kinesis Protobuf schema uploads
-
-Set `source.kinesis.format = "Protobuf"` and supply `source.kinesis.protobuf_schema` using `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept `protobuf_schema`.
-
-This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
-
-The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
-
-Import cannot recover the uploaded schema. Adding `protobuf_schema` to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.
 
 ## Example Usage
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -312,7 +312,7 @@ Optional:
 
 - `access_key` (Attributes) The access key for the Kinesis source. Use with `IAM_USER` authentication. Can be rotated in place via an update. (see [below for nested schema](#nestedatt--source--kinesis--access_key))
 - `iam_role` (String) The IAM role for the Kinesis source. Use with `IAM_ROLE` authentication. It can be used with AWS ClickHouse service only. Read more at https://clickhouse.com/docs/en/integrations/clickpipes/kinesis.
-- `protobuf_schema` (String, Sensitive) Base64-encoded Protobuf schema. Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. Required with `format = "Protobuf"` and not supported with other formats. Changing it forces replacement.
+- `protobuf_schema` (String) Base64-encoded Protobuf schema. Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. Required with `format = "Protobuf"` and not supported with other formats. Changing it forces replacement.
 - `timestamp` (String) The timestamp for the Kinesis source. Use with `AT_TIMESTAMP` iterator type. (format `2021-01-01T00:00`)
 - `use_enhanced_fan_out` (Boolean) Whether to use enhanced fan-out consumer.
 

--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -7,6 +7,11 @@ description: |-
   Supported source types: Kafka (Confluent, MSK, Azure Event Hubs, Redpanda, WarpStream), Object Storage (S3, GCS, Azure Blob), Kinesis, Postgres CDC, MySQL CDC, BigQuery, and MongoDB CDC.
   Known limitations:
   ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
+  Kinesis Protobuf schema uploads
+  Set source.kinesis.format = "Protobuf" and supply source.kinesis.protobuf_schema using filebase64() with a .proto or serialized FileDescriptorSet file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept protobuf_schema.
+  This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
+  The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
+  Import cannot recover the uploaded schema. Adding protobuf_schema to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.
 ---
 
 # clickhouse_clickpipe (Resource)
@@ -19,6 +24,16 @@ Known limitations:
 
 - ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.
 - Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
+
+### Kinesis Protobuf schema uploads
+
+Set `source.kinesis.format = "Protobuf"` and supply `source.kinesis.protobuf_schema` using `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept `protobuf_schema`.
+
+This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
+
+The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
+
+Import cannot recover the uploaded schema. Adding `protobuf_schema` to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.
 
 ## Example Usage
 
@@ -303,7 +318,7 @@ Optional:
 Required:
 
 - `authentication` (String) The authentication method for the Kinesis source. (`IAM_ROLE`, `IAM_USER`).
-- `format` (String) The format of the Kinesis source. (`JSONEachRow`, `Avro`, `AvroConfluent`)
+- `format` (String) The format of the Kinesis source. (`JSONEachRow`, `Avro`, `AvroConfluent`, `Protobuf`)
 - `iterator_type` (String) The iterator type for the Kinesis source. (`TRIM_HORIZON`, `LATEST`, `AT_TIMESTAMP`)
 - `region` (String) The AWS region of the Kinesis stream.
 - `stream_name` (String) The name of the Kinesis stream.
@@ -312,6 +327,7 @@ Optional:
 
 - `access_key` (Attributes) The access key for the Kinesis source. Use with `IAM_USER` authentication. Can be rotated in place via an update. (see [below for nested schema](#nestedatt--source--kinesis--access_key))
 - `iam_role` (String) The IAM role for the Kinesis source. Use with `IAM_ROLE` authentication. It can be used with AWS ClickHouse service only. Read more at https://clickhouse.com/docs/en/integrations/clickpipes/kinesis.
+- `protobuf_schema` (String, Sensitive) Base64-encoded Protobuf schema. Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. Required with `format = "Protobuf"` and not supported with other formats. Changing it forces replacement. Requires Protobuf schema upload to be enabled for the organization.
 - `timestamp` (String) The timestamp for the Kinesis source. Use with `AT_TIMESTAMP` iterator type. (format `2021-01-01T00:00`)
 - `use_enhanced_fan_out` (Boolean) Whether to use enhanced fan-out consumer.
 

--- a/examples/resources/clickhouse_clickpipe/resource_kinesis_protobuf.tf
+++ b/examples/resources/clickhouse_clickpipe/resource_kinesis_protobuf.tf
@@ -1,0 +1,35 @@
+# Requires Kinesis Protobuf schema upload to be enabled for the organization.
+resource "clickhouse_clickpipe" "kinesis_protobuf" {
+  name       = "My Kinesis Protobuf ClickPipe"
+  service_id = "e9465b4b-f7e5-4937-8e21-8d508b02843d"
+
+  source = {
+    kinesis = {
+      format          = "Protobuf"
+      stream_name     = "events"
+      region          = "us-east-1"
+      iterator_type   = "TRIM_HORIZON"
+      authentication  = "IAM_ROLE"
+      iam_role        = "arn:aws:iam::123456789012:role/clickpipes"
+      protobuf_schema = filebase64("${path.module}/event.proto")
+    }
+  }
+
+  destination = {
+    table         = "events"
+    managed_table = true
+
+    table_definition = {
+      engine = {
+        type = "MergeTree"
+      }
+    }
+
+    columns = [
+      {
+        name = "id"
+        type = "String"
+      }
+    ]
+  }
+}

--- a/internal/api/clickpipe.go
+++ b/internal/api/clickpipe.go
@@ -56,7 +56,12 @@ var ClickPipeKafkaFormats = []string{
 	ClickPipeProtobufFormat,
 }
 
-var ClickPipeKinesisFormats = ClickPipeStreamingFormats
+var ClickPipeKinesisFormats = []string{
+	ClickPipeJSONEachRowFormat,
+	ClickPipeAvroFormat,
+	ClickPipeAvroConfluentFormat,
+	ClickPipeProtobufFormat,
+}
 
 const (
 	ClickPipeAuthenticationIAMRole          = "IAM_ROLE"

--- a/internal/api/clickpipe_models.go
+++ b/internal/api/clickpipe_models.go
@@ -144,6 +144,8 @@ type ClickPipeObjectStorageSource struct {
 
 type ClickPipeKinesisSource struct {
 	Format string `json:"format"`
+	// ProtobufSchema contains the base64-encoded schema required for Protobuf format.
+	ProtobufSchema *string `json:"protobufSchema,omitempty"`
 
 	StreamName string `json:"streamName"`
 	Region     string `json:"region"`

--- a/internal/api/clickpipe_protobuf_test.go
+++ b/internal/api/clickpipe_protobuf_test.go
@@ -23,3 +23,21 @@ func TestClickPipeKafkaSource_OmitsUnsetProtobufSchema(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, string(payload), "protobufSchema")
 }
+
+func TestClickPipeKinesisSource_ProtobufSchemaJSON(t *testing.T) {
+	protobufSchema := "c3ludGF4ID0gInByb3RvMyI7"
+
+	payload, err := json.Marshal(ClickPipeKinesisSource{ProtobufSchema: &protobufSchema})
+
+	require.NoError(t, err)
+	var source map[string]any
+	require.NoError(t, json.Unmarshal(payload, &source))
+	assert.Equal(t, protobufSchema, source["protobufSchema"])
+}
+
+func TestClickPipeKinesisSource_OmitsUnsetProtobufSchema(t *testing.T) {
+	payload, err := json.Marshal(ClickPipeKinesisSource{})
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "protobufSchema")
+}

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -668,8 +668,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									"Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. " +
 									"Required with `format = \"Protobuf\"` and not supported with other formats. " +
 									"Changing it forces replacement.",
-								Optional:  true,
-								Sensitive: true,
+								Optional: true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.RequiresReplace(),
 								},

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -663,6 +663,17 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 									stringplanmodifier.RequiresReplace(),
 								},
 							},
+							"protobuf_schema": schema.StringAttribute{
+								MarkdownDescription: "Base64-encoded Protobuf schema. " +
+									"Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. " +
+									"Required with `format = \"Protobuf\"` and not supported with other formats. " +
+									"Changing it forces replacement. Requires Protobuf schema upload to be enabled for the organization.",
+								Optional:  true,
+								Sensitive: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.RequiresReplace(),
+								},
+							},
 							"stream_name": schema.StringAttribute{
 								Description: "The name of the Kinesis stream.",
 								Required:    true,
@@ -3264,6 +3275,9 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			Authentication:    kinesisModel.Authentication.ValueString(),
 			IAMRole:           kinesisModel.IAMRole.ValueStringPointer(),
 		}
+		if !isUpdate {
+			source.Kinesis.ProtobufSchema = kinesisModel.ProtobufSchema.ValueStringPointer()
+		}
 
 		if !kinesisModel.Timestamp.IsNull() {
 			source.Kinesis.Timestamp = kinesisModel.Timestamp.ValueStringPointer()
@@ -4331,6 +4345,7 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 
 		kinesisModel := models.ClickPipeKinesisSourceModel{
 			Format:            types.StringValue(clickPipe.Source.Kinesis.Format),
+			ProtobufSchema:    stateKinesisModel.ProtobufSchema,
 			StreamName:        types.StringValue(clickPipe.Source.Kinesis.StreamName),
 			Region:            types.StringValue(clickPipe.Source.Kinesis.Region),
 			IteratorType:      types.StringValue(clickPipe.Source.Kinesis.IteratorType),

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -667,7 +667,7 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								MarkdownDescription: "Base64-encoded Protobuf schema. " +
 									"Use `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file up to 768 KiB. " +
 									"Required with `format = \"Protobuf\"` and not supported with other formats. " +
-									"Changing it forces replacement. Requires Protobuf schema upload to be enabled for the organization.",
+									"Changing it forces replacement.",
 								Optional:  true,
 								Sensitive: true,
 								PlanModifiers: []planmodifier.String{
@@ -3275,8 +3275,9 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			Authentication:    kinesisModel.Authentication.ValueString(),
 			IAMRole:           kinesisModel.IAMRole.ValueStringPointer(),
 		}
-		if !isUpdate {
-			source.Kinesis.ProtobufSchema = kinesisModel.ProtobufSchema.ValueStringPointer()
+		if !isUpdate && !kinesisModel.ProtobufSchema.IsNull() {
+			encodedSchema := strings.TrimSpace(kinesisModel.ProtobufSchema.ValueString())
+			source.Kinesis.ProtobufSchema = &encodedSchema
 		}
 
 		if !kinesisModel.Timestamp.IsNull() {

--- a/internal/service/clickhouse/resource/clickpipe_config_validators.go
+++ b/internal/service/clickhouse/resource/clickpipe_config_validators.go
@@ -99,6 +99,86 @@ func (v kafkaProtobufSchemaValidator) ValidateResource(ctx context.Context, req 
 	}
 }
 
+// kinesisProtobufSchemaValidator enforces the Kinesis Protobuf schema rules exposed by the OpenAPI.
+type kinesisProtobufSchemaValidator struct{}
+
+// Description returns a plain-text summary of the Kinesis Protobuf schema validation.
+func (v kinesisProtobufSchemaValidator) Description(_ context.Context) string {
+	return "Validates direct Kinesis Protobuf schema configuration."
+}
+
+// MarkdownDescription returns the validation summary for the supplied context.
+func (v kinesisProtobufSchemaValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateResource reads req.Config in ctx and adds Kinesis schema errors to resp.
+// Cross-field validation is deferred until the relevant Terraform values are known.
+func (v kinesisProtobufSchemaValidator) ValidateResource(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	var data models.ClickPipeResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if data.Source.IsNull() || data.Source.IsUnknown() {
+		return
+	}
+
+	var sourceModel models.ClickPipeSourceModel
+	resp.Diagnostics.Append(data.Source.As(ctx, &sourceModel, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if sourceModel.Kinesis.IsNull() || sourceModel.Kinesis.IsUnknown() {
+		return
+	}
+
+	var kinesisModel models.ClickPipeKinesisSourceModel
+	resp.Diagnostics.Append(sourceModel.Kinesis.As(ctx, &kinesisModel, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	protobufSchemaPath := path.Root("source").AtName("kinesis").AtName("protobuf_schema")
+	protobufSchemaKnown := !kinesisModel.ProtobufSchema.IsUnknown()
+	protobufSchemaSet := protobufSchemaKnown && !kinesisModel.ProtobufSchema.IsNull()
+	if protobufSchemaSet {
+		encodedSchema := strings.TrimSpace(kinesisModel.ProtobufSchema.ValueString())
+		if !isValidProtobufSchemaBase64(encodedSchema) {
+			resp.Diagnostics.AddAttributeError(
+				protobufSchemaPath,
+				"Invalid Kinesis Protobuf schema",
+				"protobuf_schema must contain valid base64 data and must not exceed 1 MiB.",
+			)
+		}
+	}
+
+	if kinesisModel.Format.IsNull() || kinesisModel.Format.IsUnknown() {
+		return
+	}
+
+	format := kinesisModel.Format.ValueString()
+	if protobufSchemaSet && format != api.ClickPipeProtobufFormat {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("source").AtName("kinesis").AtName("format"),
+			"Invalid Kinesis Protobuf schema configuration",
+			"protobuf_schema is supported only when format is Protobuf.",
+		)
+	}
+	protobufSchemaMissing := protobufSchemaKnown && !protobufSchemaSet
+	if format == api.ClickPipeProtobufFormat && protobufSchemaMissing {
+		resp.Diagnostics.AddAttributeError(
+			protobufSchemaPath,
+			"Missing Kinesis Protobuf schema",
+			"Protobuf format requires protobuf_schema.",
+		)
+	}
+}
+
 // isValidProtobufSchemaBase64 reports whether a non-empty schema is canonical padded or unpadded base64 within the API limit.
 func isValidProtobufSchemaBase64(encodedSchema string) bool {
 	if encodedSchema == "" || len(encodedSchema) > maxClickPipeProtobufSchemaEncodedSize {
@@ -230,6 +310,7 @@ func (v cdcClickPipeScalingValidator) ValidateResource(ctx context.Context, req 
 func (c *ClickPipeResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
 	return []resource.ConfigValidator{
 		kafkaProtobufSchemaValidator{},
+		kinesisProtobufSchemaValidator{},
 		pubsubSeekValidator{},
 		cdcClickPipeScalingValidator{},
 	}

--- a/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
@@ -1,0 +1,310 @@
+package resource
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/clickhouse/resource/models"
+)
+
+// kinesisProtobufModel returns the existing Kinesis fixture with the supplied format and schema.
+// It uses t to report fixture conversion errors before the test can make misleading assertions.
+func kinesisProtobufModel(t *testing.T, format, protobufSchema types.String) models.ClickPipeResourceModel {
+	t.Helper()
+	ctx := t.Context()
+	model := getKinesisSyncState(
+		api.ClickPipeAuthenticationIAMRole,
+		types.ObjectNull(models.ClickPipeSourceAccessKeyModel{}.ObjectType().AttrTypes),
+		types.StringValue("arn:aws:iam::123456789012:role/clickpipes"),
+	)
+	var source models.ClickPipeSourceModel
+	require.False(t, model.Source.As(ctx, &source, basetypes.ObjectAsOptions{}).HasError())
+	var kinesis models.ClickPipeKinesisSourceModel
+	require.False(t, source.Kinesis.As(ctx, &kinesis, basetypes.ObjectAsOptions{}).HasError())
+	kinesis.Format = format
+	kinesis.ProtobufSchema = protobufSchema
+	source.Kinesis = kinesis.ObjectValue()
+	model.Source = source.ObjectValue()
+	model.Scaling = types.ObjectNull(models.ClickPipeScalingModel{}.ObjectType().AttrTypes)
+	model.FieldMappings = types.ListNull(models.ClickPipeFieldMappingModel{}.ObjectType())
+	model.Settings = types.DynamicNull()
+	return model
+}
+
+// validateKinesisProtobufConfig returns registered validator diagnostics for model.
+// It uses t to fail immediately if Terraform cannot encode the test configuration.
+func validateKinesisProtobufConfig(t *testing.T, model models.ClickPipeResourceModel) diag.Diagnostics {
+	t.Helper()
+	ctx := t.Context()
+	clickPipeResource := &ClickPipeResource{}
+	schemaResponse := &resource.SchemaResponse{}
+	clickPipeResource.Schema(ctx, resource.SchemaRequest{}, schemaResponse)
+	require.False(t, schemaResponse.Diagnostics.HasError())
+	plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+	require.Empty(t, plan.Set(ctx, &model))
+	request := resource.ValidateConfigRequest{Config: tfsdk.Config{Schema: schemaResponse.Schema, Raw: plan.Raw}}
+	response := &resource.ValidateConfigResponse{}
+	for _, validator := range clickPipeResource.ConfigValidators(ctx) {
+		validator.ValidateResource(ctx, request, response)
+	}
+	return response.Diagnostics
+}
+
+func TestClickPipeResource_ValidatesKinesisProtobufSchemaConfiguration(t *testing.T) {
+	validSchema := base64.StdEncoding.EncodeToString([]byte(`syntax = "proto3"; message Event { string id = 1; }`))
+	invalidSchemaMessage := "protobuf_schema must contain valid base64 data and must not exceed 1 MiB."
+	tests := []struct {
+		name           string
+		format         types.String
+		schema         types.String
+		expectedDetail string
+	}{
+		{
+			name:   "accepts an uploaded schema",
+			format: types.StringValue(api.ClickPipeProtobufFormat),
+			schema: types.StringValue(validSchema),
+		},
+		{
+			name:   "accepts the maximum encoded size",
+			format: types.StringValue(api.ClickPipeProtobufFormat),
+			schema: types.StringValue(strings.Repeat("A", maxClickPipeProtobufSchemaEncodedSize)),
+		},
+		{
+			name:   "accepts unpadded base64 with surrounding whitespace",
+			format: types.StringValue(api.ClickPipeProtobufFormat),
+			schema: types.StringValue(" \n" + strings.TrimRight(validSchema, "=") + "\t "),
+		},
+		{
+			name:           "requires a schema for Protobuf",
+			format:         types.StringValue(api.ClickPipeProtobufFormat),
+			schema:         types.StringNull(),
+			expectedDetail: "Protobuf format requires protobuf_schema.",
+		},
+		{
+			name:           "rejects empty schemas",
+			format:         types.StringValue(api.ClickPipeProtobufFormat),
+			schema:         types.StringValue(""),
+			expectedDetail: invalidSchemaMessage,
+		},
+		{
+			name:           "rejects invalid base64",
+			format:         types.StringValue(api.ClickPipeProtobufFormat),
+			schema:         types.StringValue("not@base64"),
+			expectedDetail: invalidSchemaMessage,
+		},
+		{
+			name:           "rejects oversized schemas",
+			format:         types.StringValue(api.ClickPipeProtobufFormat),
+			schema:         types.StringValue(strings.Repeat("A", maxClickPipeProtobufSchemaEncodedSize+4)),
+			expectedDetail: invalidSchemaMessage,
+		},
+		{
+			name:   "defers an unknown schema",
+			format: types.StringValue(api.ClickPipeProtobufFormat),
+			schema: types.StringUnknown(),
+		},
+		{
+			name:   "defers an unknown format",
+			format: types.StringUnknown(),
+			schema: types.StringValue(validSchema),
+		},
+		{
+			name:           "validates base64 even when the format is unknown",
+			format:         types.StringUnknown(),
+			schema:         types.StringValue("not@base64"),
+			expectedDetail: invalidSchemaMessage,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := kinesisProtobufModel(t, test.format, test.schema)
+
+			diagnostics := validateKinesisProtobufConfig(t, model)
+
+			assert.Equal(t, test.expectedDetail, diagnosticDetails(diagnostics))
+		})
+	}
+
+	for _, format := range api.ClickPipeStreamingFormats {
+		t.Run(format+" remains supported without a schema", func(t *testing.T) {
+			model := kinesisProtobufModel(t, types.StringValue(format), types.StringNull())
+
+			assert.Empty(t, validateKinesisProtobufConfig(t, model))
+		})
+		t.Run(format+" rejects an uploaded schema", func(t *testing.T) {
+			model := kinesisProtobufModel(t, types.StringValue(format), types.StringValue(validSchema))
+
+			diagnostics := validateKinesisProtobufConfig(t, model)
+
+			assert.Equal(t, "protobuf_schema is supported only when format is Protobuf.", diagnosticDetails(diagnostics))
+		})
+	}
+}
+
+func TestClickPipeResource_KinesisProtobufSchemaIsSensitiveAndImmutable(t *testing.T) {
+	ctx := t.Context()
+	clickPipeResource := &ClickPipeResource{}
+	schemaResponse := &resource.SchemaResponse{}
+	clickPipeResource.Schema(ctx, resource.SchemaRequest{}, schemaResponse)
+	require.False(t, schemaResponse.Diagnostics.HasError())
+	source := schemaResponse.Schema.Attributes["source"]
+	require.IsType(t, resourceschema.SingleNestedAttribute{}, source)
+	kinesis := source.(resourceschema.SingleNestedAttribute).Attributes["kinesis"]
+	require.IsType(t, resourceschema.SingleNestedAttribute{}, kinesis)
+	kinesisAttribute := kinesis.(resourceschema.SingleNestedAttribute)
+	upload := kinesisAttribute.Attributes["protobuf_schema"]
+	require.IsType(t, resourceschema.StringAttribute{}, upload)
+	schemaAttribute := upload.(resourceschema.StringAttribute)
+	assert.True(t, schemaAttribute.Optional)
+	assert.True(t, schemaAttribute.Sensitive)
+	assert.False(t, schemaAttribute.WriteOnly)
+	require.Len(t, schemaAttribute.PlanModifiers, 1)
+	formatAttribute := kinesisAttribute.Attributes["format"].(resourceschema.StringAttribute)
+	assert.Contains(t, formatAttribute.MarkdownDescription, "`Protobuf`")
+
+	tests := []struct {
+		name            string
+		previous        types.String
+		next            types.String
+		requiresReplace bool
+	}{
+		{
+			name:            "changing the schema requires replacement",
+			previous:        types.StringValue("b2xk"),
+			next:            types.StringValue("bmV3"),
+			requiresReplace: true,
+		},
+		{
+			name:            "adding the schema after import requires replacement",
+			previous:        types.StringNull(),
+			next:            types.StringValue("bmV3"),
+			requiresReplace: true,
+		},
+		{
+			name:            "removing the schema requires replacement",
+			previous:        types.StringValue("b2xk"),
+			next:            types.StringNull(),
+			requiresReplace: true,
+		},
+		{
+			name:     "unchanged schemas do not require replacement",
+			previous: types.StringValue("b2xk"),
+			next:     types.StringValue("b2xk"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stateModel := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), test.previous)
+			planModel := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), test.next)
+			state := tfsdk.State{
+				Schema: schemaResponse.Schema,
+				Raw:    tftypes.NewValue(schemaResponse.Schema.Type().TerraformType(ctx), nil),
+			}
+			plan := tfsdk.Plan{Schema: schemaResponse.Schema}
+			require.Empty(t, state.Set(ctx, &stateModel))
+			require.Empty(t, plan.Set(ctx, &planModel))
+			request := planmodifier.StringRequest{
+				Path:        path.Root("source").AtName("kinesis").AtName("protobuf_schema"),
+				State:       state,
+				Plan:        plan,
+				StateValue:  test.previous,
+				PlanValue:   test.next,
+				ConfigValue: test.next,
+			}
+			response := &planmodifier.StringResponse{PlanValue: request.PlanValue}
+
+			schemaAttribute.PlanModifiers[0].PlanModifyString(ctx, request, response)
+
+			assert.False(t, response.Diagnostics.HasError())
+			assert.Equal(t, test.requiresReplace, response.RequiresReplace)
+		})
+	}
+}
+
+func TestExtractSourceFromPlan_KinesisProtobufSchema(t *testing.T) {
+	encodedSchema := base64.StdEncoding.EncodeToString([]byte(`syntax = "proto3"; message Event { string id = 1; }`))
+	plan := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), types.StringValue(encodedSchema))
+	diagnostics := diag.Diagnostics{}
+
+	source := (&ClickPipeResource{}).extractSourceFromPlan(
+		t.Context(),
+		&diagnostics,
+		plan,
+		nil,
+		false,
+	)
+
+	require.False(t, diagnostics.HasError())
+	require.NotNil(t, source.Kinesis)
+	require.NotNil(t, source.Kinesis.ProtobufSchema)
+	assert.Equal(t, api.ClickPipeProtobufFormat, source.Kinesis.Format)
+	assert.Equal(t, encodedSchema, *source.Kinesis.ProtobufSchema)
+}
+
+func TestExtractSourceFromPlan_KinesisProtobufSchemaOmittedOnUpdate(t *testing.T) {
+	plan := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), types.StringValue("c2NoZW1h"))
+	diagnostics := diag.Diagnostics{}
+
+	source := (&ClickPipeResource{}).extractSourceFromPlan(
+		t.Context(),
+		&diagnostics,
+		plan,
+		nil,
+		true,
+	)
+
+	require.False(t, diagnostics.HasError())
+	require.NotNil(t, source.Kinesis)
+	assert.Nil(t, source.Kinesis.ProtobufSchema)
+	payload, err := json.Marshal(source)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "protobufSchema")
+}
+
+func TestClickPipeResource_SyncKinesisProtobufSchemaPreservesState(t *testing.T) {
+	ctx := t.Context()
+	tests := []struct {
+		name   string
+		schema types.String
+	}{
+		{name: "preserves a configured schema", schema: types.StringValue("c2NoZW1h")},
+		{name: "keeps the schema null after import", schema: types.StringNull()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), test.schema)
+			apiPipe := kinesisAPIResponse(
+				api.ClickPipeAuthenticationIAMRole,
+				strPtr("arn:aws:iam::123456789012:role/clickpipes"),
+			)
+			apiPipe.Source.Kinesis.Format = api.ClickPipeProtobufFormat
+			client := api.NewClientMock(minimock.NewController(t)).GetClickPipeMock.
+				Expect(ctx, "service-123", "test-pipe-id").Return(apiPipe, nil)
+
+			err := (&ClickPipeResource{client: client}).syncClickPipeState(ctx, &state)
+
+			require.NoError(t, err)
+			var source models.ClickPipeSourceModel
+			require.False(t, state.Source.As(ctx, &source, basetypes.ObjectAsOptions{}).HasError())
+			var kinesis models.ClickPipeKinesisSourceModel
+			require.False(t, source.Kinesis.As(ctx, &kinesis, basetypes.ObjectAsOptions{}).HasError())
+			assert.Equal(t, test.schema, kinesis.ProtobufSchema)
+		})
+	}
+}

--- a/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
@@ -239,22 +239,59 @@ func TestClickPipeResource_KinesisProtobufSchemaIsSensitiveAndImmutable(t *testi
 
 func TestExtractSourceFromPlan_KinesisProtobufSchema(t *testing.T) {
 	encodedSchema := base64.StdEncoding.EncodeToString([]byte(`syntax = "proto3"; message Event { string id = 1; }`))
-	plan := kinesisProtobufModel(t, types.StringValue(api.ClickPipeProtobufFormat), types.StringValue(encodedSchema))
-	diagnostics := diag.Diagnostics{}
+	maximumSizeSchema := strings.Repeat("A", maxClickPipeProtobufSchemaEncodedSize)
+	tests := []struct {
+		name     string
+		format   string
+		schema   types.String
+		expected types.String
+	}{
+		{
+			name:     "preserves an encoded schema",
+			format:   api.ClickPipeProtobufFormat,
+			schema:   types.StringValue(encodedSchema),
+			expected: types.StringValue(encodedSchema),
+		},
+		{
+			name:     "trims surrounding whitespace",
+			format:   api.ClickPipeProtobufFormat,
+			schema:   types.StringValue(" \n" + encodedSchema + "\t "),
+			expected: types.StringValue(encodedSchema),
+		},
+		{
+			name:     "trims a maximum-size schema before sending",
+			format:   api.ClickPipeProtobufFormat,
+			schema:   types.StringValue(" \n" + maximumSizeSchema + "\t "),
+			expected: types.StringValue(maximumSizeSchema),
+		},
+		{
+			name:     "omits an unset schema",
+			format:   api.ClickPipeJSONEachRowFormat,
+			schema:   types.StringNull(),
+			expected: types.StringNull(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			plan := kinesisProtobufModel(t, types.StringValue(test.format), test.schema)
+			originalSource := plan.Source
+			diagnostics := diag.Diagnostics{}
 
-	source := (&ClickPipeResource{}).extractSourceFromPlan(
-		t.Context(),
-		&diagnostics,
-		plan,
-		nil,
-		false,
-	)
+			source := (&ClickPipeResource{}).extractSourceFromPlan(
+				t.Context(),
+				&diagnostics,
+				plan,
+				nil,
+				false,
+			)
 
-	require.False(t, diagnostics.HasError())
-	require.NotNil(t, source.Kinesis)
-	require.NotNil(t, source.Kinesis.ProtobufSchema)
-	assert.Equal(t, api.ClickPipeProtobufFormat, source.Kinesis.Format)
-	assert.Equal(t, encodedSchema, *source.Kinesis.ProtobufSchema)
+			require.False(t, diagnostics.HasError())
+			require.NotNil(t, source.Kinesis)
+			assert.Equal(t, test.format, source.Kinesis.Format)
+			assert.Equal(t, test.expected, types.StringPointerValue(source.Kinesis.ProtobufSchema))
+			assert.Equal(t, originalSource, plan.Source)
+		})
+	}
 }
 
 func TestExtractSourceFromPlan_KinesisProtobufSchemaOmittedOnUpdate(t *testing.T) {

--- a/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_kinesis_protobuf_test.go
@@ -157,7 +157,7 @@ func TestClickPipeResource_ValidatesKinesisProtobufSchemaConfiguration(t *testin
 	}
 }
 
-func TestClickPipeResource_KinesisProtobufSchemaIsSensitiveAndImmutable(t *testing.T) {
+func TestClickPipeResource_KinesisProtobufSchemaIsNonSensitiveAndImmutable(t *testing.T) {
 	ctx := t.Context()
 	clickPipeResource := &ClickPipeResource{}
 	schemaResponse := &resource.SchemaResponse{}
@@ -172,7 +172,7 @@ func TestClickPipeResource_KinesisProtobufSchemaIsSensitiveAndImmutable(t *testi
 	require.IsType(t, resourceschema.StringAttribute{}, upload)
 	schemaAttribute := upload.(resourceschema.StringAttribute)
 	assert.True(t, schemaAttribute.Optional)
-	assert.True(t, schemaAttribute.Sensitive)
+	assert.False(t, schemaAttribute.Sensitive)
 	assert.False(t, schemaAttribute.WriteOnly)
 	require.Len(t, schemaAttribute.PlanModifiers, 1)
 	formatAttribute := kinesisAttribute.Attributes["format"].(resourceschema.StringAttribute)

--- a/internal/service/clickhouse/resource/clickpipe_kinesis_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_kinesis_test.go
@@ -30,6 +30,7 @@ func buildKinesisResourceModel(authentication string, accessKeyID, secretKey, ia
 
 	kinesisAttrs := map[string]attr.Value{
 		"format":               types.StringValue("JSONEachRow"),
+		"protobuf_schema":      types.StringNull(),
 		"stream_name":          types.StringValue("my-stream"),
 		"region":               types.StringValue("us-east-1"),
 		"iterator_type":        types.StringValue("TRIM_HORIZON"),
@@ -140,6 +141,7 @@ func TestCredentialsObjectChanged_KinesisAccessKey(t *testing.T) {
 func getKinesisSyncState(authentication string, accessKey types.Object, iamRole types.String) models.ClickPipeResourceModel {
 	kinesisAttrs := map[string]attr.Value{
 		"format":               types.StringValue("JSONEachRow"),
+		"protobuf_schema":      types.StringNull(),
 		"stream_name":          types.StringValue("my-stream"),
 		"region":               types.StringValue("us-east-1"),
 		"iterator_type":        types.StringValue("TRIM_HORIZON"),

--- a/internal/service/clickhouse/resource/descriptions/clickpipe.md
+++ b/internal/service/clickhouse/resource/descriptions/clickpipe.md
@@ -6,13 +6,3 @@ Known limitations:
 
 - ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.
 - Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
-
-### Kinesis Protobuf schema uploads
-
-Set `source.kinesis.format = "Protobuf"` and supply `source.kinesis.protobuf_schema` using `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept `protobuf_schema`.
-
-This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
-
-The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
-
-Import cannot recover the uploaded schema. Adding `protobuf_schema` to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.

--- a/internal/service/clickhouse/resource/descriptions/clickpipe.md
+++ b/internal/service/clickhouse/resource/descriptions/clickpipe.md
@@ -6,3 +6,13 @@ Known limitations:
 
 - ClickPipe does not support table updates for managed tables. If you need to update the table schema, you will have to do that externally.
 - Changing the source type of an existing ClickPipe will force replacement (destroy and recreate).
+
+### Kinesis Protobuf schema uploads
+
+Set `source.kinesis.format = "Protobuf"` and supply `source.kinesis.protobuf_schema` using `filebase64()` with a `.proto` or serialized `FileDescriptorSet` file. The maximum encoded size is 1 MiB (a file up to 768 KiB). Other formats do not accept `protobuf_schema`.
+
+This requires Kinesis Protobuf schema upload support to be enabled for your organization. The backend selects the first message declared in the last root file; message selection cannot be overridden through this resource.
+
+The schema is sent only when the ClickPipe is created. Changing, adding, or removing it forces replacement; credential updates do not resend it. Terraform preserves the schema in state because the API does not return it. It is marked sensitive to hide it from normal output, but it is still stored in state, so protect access to your state files.
+
+Import cannot recover the uploaded schema. Adding `protobuf_schema` to an imported ClickPipe forces replacement, even if it matches the schema already stored by the backend.

--- a/internal/service/clickhouse/resource/models/clickpipe_resource.go
+++ b/internal/service/clickhouse/resource/models/clickpipe_resource.go
@@ -237,6 +237,7 @@ func (m ClickPipeKafkaSourceModel) ObjectValue() types.Object {
 
 type ClickPipeKinesisSourceModel struct {
 	Format            types.String `tfsdk:"format"`
+	ProtobufSchema    types.String `tfsdk:"protobuf_schema"`
 	StreamName        types.String `tfsdk:"stream_name"`
 	Region            types.String `tfsdk:"region"`
 	IteratorType      types.String `tfsdk:"iterator_type"`
@@ -251,6 +252,7 @@ func (m ClickPipeKinesisSourceModel) ObjectType() types.ObjectType {
 	return types.ObjectType{
 		AttrTypes: map[string]attr.Type{
 			"format":               types.StringType,
+			"protobuf_schema":      types.StringType,
 			"stream_name":          types.StringType,
 			"region":               types.StringType,
 			"iterator_type":        types.StringType,
@@ -266,6 +268,7 @@ func (m ClickPipeKinesisSourceModel) ObjectType() types.ObjectType {
 func (m ClickPipeKinesisSourceModel) ObjectValue() types.Object {
 	return types.ObjectValueMust(m.ObjectType().AttrTypes, map[string]attr.Value{
 		"format":               m.Format,
+		"protobuf_schema":      m.ProtobufSchema,
 		"stream_name":          m.StreamName,
 		"region":               m.Region,
 		"iterator_type":        m.IteratorType,


### PR DESCRIPTION
## Why

Expose Kinesis Protobuf schema uploads through Terraform, matching the OpenAPI contract.

## What

- Add sensitive `source.kinesis.protobuf_schema` with format, base64, and size validation.
- Upload only on creation, preserve the schema in state, and require replacement when it changes.
- Add focused tests, documentation, and a `filebase64()` example.

## QA

Unit suite, focused race tests, build, lint, formatting, and docs validation passed. Live acceptance testing is pending the deployed OpenAPI feature and an enabled organization flag.

Manual verification:

1. Apply the Kinesis Protobuf example against an enabled test organization; confirm ingestion and a clean subsequent plan.
2. Rotate credentials without resending the schema; confirm schema changes require replacement.
3. Check invalid/oversized schemas and non-Protobuf formats are rejected; adding a schema after import requires replacement.

## References

- [CLP-1225](https://linear.app/clickhouse/issue/CLP-1225/expose-direct-protobuf-schema-upload-for-kafka-and-kinesis-in-openapi)
- [OpenAPI implementation](https://github.com/ClickHouse/control-plane/pull/40071)

## Risks

High: schema changes replace the ClickPipe, and sensitive schema content remains in Terraform state. Both behaviors are documented and match Kafka.

## Checklist

- [x] Tests and documentation added
- [x] Validation and replacement behavior covered
- [ ] Live acceptance testing
