### PR TITLE
fix: stop emitting beta notices and CDC cleanup notes on no-change plans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,11 @@ go tool adr-tool supersede     --help
 3. Add an example under [`examples/`](examples/) and run `make docs`.
 4. Add acceptance tests and run `make testacc`.
 5. If it is not GA yet, mark it **beta**: call `utils.BetaWarning("<name>",
-   &resp.Diagnostics)` so users see it at plan time, and open its description
+   &resp.Diagnostics)` from `Create`, `Update` and `ImportState` — the
+   operations that bring a beta resource under management or change it — and
+   **not** from `ValidateConfig` or `Read`, which run on every plan and refresh
+   (see [#696](https://github.com/ClickHouse/terraform-provider-clickhouse/issues/696)).
+   Open its description
    markdown with a `~> **Note:** This resource is in beta.` callout. When a
    whole service group is beta (as ClickStack is), one callout in
    [`internal/provider/README.md`](internal/provider/README.md) covers the

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,9 @@ description: |-
   For examples on how to use this provider, see the Github repository https://github.com/ClickHouse/terraform-provider-clickhouse/tree/main/examples/.
   Authentication
   To use this provider, you need a ClickHouse Cloud account. Once you have signed up for an account https://console.clickhouse.cloud/signUp, you can sign in https://clickhouse.cloud/signIn and generate an API key https://clickhouse.com/docs/en/cloud/manage/openapi for authentication.
+  Beta resources
+  Resources that are not generally available yet emit a Beta Resource warning when they are created, updated or imported — the operations that bring one under management or change it. Nothing is emitted during terraform plan, including a plan that creates or changes a beta resource; the notice appears in the apply output instead. Beta data sources are the exception: they warn when read, which happens on every plan.
+  To acknowledge beta status once and stop the notices altogether, set CLICKHOUSE_SUPPRESS_BETA_WARNINGS=true in the environment Terraform runs in. Other warnings are unaffected.
   Breaking changes
   Note: we only provide upgrade path from consecutive major releases of our terraform provider.
   If you are upgrading, please be sure to not skip any major release while you do so.
@@ -29,7 +32,7 @@ description: |-
   If you are upgrading from version < 1.0.0 to anything >= 1.0.0 and you are using the clickhouse_private_endpoint_registration resource or the private_endpoint_ids attribute of the clickhouse_service resource,
   then a manual process is required after the upgrade. Please visit https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations https://github.com/ClickHouse/terraform-provider-clickhouse#breaking-changes-and-deprecations for more details.
   ClickStack (beta)
-  This provider also manages ClickStack https://clickhouse.com/docs/use-cases/observability/clickstack (HyperDX) resources via the clickhouse_clickstack_* resources and data sources. These are in beta: they emit a beta warning at plan/apply time and their behavior may change in future releases.
+  This provider also manages ClickStack https://clickhouse.com/docs/use-cases/observability/clickstack (HyperDX) resources via the clickhouse_clickstack_* resources and data sources. These are in beta: their behavior may change in future releases, and they emit a beta notice on create, update and import (see Beta resources).
   How the clickhouse_clickstack_* resources authenticate depends on where ClickStack runs:
   ClickStack on ClickHouse Cloud is served through the ClickHouse Cloud API https://clickhouse.com/docs/use-cases/observability/clickstack/api-reference and authenticates with the same Cloud credentials as the rest of the provider (organization_id, token_key, token_secret). Set clickstack_service_id (or the CLICKSTACK_SERVICE_ID environment variable) to the ID of the Cloud service running ClickStack:
   
@@ -80,6 +83,12 @@ For examples on how to use this provider, see the [Github repository](https://gi
 
 To use this provider, you need a ClickHouse Cloud account. Once you have [signed up for an account](https://console.clickhouse.cloud/signUp), you can [sign in](https://clickhouse.cloud/signIn) and generate an [API key](https://clickhouse.com/docs/en/cloud/manage/openapi) for authentication.
 
+## Beta resources
+
+Resources that are not generally available yet emit a `Beta Resource` warning when they are created, updated or imported — the operations that bring one under management or change it. Nothing is emitted during `terraform plan`, including a plan that creates or changes a beta resource; the notice appears in the apply output instead. Beta data sources are the exception: they warn when read, which happens on every plan.
+
+To acknowledge beta status once and stop the notices altogether, set `CLICKHOUSE_SUPPRESS_BETA_WARNINGS=true` in the environment Terraform runs in. Other warnings are unaffected.
+
 ## Breaking changes
 
 Note: we only provide upgrade path from consecutive major releases of our terraform provider.
@@ -108,7 +117,7 @@ then a manual process is required after the upgrade. Please visit [https://githu
 
 ## ClickStack (beta)
 
-This provider also manages [ClickStack](https://clickhouse.com/docs/use-cases/observability/clickstack) (HyperDX) resources via the `clickhouse_clickstack_*` resources and data sources. These are in **beta**: they emit a beta warning at plan/apply time and their behavior may change in future releases.
+This provider also manages [ClickStack](https://clickhouse.com/docs/use-cases/observability/clickstack) (HyperDX) resources via the `clickhouse_clickstack_*` resources and data sources. These are in **beta**: their behavior may change in future releases, and they emit a beta notice on create, update and import (see [Beta resources](#beta-resources)).
 
 How the `clickhouse_clickstack_*` resources authenticate depends on where ClickStack runs:
 

--- a/internal/provider/README.md
+++ b/internal/provider/README.md
@@ -18,6 +18,12 @@ For examples on how to use this provider, see the [Github repository](https://gi
 
 To use this provider, you need a ClickHouse Cloud account. Once you have [signed up for an account](https://console.clickhouse.cloud/signUp), you can [sign in](https://clickhouse.cloud/signIn) and generate an [API key](https://clickhouse.com/docs/en/cloud/manage/openapi) for authentication.
 
+## Beta resources
+
+Resources that are not generally available yet emit a `Beta Resource` warning when they are created, updated or imported — the operations that bring one under management or change it. Nothing is emitted during `terraform plan`, including a plan that creates or changes a beta resource; the notice appears in the apply output instead. Beta data sources are the exception: they warn when read, which happens on every plan.
+
+To acknowledge beta status once and stop the notices altogether, set `CLICKHOUSE_SUPPRESS_BETA_WARNINGS=true` in the environment Terraform runs in. Other warnings are unaffected.
+
 ## Breaking changes
 
 Note: we only provide upgrade path from consecutive major releases of our terraform provider.
@@ -46,7 +52,7 @@ then a manual process is required after the upgrade. Please visit [https://githu
 
 ## ClickStack (beta)
 
-This provider also manages [ClickStack](https://clickhouse.com/docs/use-cases/observability/clickstack) (HyperDX) resources via the `clickhouse_clickstack_*` resources and data sources. These are in **beta**: they emit a beta warning at plan/apply time and their behavior may change in future releases.
+This provider also manages [ClickStack](https://clickhouse.com/docs/use-cases/observability/clickstack) (HyperDX) resources via the `clickhouse_clickstack_*` resources and data sources. These are in **beta**: their behavior may change in future releases, and they emit a beta notice on create, update and import (see [Beta resources](#beta-resources)).
 
 How the `clickhouse_clickstack_*` resources authenticate depends on where ClickStack runs:
 

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -2678,27 +2678,49 @@ func (c *ClickPipeResource) ModifyPlan(ctx context.Context, request resource.Mod
 		}
 	}
 
-	// Warn about manual table cleanup for CDC pipes (Postgres and MySQL)
-	// Show this for any modification to make users aware, with message clarifying it's for recreations
-	if !request.State.Raw.IsNull() && !request.Plan.Raw.IsNull() {
-		var planSourceModel, stateSourceModel models.ClickPipeSourceModel
-		if diags := plan.Source.As(ctx, &planSourceModel, basetypes.ObjectAsOptions{}); !diags.HasError() {
-			if diags := state.Source.As(ctx, &stateSourceModel, basetypes.ObjectAsOptions{}); !diags.HasError() {
-				isCDCPipe := (!planSourceModel.Postgres.IsNull() && !stateSourceModel.Postgres.IsNull()) ||
-					(!planSourceModel.MySQL.IsNull() && !stateSourceModel.MySQL.IsNull()) ||
-					(!planSourceModel.MongoDB.IsNull() && !stateSourceModel.MongoDB.IsNull())
-				if isCDCPipe {
-					response.Diagnostics.AddWarning(
-						"Note about CDC table cleanup",
-						"If this change requires replacement (check for '# forces replacement' in the plan), destination tables are not automatically deleted. You may need to manually delete previous destination tables before recreating the pipe.",
-					)
-				}
-			}
-		}
+	// Must stay the last step that touches the plan: decides `state` from the
+	// fully repaired plan. warnAboutCDCTableCleanup runs after it but only adds
+	// diagnostics, and it needs the repaired plan to tell a no-op from a change.
+	c.planStateAttribute(ctx, request, response)
+
+	c.warnAboutCDCTableCleanup(ctx, request, response, plan, state)
+}
+
+// warnAboutCDCTableCleanup tells the practitioner that a replacement leaves the
+// old destination tables behind. Only worth saying when the pipe is actually
+// changing: on a no-op plan it is noise that hides warnings needing action
+// (https://github.com/ClickHouse/terraform-provider-clickhouse/issues/696).
+// ModifyPlan cannot see the framework's RequiresReplace, so "changing" is the
+// closest signal available, hence the hedge in the message. Runs after
+// planStateAttribute because that is what settles whether the repaired plan
+// still differs from prior state.
+func (c *ClickPipeResource) warnAboutCDCTableCleanup(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse, plan, state models.ClickPipeResourceModel) {
+	if request.State.Raw.IsNull() || request.Plan.Raw.IsNull() || response.Diagnostics.HasError() {
+		return
+	}
+	if response.Plan.Raw.Equal(request.State.Raw) {
+		return
 	}
 
-	// Must stay the final step: decides `state` from the fully repaired plan.
-	c.planStateAttribute(ctx, request, response)
+	var planSourceModel, stateSourceModel models.ClickPipeSourceModel
+	if diags := plan.Source.As(ctx, &planSourceModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return
+	}
+	if diags := state.Source.As(ctx, &stateSourceModel, basetypes.ObjectAsOptions{}); diags.HasError() {
+		return
+	}
+
+	isCDCPipe := (!planSourceModel.Postgres.IsNull() && !stateSourceModel.Postgres.IsNull()) ||
+		(!planSourceModel.MySQL.IsNull() && !stateSourceModel.MySQL.IsNull()) ||
+		(!planSourceModel.MongoDB.IsNull() && !stateSourceModel.MongoDB.IsNull())
+	if !isCDCPipe {
+		return
+	}
+
+	response.Diagnostics.AddWarning(
+		"Note about CDC table cleanup",
+		"If this change requires replacement (check for '# forces replacement' in the plan), destination tables are not automatically deleted. You may need to manually delete previous destination tables before recreating the pipe.",
+	)
 }
 
 func (c *ClickPipeResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {

--- a/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_bug_fixes_test.go
@@ -1111,3 +1111,76 @@ func TestClickPipeResource_ModifyPlan_StateOnNoOpPlan_Issue595(t *testing.T) {
 			"an update may settle in a transient state, so the planned state must stay Unknown, got %v", planned)
 	})
 }
+
+// Issue #696 — the CDC cleanup note fired on every plan for every CDC pipe,
+// including plans with no changes at all, where there is nothing to act on.
+func TestClickPipeResource_ModifyPlan_CDCCleanupNoteOnlyWhenChanging_Issue696(t *testing.T) {
+	ctx := context.Background()
+
+	hasCleanupNote := func(diags diag.Diagnostics) bool {
+		for _, d := range diags.Warnings() {
+			if d.Summary() == "Note about CDC table cleanup" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("no-change plan does not warn", func(t *testing.T) {
+		state := mysqlPlanForModifyPlan()
+		plan := mysqlPlanForModifyPlan()
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.False(t, hasCleanupNote(diags),
+			"an unchanged CDC pipe has no tables to clean up; got: %v", diags)
+	})
+
+	t.Run("changed plan still warns", func(t *testing.T) {
+		state := mysqlPlanForModifyPlan()
+		plan := mysqlPlanForModifyPlan()
+		plan.Name = types.StringValue("renamed-pipe")
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.True(t, hasCleanupNote(diags),
+			"a changing CDC pipe may be replaced, so the note must survive; got: %v", diags)
+	})
+
+	// The framework marks `state` Unknown whenever the proposed plan differs
+	// from prior state, even when ModifyPlan's repairs resolve the difference.
+	// The gate reads the repaired plan, so this still has to count as a no-op.
+	t.Run("plan repaired back to a no-op does not warn", func(t *testing.T) {
+		state := mysqlPlanForModifyPlan()
+		plan := mysqlPlanForModifyPlan()
+		plan.State = types.StringUnknown()
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.False(t, hasCleanupNote(diags),
+			"a repaired no-op has no tables to clean up; got: %v", diags)
+	})
+
+	// Postgres is the source the issue was reported against, and isCDCPipe
+	// tests each source type separately.
+	t.Run("postgres no-change plan does not warn", func(t *testing.T) {
+		state := postgresPlanWithExcludedColumns(ctx, []string{"ssn"}, "users")
+		plan := postgresPlanWithExcludedColumns(ctx, []string{"ssn"}, "users")
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.False(t, hasCleanupNote(diags),
+			"an unchanged Postgres CDC pipe has no tables to clean up; got: %v", diags)
+	})
+
+	t.Run("postgres changed plan still warns", func(t *testing.T) {
+		state := postgresPlanWithExcludedColumns(ctx, []string{"ssn"}, "users")
+		plan := postgresPlanWithExcludedColumns(ctx, []string{"ssn"}, "users")
+		plan.Name = types.StringValue("renamed-pipe")
+
+		diags := driveClickPipeModifyPlan(ctx, t, state, plan)
+
+		assert.True(t, hasCleanupNote(diags),
+			"a changing Postgres CDC pipe may be replaced, so the note must survive; got: %v", diags)
+	})
+}

--- a/internal/service/clickhouse/resource/main_test.go
+++ b/internal/service/clickhouse/resource/main_test.go
@@ -1,0 +1,49 @@
+package resource
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/utils"
+)
+
+// Create and Update on the beta resources in this package prepend a beta
+// notice, which would otherwise shift every diagnostic assertion below it.
+// The notice itself is covered by TestBetaWarning in internal/utils.
+func TestMain(m *testing.M) {
+	os.Setenv(utils.SuppressBetaWarningsEnvVar, "1")
+	os.Exit(m.Run())
+}
+
+// The package-wide suppression above means a test here sees no beta notice
+// unless it opts back in, as this one does. It also covers the notice reaching
+// Create/Update/ImportState in this package, which nothing else asserts (#696).
+func TestBetaNoticeEmittedWhenNotSuppressed(t *testing.T) {
+	t.Setenv(utils.SuppressBetaWarningsEnvVar, "false")
+
+	ctx := context.Background()
+	r := &UDFAttachmentResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+	nullRaw := tftypes.NewValue(sch.Type().TerraformType(ctx), nil)
+
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: sch, Raw: nullRaw}}
+	r.Create(ctx, resource.CreateRequest{Plan: tfsdk.Plan{Schema: sch, Raw: nullRaw}}, resp)
+
+	for _, d := range resp.Diagnostics.Warnings() {
+		if d.Summary() == "Beta Resource" {
+			return
+		}
+	}
+	t.Errorf("Create emitted no beta notice; diagnostics = %v", resp.Diagnostics)
+}

--- a/internal/service/clickhouse/resource/service_scheduled_scaling.go
+++ b/internal/service/clickhouse/resource/service_scheduled_scaling.go
@@ -227,6 +227,8 @@ func (r *ServiceScheduledScalingResource) Configure(_ context.Context, req resou
 }
 
 func (r *ServiceScheduledScalingResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_service_scheduled_scaling", &resp.Diagnostics)
+
 	var plan models.ServiceScheduledScalingResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -278,7 +280,6 @@ func (r *ServiceScheduledScalingResource) Create(ctx context.Context, req resour
 }
 
 func (r *ServiceScheduledScalingResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	utils.BetaWarning("clickhouse_service_scheduled_scaling", &resp.Diagnostics)
 	var state models.ServiceScheduledScalingResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -307,6 +308,8 @@ func (r *ServiceScheduledScalingResource) Read(ctx context.Context, req resource
 }
 
 func (r *ServiceScheduledScalingResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_service_scheduled_scaling", &resp.Diagnostics)
+
 	var plan models.ServiceScheduledScalingResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -355,13 +358,14 @@ func (r *ServiceScheduledScalingResource) Delete(ctx context.Context, req resour
 }
 
 func (r *ServiceScheduledScalingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_service_scheduled_scaling", &resp.Diagnostics)
+
 	// `id` and `service_id` are equal — write both so Read finds the service.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_id"), req.ID)...)
 }
 
 func (r *ServiceScheduledScalingResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_service_scheduled_scaling", &resp.Diagnostics)
 	var config models.ServiceScheduledScalingResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/service/clickhouse/resource/service_upgrade_window.go
+++ b/internal/service/clickhouse/resource/service_upgrade_window.go
@@ -105,6 +105,8 @@ func (r *ServiceUpgradeWindowResource) Configure(_ context.Context, req resource
 }
 
 func (r *ServiceUpgradeWindowResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_service_upgrade_window", &resp.Diagnostics)
+
 	var plan models.ServiceUpgradeWindowResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -141,12 +143,7 @@ func (r *ServiceUpgradeWindowResource) Create(ctx context.Context, req resource.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
-func (r *ServiceUpgradeWindowResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_service_upgrade_window", &resp.Diagnostics)
-}
-
 func (r *ServiceUpgradeWindowResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	utils.BetaWarning("clickhouse_service_upgrade_window", &resp.Diagnostics)
 	var state models.ServiceUpgradeWindowResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -171,6 +168,8 @@ func (r *ServiceUpgradeWindowResource) Read(ctx context.Context, req resource.Re
 }
 
 func (r *ServiceUpgradeWindowResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_service_upgrade_window", &resp.Diagnostics)
+
 	var plan models.ServiceUpgradeWindowResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -205,6 +204,8 @@ func (r *ServiceUpgradeWindowResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *ServiceUpgradeWindowResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_service_upgrade_window", &resp.Diagnostics)
+
 	// Validate the service exists and is a primary before writing state.
 	// GET /upgradeWindow on a secondary returns the inherited primary's window
 	// (so import would succeed at the upgrade-window layer), but every

--- a/internal/service/clickhouse/resource/udf.go
+++ b/internal/service/clickhouse/resource/udf.go
@@ -267,8 +267,6 @@ func (r *UDFResource) Configure(_ context.Context, req resource.ConfigureRequest
 }
 
 func (r *UDFResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_udf", &resp.Diagnostics)
-
 	var config models.UDFResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() || config.Type.IsUnknown() || config.Runtime.IsUnknown() {
@@ -394,6 +392,8 @@ func (r *UDFResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanReq
 }
 
 func (r *UDFResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_udf", &resp.Diagnostics)
+
 	var plan models.UDFResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -455,6 +455,8 @@ func (r *UDFResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 }
 
 func (r *UDFResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_udf", &resp.Diagnostics)
+
 	var plan models.UDFResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -526,6 +528,8 @@ func (r *UDFResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 }
 
 func (r *UDFResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_udf", &resp.Diagnostics)
+
 	if !udfNamePattern.MatchString(req.ID) {
 		resp.Diagnostics.AddError(
 			"Invalid UDF import ID",

--- a/internal/service/clickhouse/resource/udf_attachment.go
+++ b/internal/service/clickhouse/resource/udf_attachment.go
@@ -28,10 +28,9 @@ import (
 )
 
 var (
-	_ resource.Resource                   = (*UDFAttachmentResource)(nil)
-	_ resource.ResourceWithConfigure      = (*UDFAttachmentResource)(nil)
-	_ resource.ResourceWithImportState    = (*UDFAttachmentResource)(nil)
-	_ resource.ResourceWithValidateConfig = (*UDFAttachmentResource)(nil)
+	_ resource.Resource                = (*UDFAttachmentResource)(nil)
+	_ resource.ResourceWithConfigure   = (*UDFAttachmentResource)(nil)
+	_ resource.ResourceWithImportState = (*UDFAttachmentResource)(nil)
 )
 
 //go:embed descriptions/udf_attachment.md
@@ -114,11 +113,9 @@ func (r *UDFAttachmentResource) Configure(_ context.Context, req resource.Config
 	r.client = providerData.API
 }
 
-func (r *UDFAttachmentResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_udf_attachment", &resp.Diagnostics)
-}
-
 func (r *UDFAttachmentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_udf_attachment", &resp.Diagnostics)
+
 	var plan models.UDFAttachmentResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -162,6 +159,8 @@ func (r *UDFAttachmentResource) Read(ctx context.Context, req resource.ReadReque
 }
 
 func (r *UDFAttachmentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_udf_attachment", &resp.Diagnostics)
+
 	var plan models.UDFAttachmentResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -191,6 +190,8 @@ func (r *UDFAttachmentResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *UDFAttachmentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_udf_attachment", &resp.Diagnostics)
+
 	parts := strings.Split(req.ID, "/")
 	if len(parts) != 2 || !udfNamePattern.MatchString(parts[0]) || !uuidPattern.MatchString(parts[1]) {
 		resp.Diagnostics.AddError(

--- a/internal/service/clickstack/alert_resource.go
+++ b/internal/service/clickstack/alert_resource.go
@@ -397,7 +397,6 @@ func (r *alertResource) Configure(_ context.Context, req resource.ConfigureReque
 // short-circuits when an operand is null or unknown, mirroring the guard in the
 // dashboard resource's ValidateConfig.
 func (r *alertResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_alert", &resp.Diagnostics)
 	var cfg alertResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	if resp.Diagnostics.HasError() {
@@ -605,6 +604,8 @@ func validateAlertChannel(diags *diag.Diagnostics, p path.Path, c alertChannelMo
 }
 
 func (r *alertResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_alert", &resp.Diagnostics)
+
 	var plan alertResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -662,6 +663,8 @@ func (r *alertResource) Read(ctx context.Context, req resource.ReadRequest, resp
 }
 
 func (r *alertResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_alert", &resp.Diagnostics)
+
 	var plan alertResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -711,6 +714,8 @@ func (r *alertResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 }
 
 func (r *alertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_alert", &resp.Diagnostics)
+
 	if team, id, ok := strings.Cut(req.ID, "/"); ok {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team"), team)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)

--- a/internal/service/clickstack/beta_notice_test.go
+++ b/internal/service/clickstack/beta_notice_test.go
@@ -1,0 +1,67 @@
+package clickstack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// The beta notice moved out of ValidateConfig, which no test could miss because
+// it ran on every plan, into the three operations that bring a beta resource
+// under management or change it. Nothing else asserts it reaches them, so a
+// dropped call would otherwise leave the suite green (#696).
+func TestBetaNoticeEmittedByMutatingOperations(t *testing.T) {
+	ctx := context.Background()
+	r := &sourceResource{}
+
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("building resource schema failed: %v", schemaResp.Diagnostics.Errors())
+	}
+	sch := schemaResp.Schema
+	nullRaw := tftypes.NewValue(sch.Type().TerraformType(ctx), nil)
+
+	// Each operation is driven with a null plan/state so it errors out right
+	// after the notice; the notice is emitted before any client call, so no
+	// ClickStack API is needed to observe it.
+	for name, emit := range map[string]func() []string{
+		"Create": func() []string {
+			resp := &resource.CreateResponse{State: tfsdk.State{Schema: sch, Raw: nullRaw}}
+			r.Create(ctx, resource.CreateRequest{Plan: tfsdk.Plan{Schema: sch, Raw: nullRaw}}, resp)
+			return warningSummaries(resp.Diagnostics)
+		},
+		"Update": func() []string {
+			resp := &resource.UpdateResponse{State: tfsdk.State{Schema: sch, Raw: nullRaw}}
+			r.Update(ctx, resource.UpdateRequest{Plan: tfsdk.Plan{Schema: sch, Raw: nullRaw}}, resp)
+			return warningSummaries(resp.Diagnostics)
+		},
+		"ImportState": func() []string {
+			resp := &resource.ImportStateResponse{State: tfsdk.State{Schema: sch, Raw: nullRaw}}
+			r.ImportState(ctx, resource.ImportStateRequest{ID: "source-1"}, resp)
+			return warningSummaries(resp.Diagnostics)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := emit()
+			for _, summary := range got {
+				if summary == "Beta Resource" {
+					return
+				}
+			}
+			t.Errorf("%s emitted no beta notice; warnings = %v", name, got)
+		})
+	}
+}
+
+func warningSummaries(diags diag.Diagnostics) []string {
+	summaries := make([]string, 0, len(diags.Warnings()))
+	for _, d := range diags.Warnings() {
+		summaries = append(summaries, d.Summary())
+	}
+	return summaries
+}

--- a/internal/service/clickstack/connection_resource.go
+++ b/internal/service/clickstack/connection_resource.go
@@ -133,11 +133,9 @@ func (r *connectionResource) Configure(_ context.Context, req resource.Configure
 	r.client = providerData.ClickStack
 }
 
-func (r *connectionResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_connection", &resp.Diagnostics)
-}
-
 func (r *connectionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_connection", &resp.Diagnostics)
+
 	var plan connectionResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -187,6 +185,8 @@ func (r *connectionResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (r *connectionResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_connection", &resp.Diagnostics)
+
 	var plan connectionResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -235,6 +235,8 @@ func (r *connectionResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 func (r *connectionResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_connection", &resp.Diagnostics)
+
 	// Accept either "<id>" (default team) or "<team>/<id>" so connections in a
 	// non-default team can be imported. The team is required by the API to
 	// resolve the team-scoped connection ID during the import Read.

--- a/internal/service/clickstack/dashboard_resource.go
+++ b/internal/service/clickstack/dashboard_resource.go
@@ -254,6 +254,8 @@ func (r *dashboardResource) Configure(_ context.Context, req resource.ConfigureR
 }
 
 func (r *dashboardResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_dashboard", &resp.Diagnostics)
+
 	var plan dashboardResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -333,6 +335,8 @@ func (r *dashboardResource) Read(ctx context.Context, req resource.ReadRequest, 
 }
 
 func (r *dashboardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_dashboard", &resp.Diagnostics)
+
 	var plan dashboardResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	// The prior state holds the server-canonical body with its assigned tile IDs.
@@ -406,6 +410,8 @@ func (r *dashboardResource) Delete(ctx context.Context, req resource.DeleteReque
 }
 
 func (r *dashboardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_dashboard", &resp.Diagnostics)
+
 	// Accept either "<id>" (default team) or "<team>/<id>" so dashboards in a
 	// non-default team can be imported. The team is required by the API to
 	// resolve the team-scoped dashboard ID during the import Read.
@@ -448,7 +454,6 @@ func parseDashboardJSON(s string) error {
 }
 
 func (r *dashboardResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_dashboard", &resp.Diagnostics)
 	var cfg dashboardResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/service/clickstack/dashboard_resource_test.go
+++ b/internal/service/clickstack/dashboard_resource_test.go
@@ -460,15 +460,7 @@ func TestDashboardResource_ValidateConfig(t *testing.T) {
 			resp := &fwresource.ValidateConfigResponse{}
 			r.ValidateConfig(context.Background(), dashboardValidateConfigRequest(t, tc.dashboardJSON), resp)
 
-			// ValidateConfig also emits the beta warning; drop it so these
-			// cases assert only the dashboard_json validation diagnostics.
-			var got diag.Diagnostics
-			for _, d := range resp.Diagnostics {
-				if d.Summary() == "Beta Resource" {
-					continue
-				}
-				got = append(got, d)
-			}
+			got := resp.Diagnostics
 
 			if len(got) != len(tc.want) {
 				t.Fatalf("got %d diagnostics, want %d: %s", len(got), len(tc.want), got)

--- a/internal/service/clickstack/role_resource.go
+++ b/internal/service/clickstack/role_resource.go
@@ -170,11 +170,9 @@ func (r *roleResource) Configure(_ context.Context, req resource.ConfigureReques
 	r.client = providerData.ClickStack
 }
 
-func (r *roleResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_role", &resp.Diagnostics)
-}
-
 func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_role", &resp.Diagnostics)
+
 	var plan roleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -243,6 +241,8 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_role", &resp.Diagnostics)
+
 	var plan roleResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -286,6 +286,8 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 }
 
 func (r *roleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_role", &resp.Diagnostics)
+
 	if team, id, ok := strings.Cut(req.ID, "/"); ok {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team"), team)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)

--- a/internal/service/clickstack/saved_search_resource.go
+++ b/internal/service/clickstack/saved_search_resource.go
@@ -161,7 +161,6 @@ func (r *savedSearchResource) Configure(_ context.Context, req resource.Configur
 // ValidateConfig checks enum and JSON-shape constraints at plan time so invalid
 // values surface before apply rather than as opaque API errors.
 func (r *savedSearchResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_saved_search", &resp.Diagnostics)
 	var cfg savedSearchResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	if resp.Diagnostics.HasError() {
@@ -193,6 +192,8 @@ func (m *savedSearchResourceModel) validate() diag.Diagnostics {
 }
 
 func (r *savedSearchResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_saved_search", &resp.Diagnostics)
+
 	var plan savedSearchResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -238,6 +239,8 @@ func (r *savedSearchResource) Read(ctx context.Context, req resource.ReadRequest
 }
 
 func (r *savedSearchResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_saved_search", &resp.Diagnostics)
+
 	var plan savedSearchResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -284,6 +287,8 @@ func (r *savedSearchResource) Delete(ctx context.Context, req resource.DeleteReq
 }
 
 func (r *savedSearchResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_saved_search", &resp.Diagnostics)
+
 	if team, id, ok := strings.Cut(req.ID, "/"); ok {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team"), team)...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)

--- a/internal/service/clickstack/source_resource.go
+++ b/internal/service/clickstack/source_resource.go
@@ -342,11 +342,9 @@ func (r *sourceResource) Configure(_ context.Context, req resource.ConfigureRequ
 	r.client = providerData.ClickStack
 }
 
-func (r *sourceResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_source", &resp.Diagnostics)
-}
-
 func (r *sourceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_source", &resp.Diagnostics)
+
 	var plan sourceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -388,6 +386,8 @@ func (r *sourceResource) Read(ctx context.Context, req resource.ReadRequest, res
 }
 
 func (r *sourceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_source", &resp.Diagnostics)
+
 	var plan sourceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -421,6 +421,8 @@ func (r *sourceResource) Delete(ctx context.Context, req resource.DeleteRequest,
 }
 
 func (r *sourceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_source", &resp.Diagnostics)
+
 	// Accept "<id>" (default team) or "<team>/<id>" for a non-default team.
 	if team, id, ok := strings.Cut(req.ID, "/"); ok {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team"), team)...)

--- a/internal/service/clickstack/team_member_resource.go
+++ b/internal/service/clickstack/team_member_resource.go
@@ -143,11 +143,9 @@ func (r *teamMemberResource) Configure(_ context.Context, req resource.Configure
 	r.client = providerData.ClickStack
 }
 
-func (r *teamMemberResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_team_member", &resp.Diagnostics)
-}
-
 func (r *teamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team_member", &resp.Diagnostics)
+
 	var plan teamMemberResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -218,6 +216,8 @@ func (r *teamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (r *teamMemberResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team_member", &resp.Diagnostics)
+
 	var plan, state teamMemberResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -281,6 +281,8 @@ func (r *teamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 }
 
 func (r *teamMemberResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team_member", &resp.Diagnostics)
+
 	// Accept "<email>" or "<team>/<email>". The remaining attributes are
 	// resolved during the import Read by matching on email.
 	if team, email, ok := strings.Cut(req.ID, "/"); ok {

--- a/internal/service/clickstack/team_resource.go
+++ b/internal/service/clickstack/team_resource.go
@@ -101,11 +101,9 @@ func (r *teamResource) Configure(_ context.Context, req resource.ConfigureReques
 	r.client = providerData.ClickStack
 }
 
-func (r *teamResource) ValidateConfig(_ context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_team", &resp.Diagnostics)
-}
-
 func (r *teamResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team", &resp.Diagnostics)
+
 	var plan teamResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -157,6 +155,8 @@ func (r *teamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 }
 
 func (r *teamResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team", &resp.Diagnostics)
+
 	var plan teamResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
@@ -181,6 +181,8 @@ func (r *teamResource) Delete(_ context.Context, _ resource.DeleteRequest, _ *re
 }
 
 func (r *teamResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_team", &resp.Diagnostics)
+
 	// Import by team ID, which is also used as the x-hdx-team header so the
 	// import Read resolves the correct team.
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team"), req.ID)...)

--- a/internal/service/clickstack/webhook_resource.go
+++ b/internal/service/clickstack/webhook_resource.go
@@ -179,7 +179,6 @@ func (r *webhookResource) Configure(_ context.Context, req resource.ConfigureReq
 }
 
 func (r *webhookResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_clickstack_webhook", &resp.Diagnostics)
 	var cfg webhookResourceModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &cfg)...)
 	if resp.Diagnostics.HasError() {
@@ -221,6 +220,8 @@ func (m *webhookResourceModel) validate() diag.Diagnostics {
 }
 
 func (r *webhookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_webhook", &resp.Diagnostics)
+
 	var plan webhookResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	// Write-only values live only in config, not plan.
@@ -269,6 +270,8 @@ func (r *webhookResource) Read(ctx context.Context, req resource.ReadRequest, re
 }
 
 func (r *webhookResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_webhook", &resp.Diagnostics)
+
 	var plan webhookResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	var config webhookResourceModel
@@ -317,6 +320,8 @@ func (r *webhookResource) Delete(ctx context.Context, req resource.DeleteRequest
 }
 
 func (r *webhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_clickstack_webhook", &resp.Diagnostics)
+
 	// Accept "<id>" (default team) or "<team>/<id>" for a non-default team.
 	// Write-only secrets are null on import (they live only in config).
 	if team, id, ok := strings.Cut(req.ID, "/"); ok {

--- a/internal/service/postgres/resource/postgres_service.go
+++ b/internal/service/postgres/resource/postgres_service.go
@@ -58,9 +58,6 @@ func (r *PostgresServiceResource) Metadata(_ context.Context, req resource.Metad
 	resp.TypeName = req.ProviderTypeName + "_postgres_service"
 }
 
-// ValidateConfig surfaces the beta warning at plan time, matching the other
-// beta resources (clickhouse_service_upgrade_window, …).
-//
 // State-dependent rules are NOT enforced here: ValidateConfig is stateless, so
 // it can't tell a create from an update or read prior state. That covers the
 // create-time attribute rules (required for a standard create; inherited from
@@ -69,8 +66,6 @@ func (r *PostgresServiceResource) Metadata(_ context.Context, req resource.Metad
 // block (which needs is_primary from prior state). All of these live in
 // ModifyPlan, which has prior state.
 func (r *PostgresServiceResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
-
 	var cloudProvider types.String
 	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("cloud_provider"), &cloudProvider)...)
 	if resp.Diagnostics.HasError() {
@@ -575,6 +570,8 @@ func (r *PostgresServiceResource) Configure(_ context.Context, req resource.Conf
 // Create provisions a new instance via one of three mutually-exclusive paths:
 // standard, read replica (read_replica_of), or point-in-time restore.
 func (r *PostgresServiceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
+
 	var plan, config models.PostgresServiceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
@@ -692,8 +689,6 @@ func (r *PostgresServiceResource) Create(ctx context.Context, req resource.Creat
 }
 
 func (r *PostgresServiceResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
-
 	var state models.PostgresServiceResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
@@ -759,6 +754,8 @@ func (r *PostgresServiceResource) Read(ctx context.Context, req resource.ReadReq
 // RequiresReplaceIf (replace for a live replica, adopted in place once promoted
 // out-of-band) so Update also handles that in-place adoption.
 func (r *PostgresServiceResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
+
 	var plan, state, config models.PostgresServiceResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -890,6 +887,8 @@ func (r *PostgresServiceResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *PostgresServiceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	utils.BetaWarning("clickhouse_postgres_service", &resp.Diagnostics)
+
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 

--- a/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
+++ b/internal/service/postgres/resource/postgres_service_cloud_provider_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ClickHouse/terraform-provider-clickhouse/internal/api"
 	"github.com/ClickHouse/terraform-provider-clickhouse/internal/service/postgres/resource/models"
+	"github.com/ClickHouse/terraform-provider-clickhouse/internal/utils"
 )
 
 func TestPostgresSchema_cloudProviderAndSize(t *testing.T) {
@@ -57,6 +58,30 @@ func TestPostgresSchema_cloudProviderAndSize(t *testing.T) {
 	}
 }
 
+// Suppressing the beta notices must not touch anything else -- issue #696 asked
+// for the beta notices gone, not for a quieter provider.
+func TestPostgresPrivatePreviewWarningSurvivesBetaSuppression(t *testing.T) {
+	t.Setenv(utils.SuppressBetaWarningsEnvVar, "1")
+
+	ctx := context.Background()
+	r := &PostgresServiceResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	model := gateModel(true)
+	model.CloudProvider = types.StringValue("gcp")
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	require.False(t, state.Set(ctx, model).HasError())
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, resource.ValidateConfigRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: state.Raw},
+	}, &resp)
+
+	require.Equal(t, 1, resp.Diagnostics.WarningsCount(), "%v", resp.Diagnostics)
+	require.Contains(t, resp.Diagnostics.Warnings()[0].Summary(), "private preview")
+}
+
 func TestPostgresValidateConfig_privatePreview(t *testing.T) {
 	ctx := context.Background()
 	r := &PostgresServiceResource{}
@@ -68,10 +93,10 @@ func TestPostgresValidateConfig_privatePreview(t *testing.T) {
 		provider  types.String
 		wantCount int
 	}{
-		{"aws", types.StringValue("aws"), 1},
-		{"gcp", types.StringValue("gcp"), 2},
-		{"inherited", types.StringNull(), 1},
-		{"unknown", types.StringUnknown(), 1},
+		{"aws", types.StringValue("aws"), 0},
+		{"gcp", types.StringValue("gcp"), 1},
+		{"inherited", types.StringNull(), 0},
+		{"unknown", types.StringUnknown(), 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			model := gateModel(true)
@@ -84,9 +109,8 @@ func TestPostgresValidateConfig_privatePreview(t *testing.T) {
 			}, &resp)
 			require.False(t, resp.Diagnostics.HasError(), "%v", resp.Diagnostics)
 			require.Equal(t, tc.wantCount, resp.Diagnostics.WarningsCount(), "%v", resp.Diagnostics)
-			require.Equal(t, "Beta Resource", resp.Diagnostics.Warnings()[0].Summary())
 			if tc.name == "gcp" {
-				warning := resp.Diagnostics.Warnings()[1]
+				warning := resp.Diagnostics.Warnings()[0]
 				require.Contains(t, warning.Summary(), "private preview")
 				require.Contains(t, warning.Detail(), "Contact ClickHouse support")
 				require.Equal(t, path.Root("cloud_provider"), warning.(diag.DiagnosticWithPath).Path())

--- a/internal/utils/beta_warning.go
+++ b/internal/utils/beta_warning.go
@@ -1,10 +1,24 @@
 package utils
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
+// SuppressBetaWarningsEnvVar lets a practitioner acknowledge beta status once
+// and stop the notices. On a config with many beta resources they crowd out the
+// warnings that need acting on: https://github.com/ClickHouse/terraform-provider-clickhouse/issues/696
+const SuppressBetaWarningsEnvVar = "CLICKHOUSE_SUPPRESS_BETA_WARNINGS"
+
 func BetaWarning(resourceName string, diags *diag.Diagnostics) {
+	// A value that isn't a bool leaves the warnings on, so a typo can't silence
+	// them without anyone noticing.
+	if suppressed, _ := strconv.ParseBool(os.Getenv(SuppressBetaWarningsEnvVar)); suppressed {
+		return
+	}
+
 	diags.AddWarning(
 		"Beta Resource",
 		"\""+resourceName+"\" is in beta and its behavior may change in future provider versions.",

--- a/internal/utils/beta_warning_test.go
+++ b/internal/utils/beta_warning_test.go
@@ -26,3 +26,31 @@ func TestBetaWarning(t *testing.T) {
 		t.Errorf("detail = %q, want %q", got, want)
 	}
 }
+
+func TestBetaWarningSuppressed(t *testing.T) {
+	for _, value := range []string{"1", "true", "TRUE"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(SuppressBetaWarningsEnvVar, value)
+
+			var diags diag.Diagnostics
+			BetaWarning("clickhouse_clickstack_dashboard", &diags)
+
+			if len(diags) != 0 {
+				t.Errorf("got %d diagnostics, want 0: %s", len(diags), diags)
+			}
+		})
+	}
+}
+
+// A value that isn't a bool must not silence the notice: a typo in the env var
+// should leave the warnings on rather than hide them.
+func TestBetaWarningIgnoresNonBoolEnv(t *testing.T) {
+	t.Setenv(SuppressBetaWarningsEnvVar, "yes-please")
+
+	var diags diag.Diagnostics
+	BetaWarning("clickhouse_clickstack_dashboard", &diags)
+
+	if len(diags) != 1 {
+		t.Errorf("got %d diagnostics, want 1: %s", len(diags), diags)
+	}
+}


### PR DESCRIPTION
Closes #696.

A `terraform plan` that changes nothing is quiet again. Before this, a config with six beta resources printed twelve "Beta Resource" notices on every plan — Terraform calls `ValidateResourceConfig` once on the validate walk and again on the plan walk, so each resource announced itself twice — plus a CDC table-cleanup note for every unchanged Postgres, MySQL or MongoDB ClickPipe. None of it was actionable, and it buried the warnings that were. Beta resources now announce themselves when you create, update or import one, and the cleanup note only appears when the plan actually changes the pipe.

A team that already knows it is running beta resources can set `CLICKHOUSE_SUPPRESS_BETA_WARNINGS=true` and stop the notices for good, which is the only relief available for the two beta *data sources* — they have no hook other than `Read`, which runs on every plan. Other warnings are untouched, and a value that isn't a boolean leaves the notices on, so a typo in the variable can't silence them without anyone noticing.

The cleanup note still can't be narrowed to replacements only, which is why it keeps hedging with "if this change requires replacement". `terraform-plugin-framework` seeds the resource-level `ModifyPlan` response with an empty `RequiresReplace` and appends the attribute-level paths after it returns, so `ModifyPlan` genuinely cannot see whether the plan forces replacement; "something changed" is the closest signal available. Destroys are covered separately by the note `Delete` already emitted.

Worth flagging for review: this reverses the placement chosen in #630, which deliberately put the notice in `ValidateConfig` and `Read` so it surfaced whenever a beta resource was declared or sitting in state. Nothing is emitted during plan now — including a plan that will create a beta resource — and the notice appears in the apply output instead. If you rely on scanning plan output to gate applies, that signal moves to apply. (Issue #696 attributes the plan-time behavior to #657; that PR was a mechanical alpha→beta rename, and the decision actually traces to #630.)

`CONTRIBUTING.md` told contributors to wire the notice up "so users see it at plan time", so a new beta resource built by the book would have brought the problem straight back; it now names the three operations to call it from and the two to avoid.