### PR TITLE
feat(clickpipe): add initial_load_parallelism to MongoDB CDC settings

### DIFF
--- a/docs/resources/clickpipe.md
+++ b/docs/resources/clickpipe.md
@@ -355,6 +355,7 @@ Required:
 Optional:
 
 - `delete_on_merge` (Boolean) Enable hard delete behavior in ReplacingMergeTree for MongoDB DELETE operations.
+- `initial_load_parallelism` (Number) Number of parallel workers to use per collection during the initial snapshot phase. Can only be set at creation time; changing it forces pipe replacement.
 - `pull_batch_size` (Number) Number of rows to pull in each batch during CDC replication.
 - `snapshot_num_rows_per_partition` (Number) Number of rows per partition during the snapshot phase.
 - `snapshot_number_of_parallel_tables` (Number) Number of collections to snapshot in parallel during the initial load phase.

--- a/examples/resources/clickhouse_clickpipe/resource_mongodb_cdc.tf
+++ b/examples/resources/clickhouse_clickpipe/resource_mongodb_cdc.tf
@@ -21,6 +21,10 @@ resource "clickhouse_clickpipe" "mongodb_cdc_clickpipe" {
         # Optional: Number of rows to pull per batch
         pull_batch_size = 500
 
+        # Optional: Number of parallel workers per collection during the initial
+        # snapshot. Can only be set at creation time (changing it replaces the pipe).
+        initial_load_parallelism = 4
+
         # Optional: Number of rows per partition during snapshot
         snapshot_num_rows_per_partition = 100000
 

--- a/internal/api/clickpipe_models.go
+++ b/internal/api/clickpipe_models.go
@@ -270,6 +270,7 @@ type ClickPipeMongoDBSettings struct {
 	SyncIntervalSeconds            *int   `json:"syncIntervalSeconds,omitempty"`
 	PullBatchSize                  *int   `json:"pullBatchSize,omitempty"`
 	ReplicationMode                string `json:"replicationMode,omitempty"`
+	InitialLoadParallelism         *int   `json:"initialLoadParallelism,omitempty"`
 	SnapshotNumRowsPerPartition    *int   `json:"snapshotNumRowsPerPartition,omitempty"`
 	SnapshotNumberOfParallelTables *int   `json:"snapshotNumberOfParallelTables,omitempty"`
 	DeleteOnMerge                  *bool  `json:"deleteOnMerge,omitempty"`

--- a/internal/service/clickhouse/resource/clickpipe.go
+++ b/internal/service/clickhouse/resource/clickpipe.go
@@ -1768,6 +1768,18 @@ func (c *ClickPipeResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 											int64validator.AtLeast(1),
 										},
 									},
+									"initial_load_parallelism": schema.Int64Attribute{
+										Description: "Number of parallel workers to use per collection during the initial snapshot phase. Can only be set at creation time; changing it forces pipe replacement.",
+										Computed:    true,
+										Optional:    true,
+										PlanModifiers: []planmodifier.Int64{
+											int64planmodifier.RequiresReplace(),
+											int64planmodifier.UseStateForUnknown(),
+										},
+										Validators: []validator.Int64{
+											int64validator.AtLeast(1),
+										},
+									},
 									"snapshot_num_rows_per_partition": schema.Int64Attribute{
 										Description: "Number of rows per partition during the snapshot phase.",
 										Computed:    true,
@@ -3825,6 +3837,10 @@ func (c *ClickPipeResource) extractSourceFromPlan(ctx context.Context, diagnosti
 			v := int(settingsModel.PullBatchSize.ValueInt64())
 			settings.PullBatchSize = &v
 		}
+		if !settingsModel.InitialLoadParallelism.IsNull() && !settingsModel.InitialLoadParallelism.IsUnknown() {
+			v := int(settingsModel.InitialLoadParallelism.ValueInt64())
+			settings.InitialLoadParallelism = &v
+		}
 		if !settingsModel.SnapshotNumRowsPerPartition.IsNull() && !settingsModel.SnapshotNumRowsPerPartition.IsUnknown() {
 			v := int(settingsModel.SnapshotNumRowsPerPartition.ValueInt64())
 			settings.SnapshotNumRowsPerPartition = &v
@@ -4958,6 +4974,12 @@ func (c *ClickPipeResource) syncClickPipeState(ctx context.Context, state *model
 			settingsModel.PullBatchSize = types.Int64Value(int64(*clickPipe.Source.MongoDB.Settings.PullBatchSize))
 		} else {
 			settingsModel.PullBatchSize = stateSettingsModel.PullBatchSize
+		}
+
+		if clickPipe.Source.MongoDB.Settings.InitialLoadParallelism != nil {
+			settingsModel.InitialLoadParallelism = types.Int64Value(int64(*clickPipe.Source.MongoDB.Settings.InitialLoadParallelism))
+		} else {
+			settingsModel.InitialLoadParallelism = stateSettingsModel.InitialLoadParallelism
 		}
 
 		if clickPipe.Source.MongoDB.Settings.SnapshotNumRowsPerPartition != nil {

--- a/internal/service/clickhouse/resource/clickpipe_test.go
+++ b/internal/service/clickhouse/resource/clickpipe_test.go
@@ -1270,6 +1270,7 @@ func buildMongoDBCredentialsPlan(password, passwordWO types.String, passwordWOVe
 			"replication_mode":                   types.StringValue("cdc"),
 			"sync_interval_seconds":              types.Int64Null(),
 			"pull_batch_size":                    types.Int64Null(),
+			"initial_load_parallelism":           types.Int64Null(),
 			"snapshot_num_rows_per_partition":    types.Int64Null(),
 			"snapshot_number_of_parallel_tables": types.Int64Null(),
 			"delete_on_merge":                    types.BoolNull(),
@@ -1450,11 +1451,12 @@ func TestClickPipeResource_syncClickPipeState_MongoDB(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
-		state       models.ClickPipeResourceModel
-		response    *api.ClickPipe
-		responseErr error
-		wantErr     bool
+		name                       string
+		state                      models.ClickPipeResourceModel
+		response                   *api.ClickPipe
+		responseErr                error
+		wantErr                    bool
+		wantInitialLoadParallelism types.Int64
 	}{
 		{
 			name:  "Syncs MongoDB source with all settings",
@@ -1471,6 +1473,7 @@ func TestClickPipeResource_syncClickPipeState_MongoDB(t *testing.T) {
 							ReplicationMode:                "cdc",
 							SyncIntervalSeconds:            intPtr(30),
 							PullBatchSize:                  intPtr(500),
+							InitialLoadParallelism:         intPtr(4),
 							SnapshotNumRowsPerPartition:    intPtr(100000),
 							SnapshotNumberOfParallelTables: intPtr(2),
 							DeleteOnMerge:                  boolPtr(true),
@@ -1490,7 +1493,8 @@ func TestClickPipeResource_syncClickPipeState_MongoDB(t *testing.T) {
 					Database: "default",
 				},
 			},
-			wantErr: false,
+			wantErr:                    false,
+			wantInitialLoadParallelism: types.Int64Value(4),
 		},
 		{
 			name:  "Preserves null values for optional MongoDB settings",
@@ -1519,7 +1523,8 @@ func TestClickPipeResource_syncClickPipeState_MongoDB(t *testing.T) {
 					Database: "default",
 				},
 			},
-			wantErr: false,
+			wantErr:                    false,
+			wantInitialLoadParallelism: types.Int64Null(),
 		},
 	}
 
@@ -1561,6 +1566,11 @@ func TestClickPipeResource_syncClickPipeState_MongoDB(t *testing.T) {
 				var mongodbModel models.ClickPipeMongoDBSourceModel
 				sourceModel.MongoDB.As(ctx, &mongodbModel, basetypes.ObjectAsOptions{})
 				assert.False(t, mongodbModel.Credentials.IsNull(), "credentials should be preserved from state")
+
+				// Validate initial_load_parallelism is read back from the API (or kept null when absent)
+				var settingsModel models.ClickPipeMongoDBSettingsModel
+				mongodbModel.Settings.As(ctx, &settingsModel, basetypes.ObjectAsOptions{})
+				assert.Equal(t, tt.wantInitialLoadParallelism, settingsModel.InitialLoadParallelism)
 			}
 		})
 	}
@@ -1605,6 +1615,7 @@ func getMongoDBInitialState() models.ClickPipeResourceModel {
 							"replication_mode":                   types.StringValue("cdc"),
 							"sync_interval_seconds":              types.Int64Null(),
 							"pull_batch_size":                    types.Int64Null(),
+							"initial_load_parallelism":           types.Int64Null(),
 							"snapshot_num_rows_per_partition":    types.Int64Null(),
 							"snapshot_number_of_parallel_tables": types.Int64Null(),
 							"delete_on_merge":                    types.BoolNull(),

--- a/internal/service/clickhouse/resource/models/clickpipe_resource.go
+++ b/internal/service/clickhouse/resource/models/clickpipe_resource.go
@@ -803,6 +803,7 @@ type ClickPipeMongoDBSettingsModel struct {
 	SyncIntervalSeconds            types.Int64  `tfsdk:"sync_interval_seconds"`
 	PullBatchSize                  types.Int64  `tfsdk:"pull_batch_size"`
 	ReplicationMode                types.String `tfsdk:"replication_mode"`
+	InitialLoadParallelism         types.Int64  `tfsdk:"initial_load_parallelism"`
 	SnapshotNumRowsPerPartition    types.Int64  `tfsdk:"snapshot_num_rows_per_partition"`
 	SnapshotNumberOfParallelTables types.Int64  `tfsdk:"snapshot_number_of_parallel_tables"`
 	DeleteOnMerge                  types.Bool   `tfsdk:"delete_on_merge"`
@@ -815,6 +816,7 @@ func (m ClickPipeMongoDBSettingsModel) ObjectType() types.ObjectType {
 			"sync_interval_seconds":              types.Int64Type,
 			"pull_batch_size":                    types.Int64Type,
 			"replication_mode":                   types.StringType,
+			"initial_load_parallelism":           types.Int64Type,
 			"snapshot_num_rows_per_partition":    types.Int64Type,
 			"snapshot_number_of_parallel_tables": types.Int64Type,
 			"delete_on_merge":                    types.BoolType,
@@ -828,6 +830,7 @@ func (m ClickPipeMongoDBSettingsModel) ObjectValue() types.Object {
 		"sync_interval_seconds":              m.SyncIntervalSeconds,
 		"pull_batch_size":                    m.PullBatchSize,
 		"replication_mode":                   m.ReplicationMode,
+		"initial_load_parallelism":           m.InitialLoadParallelism,
 		"snapshot_num_rows_per_partition":    m.SnapshotNumRowsPerPartition,
 		"snapshot_number_of_parallel_tables": m.SnapshotNumberOfParallelTables,
 		"delete_on_merge":                    m.DeleteOnMerge,


### PR DESCRIPTION
## Why

Expose the MongoDB initial-load parallelism setting added to the OpenAPI in ClickHouse/control-plane#30805 (`source.mongodb.settings.initialLoadParallelism`), so Terraform users can size the snapshot phase like the UI already allows. (DBI-696)

Closes: https://linear.app/clickhouse/issue/DBI-696

## What

- Add `source.mongodb.settings.initial_load_parallelism` (`Int64`, `>= 1`) to the `clickhouse_clickpipe` resource schema, model, API model, create request and read/state sync.
- The OpenAPI only accepts the value at creation time (it is excluded from `PATCH`), so the attribute is `Optional` + `Computed` with `RequiresReplace` and `UseStateForUnknown`, mirroring `snapshot_num_rows_per_partition` and `snapshot_number_of_parallel_tables`. When omitted, the API default (currently 4 for CDC initial load) is read back into state without producing a diff.
- Extend the MongoDB state-sync unit test to cover the value being read back and preserved as null when absent, update the MongoDB CDC example, regenerate docs.

## QA

- `go build ./...`, `go vet`, `go test ./internal/...` pass.
- `make docs` regenerated with Terraform 1.11.4 on PATH (the version CI uses); only the new attribute line changed.
- `make lint` reports one pre-existing gosec finding in `internal/api/common.go`, untouched by this change.
- The OpenAPI behaviour this relies on was validated end to end against the local playground in https://github.com/ClickHouse/control-plane/pull/30805#issuecomment-5646390220: explicit values and the default both land in the PeerDB catalog as `snapshot_max_parallel_workers`.
- Live acceptance against a deployed OpenAPI is pending the control-plane PR rollout.

Manual verification once the API is deployed:

1. Apply a MongoDB CDC pipe with `initial_load_parallelism = 3`; the state and `GET` echo 3.
2. Apply the same config without the attribute; state shows the API default (4) and a re-plan is empty.
3. Change the value on an existing pipe; the plan forces replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
