### PR TITLE
fix(makefile): derive GOTOOLCHAIN from go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,21 @@ BINARY=terraform-provider-${NAME}
 VERSION=0.1
 OS_ARCH=darwin_arm64
 
+# golangci-lint can only analyse Go versions <= the one it was built with, so
+# both the linter build and the lint runs have to be pinned. Take the version
+# from go.mod, the same source CI resolves its Go from, so a bump can't leave
+# the two out of step. Exported file-wide on purpose: every target then builds
+# on the version CI uses, and no new target can miss the pin.
+#
+# Prefer the toolchain directive when there is one, since that is what setup-go
+# resolves to. `go mod edit -go=1.27` writes a two-part language version, which
+# is not a valid toolchain name, so pad it.
+GO_MOD_VERSION := $(shell awk '/^toolchain go/{v=substr($$2,3)} /^go /{if (!g) g=$$2} END{if (!v) v=g; if (v ~ /^[0-9]+\.[0-9]+$$/) v=v".0"; print v}' go.mod)
+ifeq ($(GO_MOD_VERSION),)
+$(error could not read the go version from go.mod)
+endif
+export GOTOOLCHAIN := go$(GO_MOD_VERSION)
+
 default: install
 
 build:
@@ -104,7 +119,6 @@ GOLANGCILINT = $(shell go env GOPATH)/bin/golangci-lint
 ifneq ($(shell test -f $(GOLANGCILINT) && echo -n yes),yes)
 GOLANGCILINT = /tmp/golangci-lint
 endif
-ensure-golangci-lint: export GOTOOLCHAIN := go1.26.0
 ensure-golangci-lint: ## Download golangci-lint locally if necessary.
 	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2)
 


### PR DESCRIPTION
`make fmt`, `make lint` and `make sec` panicked with `file requires newer Go version` for anyone whose local Go was ahead of go.mod. The GOTOOLCHAIN pin sat on `ensure-golangci-lint`, which only builds the linter, so the recipes that actually run it fell back to the contributor's default toolchain and `go/types` rejected the newer stdlib. The pin was also a hardcoded `go1.26.0`, maintained separately from the `go` directive and free to drift from it. The version now comes from go.mod, the same source every workflow already resolves its Go from, and is exported file-wide so no target can miss it.

Contributors get the same result CI does regardless of which Go they have installed, and `make enable_git_hooks` is usable again — the pre-commit hook runs `make fmt`, so on a newer Go every commit was rejected and had to go through `--no-verify`, which discouraged enabling the hooks at all and left commit subjects unvalidated locally. A go.mod bump now carries the linter with it instead of leaving the two to be reconciled by hand.

The pin prefers a `toolchain` directive when go.mod has one, since that is what `setup-go` resolves to, and pads a two-part version because `go mod edit -go=1.27` writes `go 1.27` while `go1.27` is not a valid toolchain name. Without the padding the next routine version bump would fail every make target rather than only the lint ones.

<details><summary>Implementation detail</summary>

Verified on local go1.27.0: `make lint`, `make sec` and `make build` all clean, including a cold cache where the linter is rebuilt from scratch under the pin. The extraction was checked against `go 1.26.0`, a two-part `go 1.27`, `go 1.27rc1`, a `toolchain` directive present, a `godebug` line present, and a go.mod with no `go` directive at all — the last fails at parse time with a readable message rather than passing an invalid `GOTOOLCHAIN` down to every recipe.

One consequence of an exact-name pin is that Go's automatic toolchain upgrade is off. The only build here over a go.mod outside this repo's control is `get-tfplugindocs`, which clones `whites11/terraform-plugin-docs` (currently `go 1.23.7`), so `make docs` would need attention if that fork ever moves above the pinned version.

</details>

Closes #688
